### PR TITLE
Review par/seq dur and itemsByDuration

### DIFF
--- a/js/tests/score.html
+++ b/js/tests/score.html
@@ -81,14 +81,24 @@ test("Par(xs)", t => {
     t.equal(!par.failible, true, "not failible");
 });
 
+test("Par duration", t => {
+    t.equal(Par([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31).repeat()]).dur, Infinity,
+        "indefinite duration (1)");
+    t.equal(Par([Instant(), Delay(23).repeat(), Seq.fold(), Par.map(), Delay(31)]).dur, Infinity,
+        "indefinite duration (2)");
+    t.undefined(Par([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31)]).dur, "unresolved duration");
+});
+
 test("Par.take", t => {
     t.equal(Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take().dur, 51, "dur with n = ∞");
     t.undefined(Par([Delay(51), Delay(23), Delay(31), Par.map(), Par.map()]).take().dur,
         "dur with n = ∞ (but indefinite durations)");
-    t.equal(Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(7).dur, 51,
-        "dur with n > child count");
+    t.equal(Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(7).dur, 0,
+        "zero dur with n > child count (failure)");
      t.equal(Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(3).dur, 23,
         "dur with n < child count");
+     t.undefined(Par([Delay(51), Delay(23), Delay(31), Par.map(), Delay(19)]).take(3).dur,
+        "dur with n < child count, but unresolved duration");
     t.equal(Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(0).dur, 0,
         "dur with n = 0");
 });
@@ -118,6 +128,14 @@ test("Seq(xs)", t => {
     t.equal(delay.parent, seq, "parent (1)");
     t.equal(instant.parent, seq, "parent (2)");
     t.equal(seq.dur, 17, "duration");
+});
+
+test("Seq duration (unresolved and indefinite child durations)", t => {
+    t.equal(Seq([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31).repeat()]).dur, Infinity,
+        "indefinite duration (1)");
+    t.equal(Seq([Instant(), Delay(23).repeat(), Seq.fold(), Par.map(), Delay(31)]).dur, Infinity,
+        "indefinite duration (2)");
+    t.undefined(Seq([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31)]).dur, "unresolved duration");
 });
 
 test("Seq.fold(g, z)", t => {


### PR DESCRIPTION
Review the duration of containers (Par, Seq, Par.map and Seq.fold), taking care to handle unresolved durations (from Par.map and Seq.fold) and indefinite durations (from repeat()), which requires reviewing itemsByDuration as well. A few tests are updated and added as well.