### PR TITLE
Update Seq.fold and add Seq.map

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ elements by default.
       same as just `Seq(xs)`.
     * It is possible to limit the number of occurrences of `repeat()` with `take(n)`:
       `x.repeate().take(3)` is the same as `Seq([x, x, x])`.
-* `Par.map(g)` maps the function _g_ to an input list in parallel.
+* `Par.map(g)` and `Seq.map(g)` map the function _g_ to an input list in parallel or in sequence.
 * `Seq.fold(g, z)` folds over an input list with the function _g_ and an initial value _z_ in sequence.
 
 In SMIL, presentations are static in that their content is always the same (the user may influence the

--- a/js/lib/score.js
+++ b/js/lib/score.js
@@ -554,7 +554,11 @@ const SeqFold = {
     tag: "Seq/fold",
     show,
     take,
-    f: I,
+
+    // In the case where we take zero inputs, return the initial value.
+    f() {
+        return this.item.z;
+    },
 
     // Duration is unresolved, unless it is modified by take(0).
     get dur() {
@@ -566,7 +570,6 @@ const SeqFold = {
     // Schedule instantiation of the contents.
     instantiate(instance, t) {
         if (Capacity.get(this) === 0) {
-            instance.value = this.z;
             return Object.assign(instance, { t, forward });
         }
 
@@ -604,8 +607,8 @@ const SeqFold = {
         if (instance.begin === t) {
             delete instance.begin;
             instance.t = t;
+            instance.value = this.z;
             if (instance.children.length === 0) {
-                instance.value = this.z;
                 instance.parent?.item.childInstanceDidEnd(instance, t);
             }
         } else {
@@ -670,7 +673,9 @@ const Repeat = assign(child => extend(Repeat, { child }), {
     show,
     init,
     take,
-    f: I,
+    f() {
+        return this.z;
+    },
 
     // Duration is indefinite, unless it is modified by take.
     get dur() {

--- a/js/lib/score.js
+++ b/js/lib/score.js
@@ -673,9 +673,7 @@ const Repeat = assign(child => extend(Repeat, { child }), {
     show,
     init,
     take,
-    f() {
-        return this.z;
-    },
+    f: I,
 
     // Duration is indefinite, unless it is modified by take.
     get dur() {

--- a/js/lib/score.js
+++ b/js/lib/score.js
@@ -546,6 +546,10 @@ export const Seq = assign(children => create().call(Seq, { children: children ??
     }
 });
 
+// Seq/fold is similar to Seq but its children are produced by mapping its
+// input through the g function, and the initial value of the fold is given by
+// z. The initial instantiation is an interval with an unresolved end time and
+// an occurrence to instantiate the contents.
 const SeqFold = {
     tag: "Seq/fold",
     show,
@@ -559,7 +563,13 @@ const SeqFold = {
         }
     },
 
+    // Schedule instantiation of the contents.
     instantiate(instance, t) {
+        if (Capacity.get(this) === 0) {
+            instance.value = this.z;
+            return Object.assign(instance, { t, forward });
+        }
+
         instance.begin = t;
         return extend(instance, { t, forward(t) {
             if (instance.item.instantiateChildren(
@@ -570,6 +580,7 @@ const SeqFold = {
         } });
     },
 
+    // Actually instantiate the children from the input.
     instantiateChildren(instance, xs, t) {
         console.assert(t === instance.begin);
         if (!Array.isArray(xs)) {
@@ -579,18 +590,22 @@ const SeqFold = {
         const n = min(xs.length, Capacity.get(this));
         instance.input = xs.slice(0, n);
         instance.children = [];
-        for (let i = 0; i < n && isNumber(t); ++i) {
-            t = endOf(push(instance.children, Object.assign(
-                instance.tape.instantiate(this.g(xs[i]), t),
-                { parent: instance }
-            )));
+        for (let i = 0; i < n && isFinite(t); ++i) {
+            const childInstance = instance.tape.instantiate(this.g(xs[i]), t);
+            if (!childInstance) {
+                for (const childInstance of instance.children) {
+                    childInstance.item.pruneInstance(childInstance, t);
+                }
+                throw Fail;
+            }
+            t = endOf(push(instance.children, Object.assign(childInstance, { parent: instance })));
         }
 
         if (instance.begin === t) {
             delete instance.begin;
             instance.t = t;
             if (instance.children.length === 0) {
-                instance.value = void 0;
+                instance.value = this.z;
                 instance.parent?.item.childInstanceDidEnd(instance, t);
             }
         } else {
@@ -603,28 +618,33 @@ const SeqFold = {
         if (isNumber(t)) {
             instance.parent?.item.childInstanceEndWasResolved(instance, t);
         }
+        instance.currentChildIndex = 0;
     },
 
+    // Feed the input of the preceding child to the current child, or that of
+    // the Seq itself for the first child, which can be requested from the
+    // parent.
     inputForChildInstance(childInstance) {
         const instance = childInstance.parent;
-        if (instance.lastChildIndex >= 0) {
-            console.assert(instance.children[instance.lastChildIndex + 1] === childInstance);
-            return instance.children[instance.lastChildIndex].value;
-        }
-        console.assert(instance.children[0] === childInstance);
-        return this.z;
+        console.assert(instance.item === this);
+        return instance.currentChildIndex === 0 ?
+            this.z :
+            instance.children[instance.currentChildIndex - 1].value;
     },
 
+    // Move to the next child when a child finishes by keeping track of the
+    // index of the current child in the list of children. Done if the last
+    // child of the list ended.
     childInstanceDidEnd(childInstance, t) {
         const instance = childInstance.parent;
         console.assert(instance.item === this);
-        instance.lastChildIndex = instance.lastChildIndex >= 0 ? instance.lastChildIndex + 1 : 0;
-        console.assert(instance.children[instance.lastChildIndex] === childInstance);
-        const n = min(instance.input.length, Capacity.get(this));
-        if (instance.lastChildIndex === n - 1) {
+        console.assert(instance.children[instance.currentChildIndex] === childInstance);
+        instance.currentChildIndex += 1;
+        if (instance.currentChildIndex === min(instance.input.length, Capacity.get(this))) {
             instance.value = childInstance.value;
             instance.end = t;
             instance.parent?.item.childInstanceDidEnd(instance, t);
+            delete instance.currentChildIndex;
         }
     },
 
@@ -632,12 +652,17 @@ const SeqFold = {
     cancelInstance: Seq.cancelInstance,
 };
 
-// Seq/map is similar to Seq but its children are produced by mapping its
-// input through the g function. The initial instantiation is an interval
-// with an unresolved end time and an occurrence to instantiate the contents.
+// Seq/map is just like Seq/fold but taking its initial input from its parent,
+// like a normal Seq.
 export const SeqMap = extend(SeqFold, {
     tag: "Seq/map",
-    inputForChildInstance: Seq.inputForChildInstance
+
+    // Each successive child gets the next input from the Seq/map parent.
+    inputForChildInstance(childInstance) {
+        const instance = childInstance.parent;
+        console.assert(instance.item === this);
+        return instance.input[instance.currentChildIndex];
+    },
 });
 
 const Repeat = assign(child => extend(Repeat, { child }), {

--- a/js/tests/score.html
+++ b/js/tests/score.html
@@ -138,6 +138,14 @@ test("Seq duration (unresolved and indefinite child durations)", t => {
     t.undefined(Seq([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31)]).dur, "unresolved duration");
 });
 
+test("Seq.map(g)", t => {
+    const map = Seq.map(Delay);
+    t.equal(map.show(), "Seq/map", "show");
+    t.typeof(map.g, "function", "g function");
+    t.undefined(map.dur, "unresolved duration");
+    t.equal(map.take(0).dur, 0, "down to zero with take(0)");
+});
+
 test("Seq.fold(g, z)", t => {
     const fold = Seq.fold(x => Instant(y => x + y), 0);
     t.equal(fold.show(), "Seq/fold", "show");

--- a/js/tests/sync-core.js
+++ b/js/tests/sync-core.js
@@ -545,6 +545,13 @@ test("Seq(xs).take(n); failure in child after nth", t => {
     t.equal(seq.value, "ok", "correct value");
 });
 
+test("Seq.map(g)", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([Instant(K([31, 19, 23])), Seq.map(Delay)]), 17);
+    Deck({ tape }).now = 91;
+    console.log(dump(seq));
+});
+
 test("Seq.fold(g); child of Seq", t => {
     const tape = Tape();
     const seq = Seq([Instant(K([1, 2, 3])), Seq.fold(x => Instant(y => x + y), 0)]);

--- a/js/tests/sync-core.js
+++ b/js/tests/sync-core.js
@@ -629,7 +629,6 @@ test("Seq.fold(); no input", t => {
     ]);
     const instance = tape.instantiate(seq, 17);
     Deck({ tape }).now = 41;
-    console.log(dump(instance));
     t.equal(dump(instance),
 `* Seq-0 [17, 40[ <31>
   * Instant-1 @17 <>

--- a/js/tests/sync-core.js
+++ b/js/tests/sync-core.js
@@ -549,7 +549,13 @@ test("Seq.map(g)", t => {
     const tape = Tape();
     const seq = tape.instantiate(Seq([Instant(K([31, 19, 23])), Seq.map(Delay)]), 17);
     Deck({ tape }).now = 91;
-    console.log(dump(seq));
+    t.equal(dump(seq),
+`* Seq-0 [17, 90[ <23>
+  * Instant-1 @17 <31,19,23>
+  * Seq/map-2 [17, 90[ <23>
+    * Delay-3 [17, 48[ <31>
+    * Delay-4 [48, 67[ <19>
+    * Delay-5 [67, 90[ <23>`, "dump matches");
 });
 
 test("Seq.fold(g); child of Seq", t => {
@@ -709,11 +715,12 @@ test("Seq.fold().take(0)", t => {
     const instance = tape.instantiate(seq, 17);
 
     Deck({ tape }).now = 41;
+    console.log(dump(instance));
     t.equal(dump(instance),
-`* Seq-0 [17, 40[ <undefined>
+`* Seq-0 [17, 40[ <1,2,3,4,5>
   * Instant-1 @17 <1,2,3,4,5>
-  * Seq/fold-2 @17 <undefined>
-  * Delay-3 [17, 40[ <undefined>`, "dump matches");
+  * Seq/fold-2 @17 <0>
+  * Delay-3 [17, 40[ <1,2,3,4,5>`, "dump matches");
 });
 
 test("Nesting", t => {

--- a/js/tests/sync-core.js
+++ b/js/tests/sync-core.js
@@ -558,6 +558,16 @@ test("Seq.map(g)", t => {
     * Delay-5 [67, 90[ <23>`, "dump matches");
 });
 
+test("Seq.map(g); no input", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([Instant(K([])), Seq.map(Delay)]), 17);
+    Deck({ tape }).now = 91;
+    t.equal(dump(seq),
+`* Seq-0 @17 <undefined>
+  * Instant-1 @17 <>
+  * Seq/map-2 @17 <undefined>`, "dump matches");
+});
+
 test("Seq.fold(g); child of Seq", t => {
     const tape = Tape();
     const seq = Seq([Instant(K([1, 2, 3])), Seq.fold(x => Instant(y => x + y), 0)]);
@@ -610,6 +620,23 @@ test("Seq.fold(g); child of Par", t => {
       * Instant-7 @17 <6>`, "dump matches");
 });
 
+test("Seq.fold(); no input", t => {
+    const tape = Tape();
+    const seq = Seq([
+        Instant(K([])),
+        Seq.fold(Delay, 31),
+        Delay(23)
+    ]);
+    const instance = tape.instantiate(seq, 17);
+    Deck({ tape }).now = 41;
+    console.log(dump(instance));
+    t.equal(dump(instance),
+`* Seq-0 [17, 40[ <31>
+  * Instant-1 @17 <>
+  * Seq/fold-2 @17 <31>
+  * Delay-3 [17, 40[ <31>`, "dump matches");
+});
+
 test("Seq.fold(g) failure; child of Seq", t => {
     const tape = Tape();
     const seq = Seq([
@@ -638,7 +665,6 @@ test("Seq.fold(g) failure; child of Par", t => {
   * Par-2 @17 (failed)
     * Delay-3 @17 (cancelled)
     * Seq/fold-4 @17 (failed)`, "dump matches");
-
 });
 
 test("Seq.fold().take(n = ∞)", t => {
@@ -713,14 +739,12 @@ test("Seq.fold().take(0)", t => {
         Delay(23)
     ]);
     const instance = tape.instantiate(seq, 17);
-
     Deck({ tape }).now = 41;
-    console.log(dump(instance));
     t.equal(dump(instance),
-`* Seq-0 [17, 40[ <1,2,3,4,5>
+`* Seq-0 [17, 40[ <0>
   * Instant-1 @17 <1,2,3,4,5>
   * Seq/fold-2 @17 <0>
-  * Delay-3 [17, 40[ <1,2,3,4,5>`, "dump matches");
+  * Delay-3 [17, 40[ <0>`, "dump matches");
 });
 
 test("Nesting", t => {


### PR DESCRIPTION
Seq.fold is updated to match Seq better (e.g. using `currentChildIndex` instead of `lastChildIndex` to keep track of the current child), and also returning the initial value of the accumulator when it has no input.

Seq.map is also added as a special case of fold that only uses input values and not the output of the preceding sibling, similarly to Par.map.