### PR TITLE
Value for instance

### DIFF
--- a/js/tests/score.html
+++ b/js/tests/score.html
@@ -39,7 +39,7 @@ test("Score.add(child)", t => {
 test("Instant()", t => {
     const instant = Instant();
     t.equal(instant.show(), "Instant", "show");
-    t.equal(instant.f(17), 17, "f defaults to I");
+    t.equal(instant.valueForInstance(17), 17, "valueForInstance defaults to I");
     t.equal(instant.dur, 0, "no duration");
     t.equal(!instant.failible, true, "infailible");
 });
@@ -47,7 +47,7 @@ test("Instant()", t => {
 test("Instant(f)", t => {
     const instant = Instant(x => x * 2);
     t.equal(instant.show(), "Instant", "show");
-    t.equal(instant.f(17), 34, "f is set");
+    t.equal(instant.valueForInstance(17), 34, "valueForInstance is set");
     t.equal(instant.dur, 0, "no duration");
 });
 

--- a/js/tests/sync-core.js
+++ b/js/tests/sync-core.js
@@ -454,6 +454,13 @@ test("Seq(xs)", t => {
     t.equal(Object.hasOwn(instance, "value"), true, "value for seq");
 });
 
+test("Seq value", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([Instant(K("ok")), Delay(23)]), 17);
+    Deck({ tape }).now = 41;
+    t.equal(seq.value, "ok", "Seq value");
+});
+
 test("Seq()", t => {
     const tape = Tape();
     const seq = Seq();
@@ -640,10 +647,7 @@ test("Seq.map(g); no input", t => {
     const tape = Tape();
     const seq = tape.instantiate(Seq([Instant(K([])), Seq.map(Delay)]), 17);
     Deck({ tape }).now = 91;
-    t.equal(dump(seq),
-`* Seq-0 @17 <undefined>
-  * Instant-1 @17 <>
-  * Seq/map-2 @17 <undefined>`, "dump matches");
+    t.equal(seq.value, [], "empty list");
 });
 
 test("Seq.map(g).repeat()", t => {


### PR DESCRIPTION
Rename `f` to `valueForInstance`, although it behaves a bit differently from the other instance method in that it does take the instance as `this` and the first parameter is the input of the function. Avoid setting the value directly but rather always go through `valueForInstance`.