### PR TITLE
Dur

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,15 @@ choice(
     Seq([
         Par([Receive(A), Receive(B)]),
         Send(O),
-        Delay(Infinity)
-    ]),
+    ]).dur(Infinity),
     Receive(R)
 ).repeat()
 ```
 
 Again, `choice()` here allows receiving the event R to reset the system (which keeps running forever thanks
-to the `repeat()` modifier). The `Delay(Infinity)` ensures that after sending O, further A and B events
-are ignored until R is received. And requiring additional events before sending O is simply a matter of
-modifying the Par element, so this can turn into ABCRO with:
+to the `repeat()` modifier). Setting the duration of the sequence that waits for A and B and then sends O
+ensures that further A and B events are ignored until R is received. And requiring additional events before
+sending O is simply a matter of modifying the Par element, so this can turn into ABCRO with:
 
 ```
 Par([Receive(A), Receive(B), Receive(C)])
@@ -107,14 +106,14 @@ as `Seq([x, x, ...])`.
 * `take(n)` applies to Par, Seq or repeat and finishes when _n_ ≥ 0 child elements have finished, or all
 elements by default.
     * `Par(xs).take(n)` selects the _n_ elements from _xs_ that finish first and cancels the rest of the
-      elements (cancellation is discussed below).
+    elements (cancellation is discussed below).
     * `Par(xs).take()` differs from `Par(xs)` in the output value. In the latter case, output values are
-      in the order in which the elements are specified; in the former case, output values are in the order
-      in which they finish.
+    in the order in which the elements are specified; in the former case, output values are in the order
+    in which they finish.
     * `Seq(xs).take(n)` cuts the sequence short by taking only the first n steps. `Seq(xs).take()` is the
-      same as just `Seq(xs)`.
+    same as just `Seq(xs)`.
     * It is possible to limit the number of occurrences of `repeat()` with `take(n)`:
-      `x.repeate().take(3)` is the same as `Seq([x, x, x])`.
+    `x.repeate().take(3)` is the same as `Seq([x, x, x])`.
 * `dur(d)` applies to Par, Seq or repeat and sets the duration to exactly _d_ ≥ 0. If the natural duration
 of the element is less than _d_, then it is padded as if a Delay was added to it. If the natural duration
 of the element is more than _d_, then it is cut off earlier and the children that have not finished yet
@@ -189,9 +188,9 @@ comprised of three new elements:
 
 * `Effect(f)` is similar to `Instant(f)` but is allowed to produce side effects.
 * `Await(f)` evaluates an asynchronous function _f_ and finishes when _f_ finishes, which is _unresolved_
-  until _f_ is actually evaluated.
+until _f_ is actually evaluated.
 * `DOMEvent(target, type)` starts listening to an event of a given _type_ from a _target_, and finishes
-  when an event notification is received.
+when an event notification is received.
 
 These elements can be combined with the synchronous elements defined above, and accept the `repeat()`
 modifier. `Effect` comes with two modifiers of its own and will be detailed when describing the execution

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ These elements can be further modified through the use of the following modifier
 
 * `repeat()`: repeats an element indefinitely, producing an inifinite sequence. `x.repeat()` is the same
 as `Seq([x, x, ...])`.
-* `take(n)` applies to Par, Seq or repeat and finishes when _n_ child elements have finished, or all
+* `take(n)` applies to Par, Seq or repeat and finishes when _n_ ≥ 0 child elements have finished, or all
 elements by default.
     * `Par(xs).take(n)` selects the _n_ elements from _xs_ that finish first and cancels the rest of the
       elements (cancellation is discussed below).
@@ -115,6 +115,16 @@ elements by default.
       same as just `Seq(xs)`.
     * It is possible to limit the number of occurrences of `repeat()` with `take(n)`:
       `x.repeate().take(3)` is the same as `Seq([x, x, x])`.
+* `dur(d)` applies to Par, Seq or repeat and sets the duration to exactly _d_ ≥ 0. If the natural duration
+of the element is less than _d_, then it is padded as if a Delay was added to it. If the natural duration
+of the element is more than _d_, then it is cut off earlier and the children that have not finished yet
+are cancelled.
+    * `Par(xs).dur(d)` sets the duration of the par to _d_ and returns the elements that have finished
+    in the order in which they finished.
+    * `Seq(xs).dur(d)` sets the duration of the seq to _d_ and returns the last value that finished by _d_.
+    * Both `take(n)` and `dur(d)` can apply to an element; if by _d_ less than _n_ child elements have
+    finished, then the element fails, otherwise only the first _n_ child elements that have finished are
+    returned.
 * `Par.map(g)` and `Seq.map(g)` map the function _g_ to an input list in parallel or in sequence.
 * `Seq.fold(g, z)` folds over an input list with the function _g_ and an initial value _z_ in sequence.
 

--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ elements by default.
     same as just `Seq(xs)`.
     * It is possible to limit the number of occurrences of `repeat()` with `take(n)`:
     `x.repeate().take(3)` is the same as `Seq([x, x, x])`.
-* `dur(d)` applies to Par, Seq or repeat and sets the duration to exactly _d_ ≥ 0. If the natural duration
+* `dur(d)` applies to Par, Seq or repeat, and sets the duration to exactly _d_ ≥ 0. If the natural duration
 of the element is less than _d_, then it is padded as if a Delay was added to it. If the natural duration
 of the element is more than _d_, then it is cut off earlier and the children that have not finished yet
-are cancelled.
+are pruned.
     * `Par(xs).dur(d)` sets the duration of the par to _d_ and returns the elements that have finished
     in the order in which they finished.
     * `Seq(xs).dur(d)` sets the duration of the seq to _d_ and returns the last value that finished by _d_.

--- a/js/lib/score.js
+++ b/js/lib/score.js
@@ -686,6 +686,122 @@ export const Seq = assign(children => create().call(Seq, { children: children ??
     },
 });
 
+// Repeat is a special kind of Seq that keeps instantiating its child when it
+// finishes and never ends (unless capped by take()).
+const Repeat = assign(child => extend(Repeat, { child }), {
+    tag: "Seq/repeat",
+    show,
+    init,
+    take,
+    dur,
+
+    // Duration is indefinite, unless it is modified by take in which case it
+    // is a product of the number of iterations by the duration of the item
+    // being repeated.
+    get duration() {
+        if (Duration.has(this)) {
+            return Duration.get(this);
+        }
+        const repeats = Capacity.get(this);
+        const duration = repeats === 0 ? 0 : repeats > 0 ? this.child.duration * repeats : Infinity;
+        if (!isNaN(duration)) {
+            // Limited repetition of an unresolved duration is unresolved,
+            // so only return resolved durations.
+            return duration;
+        }
+    },
+
+    // Fails if the inner item fails, or if it has zero duration and repeats
+    // indefinitely.
+    failible() {
+        if (this.child.failible()) {
+            return true;
+        }
+        const n = Capacity.get(this) ?? Infinity;
+        return this.child.duration === 0 && n === Infinity;
+    },
+
+    // Instantiate the first iteration of the repeat, or immediately return a
+    // single occurrence if there are no iterations.
+    instantiate(instance, t, dur) {
+        if (this.failible()) {
+            throw Fail;
+        }
+
+        if (Capacity.get(this) === 0) {
+            return Object.assign(instance, { t, forward });
+        }
+
+        instance.maxEnd = t + min(dur, Duration.get(this));
+        instance.capacity = Capacity.get(this) ?? Infinity;
+        if (instance.maxEnd === t) {
+            instance.t = t;
+        } else {
+            instance.begin = t;
+            if (Duration.has(this)) {
+                instance.end = instance.maxEnd;
+            }
+        }
+        instance.children = [
+            Object.assign(instance.tape.instantiate(this.child, t, dur), { parent: instance })
+        ];
+    },
+
+    // Because repeat children are instantiated one at a time, the child
+    // instance that needs input is always the last one, and its input the
+    // output of the instance preceding, or the the input of the parent in the
+    // case of the first child instance.
+    inputForChildInstance(childInstance) {
+        const instance = childInstance.parent;
+        console.assert(instance.item === this);
+        const index = instance.children.length - 1;
+        console.assert(childInstance === instance.children[index]);
+        return index === 0 ?
+            instance.parent?.item.inputForChildInstance(instance) :
+            instance.children[index - 1].value;
+    },
+
+    // When an instance ends, immediately instantiate its contents again,
+    // unless the total number of iterations has been reached. If the end of
+    // the duration is reached, the instance may fail if it did not reach the
+    // required number of iterations as specified by take().
+    childInstanceDidEnd(childInstance, t) {
+        const instance = childInstance.parent;
+        console.assert(instance.item === this);
+        if (childInstance.cutoff) {
+            delete childInstance.cutoff;
+            if (isFinite(instance.capacity)) {
+                return failed(instance, t);
+            }
+            instance.cutoff = true;
+            return ended(instance, t, childInstance.value);
+        }
+
+        if (instance.children.length > RepeatMax) {
+            // This is just for debug purposes and should be removed eventually.
+            throw Error("Too many repeats");
+        }
+        if (instance.children.length === instance.capacity) {
+            ended(instance, t, childInstance.value);
+        } else {
+            instance.children.push(Object.assign(
+                instance.tape.instantiate(this.child, t, instance.maxEnd - t), { parent: instance }
+            ));
+        }
+    },
+
+    // Fail if the child fails.
+    childInstanceDidFail(childInstance, t) {
+        const instance = childInstance.parent;
+        console.assert(instance.item === this);
+        console.assert(childInstance === instance.children.at(-1));
+        failed(instance, t);
+    },
+
+    valueForInstance: I,
+    childInstanceEndWasResolved: nop,
+});
+
 // Seq/fold is similar to Seq but its children are produced by mapping its
 // input through the g function, and the initial value of the fold is given by
 // z. The initial instantiation is an interval with an unresolved end time and
@@ -828,97 +944,6 @@ export const SeqMap = extend(SeqFold, {
     },
 });
 
-// Repeat is a special kind of Seq that keeps instantiating its child when it
-// finishes and never ends (unless capped by take()).
-const Repeat = assign(child => extend(Repeat, { child }), {
-    tag: "Seq/repeat",
-    show,
-    init,
-    take,
-
-    // Duration is indefinite, unless it is modified by take in which case it
-    // is a product of the number of iterations by the duration of the item
-    // being repeated.
-    get duration() {
-        const repeats = Capacity.get(this);
-        const duration = repeats === 0 ? 0 : repeats > 0 ? this.child.duration * repeats : Infinity;
-        if (!isNaN(duration)) {
-            // Limited repetition of an unresolved duration is unresolved,
-            // so only return resolved durations.
-            return duration;
-        }
-    },
-
-    // Fails if the inner item fails, or if it has zero duration and repeats
-    // indefinitely.
-    failible() {
-        if (this.child.failible()) {
-            return true;
-        }
-        const n = Capacity.get(this) ?? Infinity;
-        return this.child.duration === 0 && n === Infinity;
-    },
-
-    instantiate(instance, t) {
-        if (this.failible()) {
-            throw Fail;
-        }
-
-        if (Capacity.get(this) === 0) {
-            return Object.assign(instance, { t, forward });
-        }
-        if (this.duration === 0) {
-            instance.t = t;
-        } else {
-            instance.begin = t;
-        }
-        instance.children = [Object.assign(instance.tape.instantiate(this.child, t), { parent: instance })];
-    },
-
-    // Because repeat children are instantiated one at a time, the child
-    // instance that needs input is always the last one, and its input the
-    // output of the instance preceding, or the the input of the parent in the
-    // case of the first child instance.
-    inputForChildInstance(childInstance) {
-        const instance = childInstance.parent;
-        console.assert(instance.item === this);
-        const index = instance.children.length - 1;
-        console.assert(childInstance === instance.children[index]);
-        return index === 0 ?
-            instance.parent?.item.inputForChildInstance(instance) :
-            instance.children[index - 1].value;
-    },
-
-    // When an instance ends, immediately instantiate its contents again,
-    // unless the total number of iterations has been reached.
-    childInstanceDidEnd(childInstance, t) {
-        const instance = childInstance.parent;
-        console.assert(instance.item === this);
-        if (instance.children.length > RepeatMax) {
-            // This is just for debug purposes and should be removed eventually.
-            throw Error("Too many repeats");
-        }
-        if (instance.children.length === Capacity.get(this)) {
-            ended(instance, t, childInstance.value);
-        } else {
-            instance.children.push(Object.assign(
-                instance.tape.instantiate(this.child, t), { parent: instance }
-            ));
-        }
-    },
-
-    // Fail if the child fails.
-    childInstanceDidFail(childInstance, t) {
-        const instance = childInstance.parent;
-        console.assert(instance.item === this);
-        console.assert(childInstance === instance.children.at(-1));
-        failed(instance, t);
-    },
-
-    valueForInstance: I,
-    childInstanceEndWasResolved: nop,
-});
-
 // Dump an instance and its children for debugging and testing.
 export function dump(instance, indent = "* ") {
     const selfDump = `${indent}${instance.id} ${
@@ -963,8 +988,9 @@ function take(n = Infinity) {
 // Set the duration of an item with dur.
 function dur(d) {
     console.assert(!Duration.has(this));
-    console.assert(d >= 0);
-    Duration.set(this, d);
+    if (d >= 0) {
+        Duration.set(this, d);
+    }
     return this;
 }
 

--- a/js/lib/score.js
+++ b/js/lib/score.js
@@ -360,8 +360,7 @@ export const ParMap = {
         }
 
         // Get the child elements first.
-        instance.input = xs;
-        const children = instance.input.map((x, i) => {
+        const children = xs.map((x, i) => {
             try {
                 return this.g(x, i);
             } catch {
@@ -372,6 +371,9 @@ export const ParMap = {
         try {
             const occurrence = Par.instantiateChildren.call(this, instance, children, t, dur);
             const end = endOf(instance);
+            instance.children.forEach(child => {
+                child.input = xs[children.indexOf(child.item)];
+            });
             if (isNumber(end)) {
                 if (instance.children.length === 0) {
                     instance.value = this.valueForInstance.call(instance);
@@ -385,13 +387,13 @@ export const ParMap = {
         }
     },
 
-    // Input values are distributed to the children as their input.
+    // Input values are distributed to the children as their input. Because
+    // child instances may be reordered, each instance records its input value.
     inputForChildInstance(childInstance) {
-        const instance = childInstance.parent;
-        console.assert(instance.item === this);
-        const index = instance.children.indexOf(childInstance);
-        console.assert(index >= 0);
-        return instance.input[index];
+        console.assert(Object.hasOwn(childInstance, "input"));
+        const input = childInstance.input;
+        delete childInstance.input;
+        return input;
     },
 };
 

--- a/js/lib/tape.js
+++ b/js/lib/tape.js
@@ -15,9 +15,10 @@ export const Tape = Object.assign(() => create().call(Tape), {
         return `Tape<${this.occurrences.map(occurrence => occurrence.t)}>`
     },
 
-    // Instantiate an item beginning at time t and commit its occurrences to
-    // this tape. Return an instance on success or nothing on failure.
-    instantiate(item, t) {
+    // Instantiate an item beginning at time t with a duration cap dur, and
+    // commit its occurrences to this tape. Return an instance on success or
+    // nothing on failure.
+    instantiate(item, t, dur = Infinity) {
         // An instance points to this tape (so that its children can be
         // instantiated in the same tape), its item, and is given an ID for
         // debugging purposes.
@@ -25,7 +26,7 @@ export const Tape = Object.assign(() => create().call(Tape), {
         try {
             // Item-specific instantiation may return an occurrence to be added
             // to the tape.
-            const occurrence = item.instantiate(instance, t);
+            const occurrence = item.instantiate(instance, t, dur);
             if (occurrence) {
                 this.instances.set(instance, this.addOccurrence(occurrence));
             }

--- a/js/lib/tape.js
+++ b/js/lib/tape.js
@@ -15,7 +15,7 @@ export const Tape = Object.assign(() => create().call(Tape), {
         return `Tape<${this.occurrences.map(occurrence => occurrence.t)}>`
     },
 
-    // Instantiate an item beginning at time t with a duration cap dur, and
+    // Instantiate an item beginning at time t with a maximum duration dur, and
     // commit its occurrences to this tape. Return an instance on success or
     // nothing on failure.
     instantiate(item, t, dur = Infinity) {

--- a/js/tests/delay.html
+++ b/js/tests/delay.html
@@ -16,9 +16,8 @@ test("Delay(duration)", t => {
     const delay = Delay(23);
     t.equal(delay.show(), "Delay<23>", "show");
     t.equal(delay.duration, 23, "duration");
-    t.equal(delay.failible(19), false, "not failible");
+    t.equal(delay.failible(), false, "not failible");
     t.throws(() => { delay.duration = 19; }, "cannot overwrite dur");
-    t.equal(Delay(0).failible(), false, "zero duration delay is OK");
 });
 
 test("Delay.repeat()", t => {
@@ -51,6 +50,18 @@ test("Instantiation (zero duration)", t => {
     const delay = tape.instantiate(Delay(0), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(delay), "* Instant-0 @17 <undefined>", "dump matches");
+});
+
+test("Instantiation (illegal duration)", t => {
+    const tape = Tape();
+    t.equal(dump(tape.instantiate(Delay(-23), 17)), "* Instant-0 @17", "negative duration");
+    t.equal(dump(tape.instantiate(Delay("23s"), 17)), "* Instant-1 @17", "not a number");
+});
+
+test("Instantiation with parent duration", t => {
+    const tape = Tape();
+    t.equal(dump(tape.instantiate(Delay(23), 17, 31)), "* Delay-0 [17, 40[", "no cutoff");
+    t.equal(dump(tape.instantiate(Delay(23), 17, 19)), "* Delay-1 [17, 36[", "cutoff");
 });
 
 test("Delay(d).repeat()", t => {
@@ -107,12 +118,6 @@ test("Prune delay", t => {
     ]), 17), "instantiation failed");
     Deck({ tape }).now = 18;
     t.equal(tape.occurrences, [], "no occurrence on tape");
-});
-
-test("Instantiation with parent duration", t => {
-    const tape = Tape();
-    t.equal(dump(tape.instantiate(Delay(23), 17, 31)), "* Delay-0 [17, 40[", "cap is high enough");
-    t.equal(dump(tape.instantiate(Delay(23), 17, 19)), "* Delay-1 [17, 36[", "delay may be shortened");
 });
 
         </script>

--- a/js/tests/delay.html
+++ b/js/tests/delay.html
@@ -12,12 +12,12 @@ import { Instant, Delay, Par, Seq, dump } from "../lib/score.js";
 import { Tape } from "../lib/tape.js";
 import { Deck } from "../lib/deck.js";
 
-test("Delay(dur)", t => {
+test("Delay(duration)", t => {
     const delay = Delay(23);
     t.equal(delay.show(), "Delay<23>", "show");
-    t.equal(delay.dur, 23, "duration");
+    t.equal(delay.duration, 23, "duration");
     t.equal(!delay.failible, true, "not failible (delay > 0)");
-    t.throws(() => { delay.dur = 19; }, "cannot overwrite dur");
+    t.throws(() => { delay.duration = 19; }, "cannot overwrite dur");
     t.equal(!Delay(0).failible, true, "zero duration delay is OK");
     t.equal(Delay(-17).failible, true, "negative duration delay is failible");
 });
@@ -27,10 +27,10 @@ test("Delay.repeat()", t => {
     const repeat = delay.repeat();
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, delay, "repeat child");
-    t.equal(repeat.dur, Infinity, "repeat dur");
+    t.equal(repeat.duration, Infinity, "repeat dur");
     t.equal(repeat.failible, false, "unlimited repetitions do not fail");
     const limitedRepeats = repeat.take(3);
-    t.equal(limitedRepeats.dur, 69, "repeat dur (limited)");
+    t.equal(limitedRepeats.duration, 69, "repeat dur (limited)");
     t.equal(!limitedRepeats.failible, true, "limited repetitions do not fail");
     t.equal(Delay(0).repeat().failible, true, "zero duration delay cannot repeat");
 });
@@ -113,6 +113,12 @@ test("Prune delay", t => {
     ]), 17), "instantiation failed");
     Deck({ tape }).now = 18;
     t.equal(tape.occurrences, [], "no occurrence on tape");
+});
+
+test("Instantiation with duration cap", t => {
+    const tape = Tape();
+    t.equal(dump(tape.instantiate(Delay(23), 17, 31)), "* Delay-0 [17, 40[", "cap is high enough");
+    t.undefined(tape.instantiate(Delay(23), 17, 19), "cap is too low");
 });
 
         </script>

--- a/js/tests/delay.html
+++ b/js/tests/delay.html
@@ -16,7 +16,8 @@ test("Delay(duration)", t => {
     const delay = Delay(23);
     t.equal(delay.show(), "Delay<23>", "show");
     t.equal(delay.duration, 23, "duration");
-    t.equal(delay.failible(), false, "not failible (delay > 0)");
+    t.equal(delay.failible(31), false, "not failible (delay > 0 and parent duration is high enough)");
+    t.equal(delay.failible(19), true, "failible (if the cap is too low");
     t.throws(() => { delay.duration = 19; }, "cannot overwrite dur");
     t.equal(Delay(0).failible(), false, "zero duration delay is OK");
     t.equal(Delay(-17).failible(), true, "negative duration delay is failible");

--- a/js/tests/delay.html
+++ b/js/tests/delay.html
@@ -16,11 +16,9 @@ test("Delay(duration)", t => {
     const delay = Delay(23);
     t.equal(delay.show(), "Delay<23>", "show");
     t.equal(delay.duration, 23, "duration");
-    t.equal(delay.failible(31), false, "not failible (delay > 0 and parent duration is high enough)");
-    t.equal(delay.failible(19), true, "failible (if the cap is too low");
+    t.equal(delay.failible(19), false, "not failible");
     t.throws(() => { delay.duration = 19; }, "cannot overwrite dur");
     t.equal(Delay(0).failible(), false, "zero duration delay is OK");
-    t.equal(Delay(-17).failible(), true, "negative duration delay is failible");
 });
 
 test("Delay.repeat()", t => {
@@ -53,11 +51,6 @@ test("Instantiation (zero duration)", t => {
     const delay = tape.instantiate(Delay(0), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(delay), "* Instant-0 @17 <undefined>", "dump matches");
-});
-
-test("Instantiation fails if d < 0", t => {
-    const tape = Tape();
-    t.undefined(tape.instantiate(Delay(-23), 17), "negative delay");
 });
 
 test("Delay(d).repeat()", t => {
@@ -110,16 +103,16 @@ test("Prune delay", t => {
     const tape = Tape();
     t.undefined(tape.instantiate(Seq([
         Delay(1),
-        Delay(-1)
+        Par().take(1)
     ]), 17), "instantiation failed");
     Deck({ tape }).now = 18;
     t.equal(tape.occurrences, [], "no occurrence on tape");
 });
 
-test("Instantiation with duration cap", t => {
+test("Instantiation with parent duration", t => {
     const tape = Tape();
     t.equal(dump(tape.instantiate(Delay(23), 17, 31)), "* Delay-0 [17, 40[", "cap is high enough");
-    t.undefined(tape.instantiate(Delay(23), 17, 19), "cap is too low");
+    t.equal(dump(tape.instantiate(Delay(23), 17, 19)), "* Delay-1 [17, 36[", "delay may be shortened");
 });
 
         </script>

--- a/js/tests/delay.html
+++ b/js/tests/delay.html
@@ -16,7 +16,7 @@ test("Delay(duration)", t => {
     const delay = Delay(23);
     t.equal(delay.show(), "Delay<23>", "show");
     t.equal(delay.duration, 23, "duration");
-    t.equal(delay.failible(), false, "not failible");
+    t.equal(!delay.failible, true, "not failible");
     t.throws(() => { delay.duration = 19; }, "cannot overwrite dur");
 });
 
@@ -26,11 +26,11 @@ test("Delay.repeat()", t => {
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, delay, "repeat child");
     t.equal(repeat.duration, Infinity, "repeat dur");
-    t.equal(repeat.failible(), false, "unlimited repetitions do not fail");
+    t.equal(!repeat.failible, true, "unlimited repetitions do not fail");
     const limitedRepeats = repeat.take(3);
     t.equal(limitedRepeats.duration, 69, "repeat dur (limited)");
-    t.equal(limitedRepeats.failible(), false, "limited repetitions do not fail");
-    t.equal(Delay(0).repeat().failible(), true, "zero duration delay cannot repeat");
+    t.equal(!limitedRepeats.failible, true, "limited repetitions do not fail");
+    t.equal(Delay(0).repeat().failible, true, "zero duration delay cannot repeat");
 });
 
 test("Instantiation", t => {

--- a/js/tests/delay.html
+++ b/js/tests/delay.html
@@ -16,10 +16,10 @@ test("Delay(duration)", t => {
     const delay = Delay(23);
     t.equal(delay.show(), "Delay<23>", "show");
     t.equal(delay.duration, 23, "duration");
-    t.equal(!delay.failible, true, "not failible (delay > 0)");
+    t.equal(delay.failible(), false, "not failible (delay > 0)");
     t.throws(() => { delay.duration = 19; }, "cannot overwrite dur");
-    t.equal(!Delay(0).failible, true, "zero duration delay is OK");
-    t.equal(Delay(-17).failible, true, "negative duration delay is failible");
+    t.equal(Delay(0).failible(), false, "zero duration delay is OK");
+    t.equal(Delay(-17).failible(), true, "negative duration delay is failible");
 });
 
 test("Delay.repeat()", t => {
@@ -28,11 +28,11 @@ test("Delay.repeat()", t => {
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, delay, "repeat child");
     t.equal(repeat.duration, Infinity, "repeat dur");
-    t.equal(repeat.failible, false, "unlimited repetitions do not fail");
+    t.equal(repeat.failible(), false, "unlimited repetitions do not fail");
     const limitedRepeats = repeat.take(3);
     t.equal(limitedRepeats.duration, 69, "repeat dur (limited)");
-    t.equal(!limitedRepeats.failible, true, "limited repetitions do not fail");
-    t.equal(Delay(0).repeat().failible, true, "zero duration delay cannot repeat");
+    t.equal(limitedRepeats.failible(), false, "limited repetitions do not fail");
+    t.equal(Delay(0).repeat().failible(), true, "zero duration delay cannot repeat");
 });
 
 test("Instantiation", t => {

--- a/js/tests/delay.html
+++ b/js/tests/delay.html
@@ -62,6 +62,7 @@ test("Instantiation with parent duration", t => {
     const tape = Tape();
     t.equal(dump(tape.instantiate(Delay(23), 17, 31)), "* Delay-0 [17, 40[", "no cutoff");
     t.equal(dump(tape.instantiate(Delay(23), 17, 19)), "* Delay-1 [17, 36[", "cutoff");
+    t.equal(dump(tape.instantiate(Delay(23), 17, 0)), "* Delay-2 @17", "zero duration");
 });
 
 test("Delay(d).repeat()", t => {

--- a/js/tests/index.html
+++ b/js/tests/index.html
@@ -19,6 +19,7 @@
             <li>delay.html</li>
             <li>par.html</li>
             <li>par-take.html</li>
+            <li>par-dur.html</li>
             <li>par-repeat.html</li>
             <li>par-map.html</li>
             <li>seq.html</li>

--- a/js/tests/index.html
+++ b/js/tests/index.html
@@ -24,6 +24,7 @@
             <li>par-map.html</li>
             <li>seq.html</li>
             <li>seq-take.html</li>
+            <li>seq-dur.html</li>
             <li>seq-repeat.html</li>
             <li>seq-map.html</li>
             <li>seq-fold.html</li>

--- a/js/tests/instant.html
+++ b/js/tests/instant.html
@@ -48,6 +48,10 @@ test("Instantiatiation", t => {
     t.equal(instance.value, "ok", "instance value");
 });
 
+test("Instantiation with parent duration", t => {
+    t.equal(dump(Tape().instantiate(Instant(), 17, 31)), "* Instant-0 @17", "cap is always high enough");
+});
+
 test("Instant(f).repeat().take(n = ∞)", t => {
     const tape = Tape();
     const repeat = tape.instantiate(Instant(K("ok")).repeat(), 17);
@@ -82,10 +86,6 @@ test("Prune instant", t => {
     ]), 17), "instantiation failed");
     Deck({ tape }).now = 18;
     t.equal(tape.occurrences, [], "no occurrence on tape");
-});
-
-test("Instantiation with parent duration", t => {
-    t.equal(dump(Tape().instantiate(Instant(), 17, 31)), "* Instant-0 @17", "cap is always high enough");
 });
 
         </script>

--- a/js/tests/instant.html
+++ b/js/tests/instant.html
@@ -17,7 +17,7 @@ test("Instant()", t => {
     t.equal(instant.show(), "Instant", "show");
     t.equal(instant.valueForInstance(17), 17, "valueForInstance defaults to I");
     t.equal(instant.duration, 0, "zero duration");
-    t.equal(!instant.failible, true, "infailible (at instantiation)");
+    t.equal(instant.failible(), false, "infailible (at instantiation)");
 });
 
 test("Instant(f)", t => {
@@ -31,10 +31,10 @@ test("Instant.repeat(); must be limited by take()", t => {
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, instant, "repeat child");
     t.equal(repeat.duration, Infinity, "repeat dur");
-    t.equal(repeat.failible, true, "unlimited repetitions fail");
+    t.equal(repeat.failible(), true, "unlimited repetitions fail");
     const limitedRepeats = repeat.take(3);
     t.equal(limitedRepeats.duration, 0, "repeat dur (limited)");
-    t.equal(!limitedRepeats.failible, true, "limited repetitions do not fail");
+    t.equal(limitedRepeats.failible(), false, "limited repetitions do not fail");
 });
 
 test("Instantiatiation", t => {

--- a/js/tests/instant.html
+++ b/js/tests/instant.html
@@ -78,13 +78,13 @@ test("Prune instant", t => {
     const tape = Tape();
     t.undefined(tape.instantiate(Seq([
         Instant(() => { throw Error("not pruned?!"); }),
-        Delay(-1)
+        Par().take(1)
     ]), 17), "instantiation failed");
     Deck({ tape }).now = 18;
     t.equal(tape.occurrences, [], "no occurrence on tape");
 });
 
-test("Instantiation with duration cap", t => {
+test("Instantiation with parent duration", t => {
     t.equal(dump(Tape().instantiate(Instant(), 17, 31)), "* Instant-0 @17", "cap is always high enough");
 });
 

--- a/js/tests/instant.html
+++ b/js/tests/instant.html
@@ -16,7 +16,7 @@ test("Instant()", t => {
     const instant = Instant();
     t.equal(instant.show(), "Instant", "show");
     t.equal(instant.valueForInstance(17), 17, "valueForInstance defaults to I");
-    t.equal(instant.dur, 0, "zero duration");
+    t.equal(instant.duration, 0, "zero duration");
     t.equal(!instant.failible, true, "infailible (at instantiation)");
 });
 
@@ -30,10 +30,10 @@ test("Instant.repeat(); must be limited by take()", t => {
     const repeat = instant.repeat();
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, instant, "repeat child");
-    t.equal(repeat.dur, Infinity, "repeat dur");
+    t.equal(repeat.duration, Infinity, "repeat dur");
     t.equal(repeat.failible, true, "unlimited repetitions fail");
     const limitedRepeats = repeat.take(3);
-    t.equal(limitedRepeats.dur, 0, "repeat dur (limited)");
+    t.equal(limitedRepeats.duration, 0, "repeat dur (limited)");
     t.equal(!limitedRepeats.failible, true, "limited repetitions do not fail");
 });
 
@@ -84,6 +84,9 @@ test("Prune instant", t => {
     t.equal(tape.occurrences, [], "no occurrence on tape");
 });
 
+test("Instantiation with duration cap", t => {
+    t.equal(dump(Tape().instantiate(Instant(), 17, 31)), "* Instant-0 @17", "cap is always high enough");
+});
 
         </script>
     </head>

--- a/js/tests/instant.html
+++ b/js/tests/instant.html
@@ -17,7 +17,7 @@ test("Instant()", t => {
     t.equal(instant.show(), "Instant", "show");
     t.equal(instant.valueForInstance(17), 17, "valueForInstance defaults to I");
     t.equal(instant.duration, 0, "zero duration");
-    t.equal(instant.failible(), false, "infailible (at instantiation)");
+    t.equal(!instant.failible, true, "infailible (at instantiation)");
 });
 
 test("Instant(f)", t => {
@@ -31,10 +31,10 @@ test("Instant.repeat(); must be limited by take()", t => {
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, instant, "repeat child");
     t.equal(repeat.duration, Infinity, "repeat dur");
-    t.equal(repeat.failible(), true, "unlimited repetitions fail");
+    t.equal(repeat.failible, true, "unlimited repetitions fail");
     const limitedRepeats = repeat.take(3);
     t.equal(limitedRepeats.duration, 0, "repeat dur (limited)");
-    t.equal(limitedRepeats.failible(), false, "limited repetitions do not fail");
+    t.equal(!limitedRepeats.failible, true, "limited repetitions do not fail");
 });
 
 test("Instantiatiation", t => {

--- a/js/tests/par-dur.html
+++ b/js/tests/par-dur.html
@@ -103,6 +103,46 @@ test("dur(0) with only zero-duration children", t => {
   * Par-3 @17`, "dump matches");
 });
 
+test("Par.take(n).dur(d), extending the duration", t => {
+    const tape = Tape();
+    const par = tape.instantiate(Par([
+        Seq([Instant(K("A")), Delay(23)]),
+        Instant(K("B")),
+        Seq([Instant(K("C")), Delay(23), Instant(x => x + "*")]),
+        Seq([Instant(K("D")), Delay(19)]),
+    ]).take(3).dur(31), 17);
+    Deck({ tape }).now = 49;
+    t.equal(dump(par),
+`* Par-0 [17, 48[ <B,D,A>
+  * Instant-1 @17 <B>
+  * Seq-2 [17, 36[ <D>
+    * Instant-3 @17 <D>
+    * Delay-4 [17, 36[ <D>
+  * Seq-5 [17, 40[ <A>
+    * Instant-6 @17 <A>
+    * Delay-7 [17, 40[ <A>`, "dump matches");
+});
+
+test("Par.take(n).dur(d), extending the duration", t => {
+    const tape = Tape();
+    const par = tape.instantiate(Par([
+        Seq([Instant(K("A")), Delay(23), Instant(x => x + "*")]),
+        Instant(K("B")),
+        Seq([Instant(K("C")), Delay(23), Instant(x => x + "*")]),
+        Seq([Instant(K("D")), Delay(19)]),
+    ]).take(3).dur(20), 17);
+    Deck({ tape }).now = 37;
+    t.equal(dump(par),
+`* Par-0 [17, 37[ <B,D,A>
+  * Instant-1 @17 <B>
+  * Seq-2 [17, 36[ <D>
+    * Instant-3 @17 <D>
+    * Delay-4 [17, 36[ <D>
+  * Seq-5 [17, 37[ <A>
+    * Instant-6 @17 <A>
+    * Delay-7 [17, 37[ <A>`, "dump matches");
+});
+
         </script>
     </head>
     <body>

--- a/js/tests/par-dur.html
+++ b/js/tests/par-dur.html
@@ -66,16 +66,24 @@ test("Extending duration (but constrained by parent)", t => {
   * Delay-3 [17, 36[`, "dump matches");
 });
 
-test("Cutting off duration (failure)", t => {
+test("Cutting off duration (dur)", t => {
     const tape = Tape();
-    t.undefined(
-        tape.instantiate(Par([Instant(), Delay(31), Delay(19)]).dur(23), 17),
-        "Par.dur is less than natural duration"
-    );
-    t.undefined(
-        tape.instantiate(Par([Instant(), Delay(31), Delay(19)]), 17, 23),
-        "Instantiation dur is less than natural duration"
-    );
+    const par = tape.instantiate(Par([Instant(), Delay(31), Delay(19)]).dur(23), 17);
+    t.equal(dump(par),
+`* Par-0 [17, 40[
+  * Instant-1 @17
+  * Delay-2 [17, 40[
+  * Delay-3 [17, 36[`, "dump matches");
+});
+
+test("Cutting off duration (parent duration)", t => {
+    const tape = Tape();
+    const par = tape.instantiate(Par([Instant(), Delay(31), Delay(19)]), 17, 23);
+    t.equal(dump(par),
+`* Par-0 [17, 40[
+  * Instant-1 @17
+  * Delay-2 [17, 40[
+  * Delay-3 [17, 36[`, "dump matches");
 });
 
 test("Cutting off duration (success with take())", t => {

--- a/js/tests/par-dur.html
+++ b/js/tests/par-dur.html
@@ -13,6 +13,7 @@ import { Tape } from "../lib/tape.js";
 import { Deck } from "../lib/deck.js";
 
 test("Par(xs).dur(d) duration", t => {
+    t.equal(Par().dur(29).duration, 29, "empty par");
     t.equal(
         Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).dur(79).duration, 79,
         "dur (more than natural duration)"
@@ -26,6 +27,8 @@ test("Par(xs).dur(d) duration", t => {
         "dur (indefinite natural durations)"
     );
 });
+
+
 
         </script>
     </head>

--- a/js/tests/par-dur.html
+++ b/js/tests/par-dur.html
@@ -50,8 +50,11 @@ test("Extending duration (indefinite duration)", t => {
 
 test("Extending duration (no children)", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par().dur(23), 17);
-    t.equal(dump(par), "* Par-0 [17, 40[", "dump matches");
+    const noChildren = tape.instantiate(Par().dur(23), 17);
+    const emptyList = tape.instantiate(Par([]).dur(23), 17);
+    Deck({ tape }).now = 41;
+    t.equal(dump(noChildren), "* Par-0 [17, 40[ <>", "no children");
+    t.equal(dump(emptyList), "* Par-1 [17, 40[ <>", "empty list");
 });
 
 test("Extending duration (but constrained by parent)", t => {

--- a/js/tests/par-dur.html
+++ b/js/tests/par-dur.html
@@ -28,7 +28,46 @@ test("Par(xs).dur(d) duration", t => {
     );
 });
 
+test("Extending duration", t => {
+    const tape = Tape();
+    const par = tape.instantiate(Par([Instant(), Delay(23), Delay(19)]).dur(31), 17);
+    t.equal(dump(par),
+`* Par-0 [17, 48[
+  * Instant-1 @17
+  * Delay-2 [17, 40[
+  * Delay-3 [17, 36[`, "dump matches");
+});
 
+test("Extending duration (but constrained by parent)", t => {
+    const tape = Tape();
+    const par = tape.instantiate(Par([Instant(), Delay(23), Delay(19)]).dur(51), 17, 31);
+    t.equal(dump(par),
+`* Par-0 [17, 48[
+  * Instant-1 @17
+  * Delay-2 [17, 40[
+  * Delay-3 [17, 36[`, "dump matches");
+});
+
+test("Cutting off duration (failure)", t => {
+    const tape = Tape();
+    t.undefined(
+        tape.instantiate(Par([Instant(), Delay(31), Delay(19)]).dur(23), 17),
+        "Par.dur is less than natural duration"
+    );
+    t.undefined(
+        tape.instantiate(Par([Instant(), Delay(31), Delay(19)]), 17, 23),
+        "Instantiation dur is less than natural duration"
+    );
+});
+
+test("Cutting off duration (success with take())", t => {
+    const tape = Tape();
+    const par = tape.instantiate(Par([Instant(), Delay(31), Delay(19)]).dur(23).take(2), 17);
+    t.equal(dump(par),
+`* Par-0 [17, 40[
+  * Instant-1 @17
+  * Delay-2 [17, 36[`, "dump matches");
+});
 
         </script>
     </head>

--- a/js/tests/par-dur.html
+++ b/js/tests/par-dur.html
@@ -26,6 +26,10 @@ test("Par(xs).dur(d) duration", t => {
         Par([Delay(51), Delay(23), Delay(31), Par.map(), Par.map()]).dur(29).duration, 29,
         "dur (indefinite natural durations)"
     );
+    t.equal(
+        Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).dur("79s").duration, 51,
+        "dur (illegal value is not applied)"
+    );
 });
 
 test("Extending the duration", t => {

--- a/js/tests/par-dur.html
+++ b/js/tests/par-dur.html
@@ -55,8 +55,7 @@ test("Extending duration (no children)", t => {
 });
 
 test("Extending duration (but constrained by parent)", t => {
-    const tape = Tape();
-    const par = tape.instantiate(Par([Instant(), Delay(23), Delay(19)]).dur(51), 17, 31);
+    const par = Tape().instantiate(Par([Instant(), Delay(23), Delay(19)]).dur(51), 17, 31);
     t.equal(dump(par),
 `* Par-0 [17, 48[
   * Instant-1 @17
@@ -77,12 +76,20 @@ test("Cutting off duration (failure)", t => {
 });
 
 test("Cutting off duration (success with take())", t => {
-    const tape = Tape();
-    const par = tape.instantiate(Par([Instant(), Delay(31), Delay(19)]).dur(23).take(2), 17);
+    const par = Tape().instantiate(Par([Instant(), Delay(31), Delay(19)]).dur(23).take(2), 17);
     t.equal(dump(par),
 `* Par-0 [17, 40[
   * Instant-1 @17
   * Delay-2 [17, 36[`, "dump matches");
+});
+
+test("dur(0) with only zero-duration children", t => {
+    const par = Tape().instantiate(Par([Instant(), Delay(0), Par()]).dur(0), 17);
+    t.equal(dump(par),
+`* Par-0 @17
+  * Instant-1 @17
+  * Instant-2 @17
+  * Par-3 @17`, "dump matches");
 });
 
         </script>

--- a/js/tests/par-dur.html
+++ b/js/tests/par-dur.html
@@ -38,6 +38,22 @@ test("Extending duration", t => {
   * Delay-3 [17, 36[`, "dump matches");
 });
 
+test("Extending duration (indefinite duration)", t => {
+    const tape = Tape();
+    const par = tape.instantiate(Par([Instant(), Delay(23), Delay(19)]).dur(Infinity), 17);
+    t.equal(dump(par),
+`* Par-0 [17, ∞[
+  * Instant-1 @17
+  * Delay-2 [17, 40[
+  * Delay-3 [17, 36[`, "dump matches");
+});
+
+test("Extending duration (no children)", t => {
+    const tape = Tape();
+    const par = tape.instantiate(Par().dur(23), 17);
+    t.equal(dump(par), "* Par-0 [17, 40[", "dump matches");
+});
+
 test("Extending duration (but constrained by parent)", t => {
     const tape = Tape();
     const par = tape.instantiate(Par([Instant(), Delay(23), Delay(19)]).dur(51), 17, 31);

--- a/js/tests/par-dur.html
+++ b/js/tests/par-dur.html
@@ -28,7 +28,7 @@ test("Par(xs).dur(d) duration", t => {
     );
 });
 
-test("Extending duration", t => {
+test("Extending the duration", t => {
     const tape = Tape();
     const par = tape.instantiate(Par([Instant(), Delay(23), Delay(19)]).dur(31), 17);
     t.equal(dump(par),
@@ -103,6 +103,49 @@ test("dur(0) with only zero-duration children", t => {
   * Par-3 @17`, "dump matches");
 });
 
+test("Par.dur(d), cutting off the duration", t => {
+    const tape = Tape();
+    const par = tape.instantiate(Par([
+        Seq([Instant(K("A")), Delay(23), Instant(x => x + "*")]),
+        Instant(K("B")),
+        Seq([Instant(K("C")), Delay(23), Instant(x => x + "*")]),
+        Seq([Instant(K("D")), Delay(19)]),
+    ]).dur(21), 17);
+    Deck({ tape }).now = 47;
+    t.equal(dump(par),
+`* Par-0 [17, 38[ <A,B,C,D>
+  * Seq-1 [17, 38[ <A>
+    * Instant-2 @17 <A>
+    * Delay-3 [17, 38[ <A>
+  * Instant-4 @17 <B>
+  * Seq-5 [17, 38[ <C>
+    * Instant-6 @17 <C>
+    * Delay-7 [17, 38[ <C>
+  * Seq-8 [17, 36[ <D>
+    * Instant-9 @17 <D>
+    * Delay-10 [17, 36[ <D>`, "dump matches");
+});
+
+test("Par.take(n).dur(d), cutting off the duration", t => {
+    const tape = Tape();
+    const par = tape.instantiate(Par([
+        Seq([Instant(K("A")), Delay(23), Instant(x => x + "*")]),
+        Instant(K("B")),
+        Seq([Instant(K("C")), Delay(23), Instant(x => x + "*")]),
+        Seq([Instant(K("D")), Delay(19)]),
+    ]).take(3).dur(20), 17);
+    Deck({ tape }).now = 38;
+    t.equal(dump(par),
+`* Par-0 [17, 37[ <B,D,A>
+  * Instant-1 @17 <B>
+  * Seq-2 [17, 36[ <D>
+    * Instant-3 @17 <D>
+    * Delay-4 [17, 36[ <D>
+  * Seq-5 [17, 37[ <A>
+    * Instant-6 @17 <A>
+    * Delay-7 [17, 37[ <A>`, "dump matches");
+});
+
 test("Par.take(n).dur(d), extending the duration", t => {
     const tape = Tape();
     const par = tape.instantiate(Par([
@@ -121,26 +164,6 @@ test("Par.take(n).dur(d), extending the duration", t => {
   * Seq-5 [17, 40[ <A>
     * Instant-6 @17 <A>
     * Delay-7 [17, 40[ <A>`, "dump matches");
-});
-
-test("Par.take(n).dur(d), extending the duration", t => {
-    const tape = Tape();
-    const par = tape.instantiate(Par([
-        Seq([Instant(K("A")), Delay(23), Instant(x => x + "*")]),
-        Instant(K("B")),
-        Seq([Instant(K("C")), Delay(23), Instant(x => x + "*")]),
-        Seq([Instant(K("D")), Delay(19)]),
-    ]).take(3).dur(20), 17);
-    Deck({ tape }).now = 37;
-    t.equal(dump(par),
-`* Par-0 [17, 37[ <B,D,A>
-  * Instant-1 @17 <B>
-  * Seq-2 [17, 36[ <D>
-    * Instant-3 @17 <D>
-    * Delay-4 [17, 36[ <D>
-  * Seq-5 [17, 37[ <A>
-    * Instant-6 @17 <A>
-    * Delay-7 [17, 37[ <A>`, "dump matches");
 });
 
         </script>

--- a/js/tests/par-dur.html
+++ b/js/tests/par-dur.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Par.dur</title>
+        <meta charset="utf8">
+        <link rel="stylesheet" href="test.css">
+        <script type="module">
+
+import { test } from "./test.js";
+import { K } from "../lib/util.js";
+import { Instant, Delay, Par, Seq, dump } from "../lib/score.js";
+import { Tape } from "../lib/tape.js";
+import { Deck } from "../lib/deck.js";
+
+test("Par(xs).dur(d) duration", t => {
+    t.equal(
+        Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).dur(79).duration, 79,
+        "dur (more than natural duration)"
+    );
+    t.equal(
+        Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).dur(29).duration, 29,
+        "dur (less than natural duration)"
+    );
+    t.equal(
+        Par([Delay(51), Delay(23), Delay(31), Par.map(), Par.map()]).dur(29).duration, 29,
+        "dur (indefinite natural durations)"
+    );
+});
+
+        </script>
+    </head>
+    <body>
+        <p><a href="index.html">Back</a></p>
+    </body>
+</html>

--- a/js/tests/par-dur.html
+++ b/js/tests/par-dur.html
@@ -66,43 +66,6 @@ test("Extending duration (but constrained by parent)", t => {
   * Delay-3 [17, 36[`, "dump matches");
 });
 
-test("Cutting off duration (dur)", t => {
-    const tape = Tape();
-    const par = tape.instantiate(Par([Instant(), Delay(31), Delay(19)]).dur(23), 17);
-    t.equal(dump(par),
-`* Par-0 [17, 40[
-  * Instant-1 @17
-  * Delay-2 [17, 40[
-  * Delay-3 [17, 36[`, "dump matches");
-});
-
-test("Cutting off duration (parent duration)", t => {
-    const tape = Tape();
-    const par = tape.instantiate(Par([Instant(), Delay(31), Delay(19)]), 17, 23);
-    t.equal(dump(par),
-`* Par-0 [17, 40[
-  * Instant-1 @17
-  * Delay-2 [17, 40[
-  * Delay-3 [17, 36[`, "dump matches");
-});
-
-test("Cutting off duration (success with take())", t => {
-    const par = Tape().instantiate(Par([Instant(), Delay(31), Delay(19)]).dur(23).take(2), 17);
-    t.equal(dump(par),
-`* Par-0 [17, 40[
-  * Instant-1 @17
-  * Delay-2 [17, 36[`, "dump matches");
-});
-
-test("dur(0) with only zero-duration children", t => {
-    const par = Tape().instantiate(Par([Instant(), Delay(0), Par()]).dur(0), 17);
-    t.equal(dump(par),
-`* Par-0 @17
-  * Instant-1 @17
-  * Instant-2 @17
-  * Par-3 @17`, "dump matches");
-});
-
 test("Par.dur(d), cutting off the duration", t => {
     const tape = Tape();
     const par = tape.instantiate(Par([
@@ -124,6 +87,58 @@ test("Par.dur(d), cutting off the duration", t => {
   * Seq-8 [17, 36[ <D>
     * Instant-9 @17 <D>
     * Delay-10 [17, 36[ <D>`, "dump matches");
+});
+
+test("Par, cutting off the duration (parent duration)", t => {
+    const tape = Tape();
+    const par = tape.instantiate(Par([
+        Seq([Instant(K("A")), Delay(23), Instant(x => x + "*")]),
+        Instant(K("B")),
+        Seq([Instant(K("C")), Delay(23), Instant(x => x + "*")]),
+        Seq([Instant(K("D")), Delay(19)]),
+    ]), 17, 21);
+    Deck({ tape }).now = 47;
+    t.equal(dump(par),
+`* Par-0 [17, 38[ <A,B,C,D>
+  * Seq-1 [17, 38[ <A>
+    * Instant-2 @17 <A>
+    * Delay-3 [17, 38[ <A>
+  * Instant-4 @17 <B>
+  * Seq-5 [17, 38[ <C>
+    * Instant-6 @17 <C>
+    * Delay-7 [17, 38[ <C>
+  * Seq-8 [17, 36[ <D>
+    * Instant-9 @17 <D>
+    * Delay-10 [17, 36[ <D>`, "dump matches");
+});
+
+test("Cutting off duration (parent duration)", t => {
+    const tape = Tape();
+    const par = tape.instantiate(Par([Instant(), Delay(31), Delay(19)]), 17, 23);
+    t.equal(dump(par),
+`* Par-0 [17, 40[
+  * Instant-1 @17
+  * Delay-2 [17, 40[
+  * Delay-3 [17, 36[`, "dump matches");
+});
+
+test("dur(0)", t => {
+    const par = Tape().instantiate(Par([Instant(), Delay(0), Par(), Delay(23)]).dur(0), 17);
+    t.equal(dump(par),
+`* Par-0 @17
+  * Instant-1 @17
+  * Instant-2 @17
+  * Par-3 @17
+  * Delay-4 @17`, "dump matches");
+});
+
+test("dur(0) with only zero-duration children", t => {
+    const par = Tape().instantiate(Par([Instant(), Delay(0), Par()]).dur(0), 17);
+    t.equal(dump(par),
+`* Par-0 @17
+  * Instant-1 @17
+  * Instant-2 @17
+  * Par-3 @17`, "dump matches");
 });
 
 test("Par.take(n).dur(d), cutting off the duration", t => {

--- a/js/tests/par-map.html
+++ b/js/tests/par-map.html
@@ -139,30 +139,50 @@ test("Par.map(g).dur(d); cutting off duration", t => {
         Instant(K([19, 37, 31, 19, 51])),
         Par.map(Delay).dur(41)
     ]), 17);
-    Deck({ tape }).now = 18;
+    Deck({ tape }).now = 59;
     t.equal(dump(instance),
-`* Seq-0 [17, 58[
+`* Seq-0 [17, 58[ <19,37,31,19,51>
   * Instant-1 @17 <19,37,31,19,51>
-  * Par/map-2 [17, 58[
-    * Delay-3 [17, 36[
-    * Delay-4 [17, 54[
-    * Delay-5 [17, 48[
-    * Delay-6 [17, 36[
-    * Delay-7 [17, 58[`, "dump matches");
+  * Par/map-2 [17, 58[ <19,37,31,19,51>
+    * Delay-3 [17, 36[ <19>
+    * Delay-4 [17, 54[ <37>
+    * Delay-5 [17, 48[ <31>
+    * Delay-6 [17, 36[ <19>
+    * Delay-7 [17, 58[ <51>`, "dump matches");
 });
 
-test("Par.map(g).dur(d); cutting off instantiation duration, failure at runtime", t => {
+test("Par.map(g).dur(d); cutting off instantiation duration", t => {
     const tape = Tape();
     const instance = tape.instantiate(Seq([
         Instant(K([19, 37, 31, 19, 51])),
         Par.map(Delay)
     ]), 17, 41);
-    Deck({ tape }).now = 18;
-    console.log(dump(instance));
+    Deck({ tape }).now = 59;
     t.equal(dump(instance),
-`* Seq-0 @17 (failed)
+`* Seq-0 [17, 58[ <19,37,31,19,51>
   * Instant-1 @17 <19,37,31,19,51>
-  * Par/map-2 @17 (failed)`, "dump matches");
+  * Par/map-2 [17, 58[ <19,37,31,19,51>
+    * Delay-3 [17, 36[ <19>
+    * Delay-4 [17, 54[ <37>
+    * Delay-5 [17, 48[ <31>
+    * Delay-6 [17, 36[ <19>
+    * Delay-7 [17, 58[ <51>`, "dump matches");
+});
+
+test("Par.map(g).take(n).dur(d); extending duration", t => {
+    const tape = Tape();
+    const instance = tape.instantiate(Seq([
+        Instant(K([19, 37, 31, 19, 51])),
+        Par.map(Delay).take(3).dur(71)
+    ]), 17);
+    Deck({ tape }).now = 89;
+    t.equal(dump(instance),
+`* Seq-0 [17, 88[ <19,19,31>
+  * Instant-1 @17 <19,37,31,19,51>
+  * Par/map-2 [17, 88[ <19,19,31>
+    * Delay-3 [17, 36[ <19>
+    * Delay-4 [17, 36[ <19>
+    * Delay-5 [17, 48[ <31>`, "dump matches");
 });
 
 test("Par.map(g) failure", t => {

--- a/js/tests/par-map.html
+++ b/js/tests/par-map.html
@@ -152,7 +152,6 @@ test("Par.map(g).dur(d); cutting off duration", t => {
 });
 
 test("Par.map(g).dur(d); cutting off instantiation duration, failure at runtime", t => {
-    t.skip();
     const tape = Tape();
     const instance = tape.instantiate(Seq([
         Instant(K([19, 37, 31, 19, 51])),

--- a/js/tests/par-map.html
+++ b/js/tests/par-map.html
@@ -133,7 +133,7 @@ test("Par.map(g).dur(d); extending duration, no children", t => {
   * Par/map-2 [17, 88[ <>`, "dump matches");
 });
 
-test("Par.map(g).dur(d); cutting off duration, failure at runtime", t => {
+test("Par.map(g).dur(d); cutting off duration", t => {
     const tape = Tape();
     const instance = tape.instantiate(Seq([
         Instant(K([19, 37, 31, 19, 51])),
@@ -141,9 +141,14 @@ test("Par.map(g).dur(d); cutting off duration, failure at runtime", t => {
     ]), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(instance),
-`* Seq-0 @17 (failed)
+`* Seq-0 [17, 58[
   * Instant-1 @17 <19,37,31,19,51>
-  * Par/map-2 @17 (failed)`, "dump matches");
+  * Par/map-2 [17, 58[
+    * Delay-3 [17, 36[
+    * Delay-4 [17, 54[
+    * Delay-5 [17, 48[
+    * Delay-6 [17, 36[
+    * Delay-7 [17, 58[`, "dump matches");
 });
 
 test("Par.map(g).dur(d); cutting off instantiation duration, failure at runtime", t => {
@@ -223,7 +228,7 @@ test("Par may recover from failing child", t => {
     const instance = tape.instantiate(Seq([
         Instant(K([23, 19])),
         Par([
-            Par.map(x => Delay(-x)),
+            Par().take(1),
             Par.map(Delay)
         ]).take(1)
     ]), 17)
@@ -232,9 +237,9 @@ test("Par may recover from failing child", t => {
 `* Seq-0 [17, 40[ <23,19>
   * Instant-1 @17 <23,19>
   * Par-2 [17, 40[ <23,19>
-    * Par/map-4 [17, 40[ <23,19>
-      * Delay-5 [17, 40[ <23>
-      * Delay-6 [17, 36[ <19>`, "dump matches");
+    * Par/map-3 [17, 40[ <23,19>
+      * Delay-4 [17, 40[ <23>
+      * Delay-5 [17, 36[ <19>`, "dump matches");
 });
 
 test("Cancel Par.map", t => {

--- a/js/tests/par-map.html
+++ b/js/tests/par-map.html
@@ -102,6 +102,65 @@ test("Par.map(g).take(0)", t => {
     t.equal(instance.value, [], "empty list");
 });
 
+test("Par.map(g).dur(d); extending duration", t => {
+    const tape = Tape();
+    const instance = tape.instantiate(Seq([
+        Instant(K([19, 37, 31, 19, 51])),
+        Par.map(Delay).dur(71)
+    ]), 17);
+    Deck({ tape }).now = 89;
+    t.equal(dump(instance),
+`* Seq-0 [17, 88[ <19,37,31,19,51>
+  * Instant-1 @17 <19,37,31,19,51>
+  * Par/map-2 [17, 88[ <19,37,31,19,51>
+    * Delay-3 [17, 36[ <19>
+    * Delay-4 [17, 54[ <37>
+    * Delay-5 [17, 48[ <31>
+    * Delay-6 [17, 36[ <19>
+    * Delay-7 [17, 68[ <51>`, "dump matches");
+});
+
+test("Par.map(g).dur(d); extending duration, no children", t => {
+    const tape = Tape();
+    const instance = tape.instantiate(Seq([
+        Instant(K([])),
+        Par.map(Delay).dur(71)
+    ]), 17);
+    Deck({ tape }).now = 89;
+    t.equal(dump(instance),
+`* Seq-0 [17, 88[ <>
+  * Instant-1 @17 <>
+  * Par/map-2 [17, 88[ <>`, "dump matches");
+});
+
+test("Par.map(g).dur(d); cutting off duration, failure at runtime", t => {
+    const tape = Tape();
+    const instance = tape.instantiate(Seq([
+        Instant(K([19, 37, 31, 19, 51])),
+        Par.map(Delay).dur(41)
+    ]), 17);
+    Deck({ tape }).now = 18;
+    t.equal(dump(instance),
+`* Seq-0 @17 (failed)
+  * Instant-1 @17 <19,37,31,19,51>
+  * Par/map-2 @17 (failed)`, "dump matches");
+});
+
+test("Par.map(g).dur(d); cutting off instantiation duration, failure at runtime", t => {
+    t.skip();
+    const tape = Tape();
+    const instance = tape.instantiate(Seq([
+        Instant(K([19, 37, 31, 19, 51])),
+        Par.map(Delay)
+    ]), 17, 41);
+    Deck({ tape }).now = 18;
+    console.log(dump(instance));
+    t.equal(dump(instance),
+`* Seq-0 @17 (failed)
+  * Instant-1 @17 <19,37,31,19,51>
+  * Par/map-2 @17 (failed)`, "dump matches");
+});
+
 test("Par.map(g) failure", t => {
     const tape = Tape();
     const instance = tape.instantiate(Seq([
@@ -174,8 +233,8 @@ test("Par may recover from failing child", t => {
   * Instant-1 @17 <23,19>
   * Par-2 [17, 40[ <23,19>
     * Par/map-4 [17, 40[ <23,19>
-      * Delay-7 [17, 40[ <23>
-      * Delay-8 [17, 36[ <19>`, "dump matches");
+      * Delay-5 [17, 40[ <23>
+      * Delay-6 [17, 36[ <19>`, "dump matches");
 });
 
 test("Cancel Par.map", t => {

--- a/js/tests/par-map.html
+++ b/js/tests/par-map.html
@@ -16,9 +16,9 @@ test("Par.map(g)", t => {
     const par = Par.map(Delay);
     t.equal(par.show(), "Par/map", "show");
     t.typeof(par.g, "function", "g function");
-    t.undefined(par.dur, "unresolved duration");
+    t.undefined(par.duration, "unresolved duration");
     t.equal(!par.failible, true, "not failible");
-    t.equal(par.take(0).dur, 0, "down to zero with take(0)");
+    t.equal(par.take(0).duration, 0, "down to zero with take(0)");
 });
 
 test("Par.map(g).repeat()", t => {
@@ -26,9 +26,9 @@ test("Par.map(g).repeat()", t => {
     const repeat = par.repeat();
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, par, "repeat child");
-    t.equal(repeat.dur, Infinity, "indefinite duration");
+    t.equal(repeat.duration, Infinity, "indefinite duration");
     t.equal(repeat.failible, false, "not failible");
-    t.undefined(repeat.take(3).dur, "repeat dur (limited)");
+    t.undefined(repeat.take(3).duration, "repeat dur (limited)");
 });
 
 test("Instantiation", t => {

--- a/js/tests/par-map.html
+++ b/js/tests/par-map.html
@@ -17,7 +17,7 @@ test("Par.map(g)", t => {
     t.equal(par.show(), "Par/map", "show");
     t.typeof(par.g, "function", "g function");
     t.undefined(par.duration, "unresolved duration");
-    t.equal(!par.failible, true, "not failible");
+    t.equal(par.failible(), false, "not failible");
     t.equal(par.take(0).duration, 0, "down to zero with take(0)");
 });
 
@@ -27,7 +27,7 @@ test("Par.map(g).repeat()", t => {
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, par, "repeat child");
     t.equal(repeat.duration, Infinity, "indefinite duration");
-    t.equal(repeat.failible, false, "not failible");
+    t.equal(repeat.failible(), false, "not failible");
     t.undefined(repeat.take(3).duration, "repeat dur (limited)");
 });
 

--- a/js/tests/par-map.html
+++ b/js/tests/par-map.html
@@ -17,7 +17,7 @@ test("Par.map(g)", t => {
     t.equal(par.show(), "Par/map", "show");
     t.typeof(par.g, "function", "g function");
     t.undefined(par.duration, "unresolved duration");
-    t.equal(par.failible(), false, "not failible");
+    t.equal(!par.failible, true, "not failible");
     t.equal(par.take(0).duration, 0, "down to zero with take(0)");
 });
 
@@ -27,7 +27,7 @@ test("Par.map(g).repeat()", t => {
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, par, "repeat child");
     t.equal(repeat.duration, Infinity, "indefinite duration");
-    t.equal(repeat.failible(), false, "not failible");
+    t.equal(!repeat.failible, true, "not failible");
     t.undefined(repeat.take(3).duration, "repeat dur (limited)");
 });
 

--- a/js/tests/par-repeat.html
+++ b/js/tests/par-repeat.html
@@ -18,8 +18,8 @@ test("Par(xs).repeat()", t => {
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, par, "repeat child");
     t.equal(repeat.duration, Infinity, "indefinite duration");
-    t.equal(repeat.failible(), false, "not failible (when par duration > 0)");
-    t.equal(Par().repeat().failible(), true, "failible (when par duration = 0)");
+    t.equal(!repeat.failible, true, "not failible (when par duration > 0)");
+    t.equal(Par().repeat().failible, true, "failible (when par duration = 0)");
 });
 
 test("Instantiation", t => {

--- a/js/tests/par-repeat.html
+++ b/js/tests/par-repeat.html
@@ -18,6 +18,8 @@ test("Par(xs).repeat()", t => {
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, par, "repeat child");
     t.equal(repeat.duration, Infinity, "indefinite duration");
+    t.equal(repeat.failible(), false, "not failible (when par duration > 0)");
+    t.equal(Par().repeat().failible(), true, "failible (when par duration = 0)");
 });
 
 test("Instantiation", t => {

--- a/js/tests/par-repeat.html
+++ b/js/tests/par-repeat.html
@@ -17,7 +17,7 @@ test("Par(xs).repeat()", t => {
     const repeat = par.repeat();
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, par, "repeat child");
-    t.equal(repeat.dur, Infinity, "indefinite duration");
+    t.equal(repeat.duration, Infinity, "indefinite duration");
 });
 
 test("Instantiation", t => {

--- a/js/tests/par-take.html
+++ b/js/tests/par-take.html
@@ -79,7 +79,7 @@ test("Instantiation; n < xs.length", t => {
 test("Instantiation failure in child after nth", t => {
     const tape = Tape();
     const par = tape.instantiate(Par([
-        Seq([Delay(23), Delay(-19)]),
+        Seq([Delay(23), Par().take(1)]),
         Instant(K("B")),
     ]).take(1), 17);
     Deck({ tape }).now = 18;
@@ -106,7 +106,7 @@ test("Allowing failure during instantiation", t => {
     const par = tape.instantiate(Par([
         Delay(23),
         Delay(31),
-        Delay(-17), // fails
+        Par().take(1), // fails
         Delay(19),
         Instant().repeat(), // fails
     ]).take(3), 17);

--- a/js/tests/par-take.html
+++ b/js/tests/par-take.html
@@ -76,6 +76,22 @@ test("Instantiation; n < xs.length", t => {
   * Instant-1 @17 <B>`, "dump matches");
 });
 
+test("Instantiation; unresolved durations result in more than n children", t => {
+    const par = Tape().instantiate(Par([
+        Delay(23),
+        Delay(31),
+        Par.map(Delay),
+        Delay(19),
+        Delay(51) // this delay will not be instantiated
+    ]).take(3), 17);
+    t.equal(dump(par),
+`* Par-0 [17, ∞[
+  * Par/map-1 [17, ∞[
+  * Delay-2 [17, 36[
+  * Delay-3 [17, 40[
+  * Delay-4 [17, 48[`, "dump matches");
+});
+
 test("Instantiation failure in child after nth", t => {
     const tape = Tape();
     const par = tape.instantiate(Par([

--- a/js/tests/par-take.html
+++ b/js/tests/par-take.html
@@ -13,17 +13,30 @@ import { Tape } from "../lib/tape.js";
 import { Deck } from "../lib/deck.js";
 
 test("Par(xs).take(n = ∞) duration", t => {
-    t.equal(Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take().dur, 51, "dur with n = ∞");
-    t.undefined(Par([Delay(51), Delay(23), Delay(31), Par.map(), Par.map()]).take().dur,
-        "dur with n = ∞ (indefinite durations)");
-    t.equal(Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(7).dur, 0,
-        "zero dur with n > child count (failure)");
-     t.equal(Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(3).dur, 23,
-        "dur with n < child count");
-     t.undefined(Par([Delay(51), Delay(23), Delay(31), Par.map(), Delay(19)]).take(3).dur,
-        "dur with n < child count, but unresolved duration");
-    t.equal(Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(0).dur, 0,
-        "dur with n = 0");
+    t.equal(
+        Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take().duration, 51,
+        "dur with n = ∞"
+    );
+    t.undefined(
+        Par([Delay(51), Delay(23), Delay(31), Par.map(), Par.map()]).take().duration,
+        "dur with n = ∞ (indefinite durations)"
+    );
+    t.equal(
+        Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(7).duration, 0,
+        "zero dur with n > child count (failure)"
+    );
+    t.equal(
+        Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(3).duration, 23,
+        "dur with n < child count"
+    );
+    t.undefined(
+        Par([Delay(51), Delay(23), Delay(31), Par.map(), Delay(19)]).take(3).duration,
+        "dur with n < child count, but unresolved duration"
+    );
+    t.equal(
+        Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(0).duration, 0,
+        "dur with n = 0"
+    );
 });
 
 test("Instantiation; n = ∞", t => {

--- a/js/tests/par.html
+++ b/js/tests/par.html
@@ -153,6 +153,10 @@ test("Prune par", t => {
     t.equal(tape.show(), "Tape<17,17,36>", "occurrences were removed from the tape");
 });
 
+test("Instantiation with parent duration", t => {
+    t.skip("TODO");
+});
+
         </script>
     </head>
     <body>

--- a/js/tests/par.html
+++ b/js/tests/par.html
@@ -17,7 +17,7 @@ test("Par()", t => {
     t.equal(par.show(), "Par/0", "show");
     t.equal(par.children, [], "no children");
     t.equal(par.duration, 0, "no duration");
-    t.equal(!par.failible, true, "not failible");
+    t.equal(par.failible(), false, "not failible");
 });
 
 test("Par(xs)", t => {
@@ -29,7 +29,7 @@ test("Par(xs)", t => {
     t.equal(delay.parent, par, "parent (first child)");
     t.equal(instant.parent, par, "parent (second child)");
     t.equal(par.duration, 17, "duration");
-    t.equal(!par.failible, true, "not failible");
+    t.equal(par.failible(), false, "not failible");
 });
 
 test("Par duration", t => {

--- a/js/tests/par.html
+++ b/js/tests/par.html
@@ -16,7 +16,7 @@ test("Par()", t => {
     const par = Par();
     t.equal(par.show(), "Par/0", "show");
     t.equal(par.children, [], "no children");
-    t.equal(par.dur, 0, "no duration");
+    t.equal(par.duration, 0, "no duration");
     t.equal(!par.failible, true, "not failible");
 });
 
@@ -28,16 +28,23 @@ test("Par(xs)", t => {
     t.equal(par.children, [delay, instant], "children");
     t.equal(delay.parent, par, "parent (first child)");
     t.equal(instant.parent, par, "parent (second child)");
-    t.equal(par.dur, 17, "duration");
+    t.equal(par.duration, 17, "duration");
     t.equal(!par.failible, true, "not failible");
 });
 
 test("Par duration", t => {
-    t.equal(Par([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31).repeat()]).dur, Infinity,
-        "indefinite duration (repeated child at the end)");
-    t.equal(Par([Instant(), Delay(23).repeat(), Seq.fold(), Par.map(), Delay(31)]).dur, Infinity,
-        "indefinite duration (repeated child)");
-    t.undefined(Par([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31)]).dur, "unresolved duration");
+    t.equal(
+        Par([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31).repeat()]).duration, Infinity,
+        "indefinite duration (repeated child at the end)"
+    );
+    t.equal(
+        Par([Instant(), Delay(23).repeat(), Seq.fold(), Par.map(), Delay(31)]).duration, Infinity,
+        "indefinite duration (repeated child)"
+    );
+    t.undefined(
+        Par([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31)]).duration,
+        "unresolved duration"
+    );
 });
 
 test("Instantiation", t => {

--- a/js/tests/par.html
+++ b/js/tests/par.html
@@ -17,7 +17,7 @@ test("Par()", t => {
     t.equal(par.show(), "Par/0", "show");
     t.equal(par.children, [], "no children");
     t.equal(par.duration, 0, "no duration");
-    t.equal(par.failible(), false, "not failible");
+    t.equal(!par.failible, true, "not failible");
 });
 
 test("Par(xs)", t => {
@@ -29,7 +29,7 @@ test("Par(xs)", t => {
     t.equal(delay.parent, par, "parent (first child)");
     t.equal(instant.parent, par, "parent (second child)");
     t.equal(par.duration, 17, "duration");
-    t.equal(par.failible(), false, "not failible");
+    t.equal(!par.failible, true, "not failible");
 });
 
 test("Par duration", t => {

--- a/js/tests/par.html
+++ b/js/tests/par.html
@@ -94,6 +94,52 @@ test("Instantiation; empty par", t => {
     t.equal(instance.value, [], "value for empty par");
 });
 
+test("Instantiation with parent duration (no cutoff)", t => {
+    const tape = Tape();
+    const par = tape.instantiate(Par([
+        Seq([Instant(K("A")), Delay(23)]),
+        Instant(K("B")),
+        Seq([Instant(K("C")), Delay(23)]),
+        Seq([Instant(K("D")), Delay(19)]),
+    ]), 17, 31);
+    Deck({ tape }).now = 41;
+    t.equal(dump(par),
+`* Par-0 [17, 40[ <A,B,C,D>
+  * Seq-1 [17, 40[ <A>
+    * Instant-2 @17 <A>
+    * Delay-3 [17, 40[ <A>
+  * Instant-4 @17 <B>
+  * Seq-5 [17, 40[ <C>
+    * Instant-6 @17 <C>
+    * Delay-7 [17, 40[ <C>
+  * Seq-8 [17, 36[ <D>
+    * Instant-9 @17 <D>
+    * Delay-10 [17, 36[ <D>`, "dump matches");
+});
+
+test("Instantiation with parent duration (cutoff)", t => {
+    const tape = Tape();
+    const par = tape.instantiate(Par([
+        Seq([Instant(K("A")), Delay(23)]),
+        Instant(K("B")),
+        Seq([Instant(K("C")), Delay(23)]),
+        Seq([Instant(K("D")), Delay(19)]),
+    ]), 17, 21);
+    Deck({ tape }).now = 39;
+    t.equal(dump(par),
+`* Par-0 [17, 38[ <A,B,C,D>
+  * Seq-1 [17, 38[ <A>
+    * Instant-2 @17 <A>
+    * Delay-3 [17, 38[ <A>
+  * Instant-4 @17 <B>
+  * Seq-5 [17, 38[ <C>
+    * Instant-6 @17 <C>
+    * Delay-7 [17, 38[ <C>
+  * Seq-8 [17, 36[ <D>
+    * Instant-9 @17 <D>
+    * Delay-10 [17, 36[ <D>`, "dump matches");
+});
+
 test("Value", t => {
     const tape = Tape();
     const par = tape.instantiate(Par([
@@ -151,10 +197,6 @@ test("Prune par", t => {
   * Seq-4 [17, 36[ (cancelled)
     * Delay-5 [17, 36[ (cancelled)`, "dump matches");
     t.equal(tape.show(), "Tape<17,17,36>", "occurrences were removed from the tape");
-});
-
-test("Instantiation with parent duration", t => {
-    t.skip("TODO");
 });
 
         </script>

--- a/js/tests/seq-dur.html
+++ b/js/tests/seq-dur.html
@@ -16,25 +16,24 @@ test("Seq(xs).dur(d) duration", t => {
     t.equal(Seq().dur(29).duration, 29, "empty seq");
     t.equal(
         Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).dur(179).duration, 179,
-        "dur (more than natural duration)"
+        "more than natural duration"
     );
     t.equal(
-        Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).dur(29).duration, 0,
-        "zero dur (less than natural duration)"
+        Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).dur(79).duration, 79,
+        "less than natural duration"
     );
     t.equal(
-        Seq([Delay(51), Delay(23).repeat()]).dur(179).duration, 0,
-        "zero dur (indefinite natural duration)"
+        Seq([Delay(51), Delay(23).repeat()]).dur(179).duration, 179,
+        "indefinite natural duration"
     );
     t.equal(
         Seq([Delay(51), Delay(23), Delay(31), Par.map(), Par.map()]).dur(179).duration, 179,
-        "dur (indefinite natural durations)"
+        "unresolved natural duration"
     );
 });
 
 test("Extending duration", t => {
-    const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(), Delay(23), Delay(19)]).dur(51), 17);
+    const seq = Tape().instantiate(Seq([Instant(), Delay(23), Delay(19)]).dur(51), 17);
     t.equal(dump(seq),
 `* Seq-0 [17, 68[
   * Instant-1 @17
@@ -42,6 +41,14 @@ test("Extending duration", t => {
   * Delay-3 [40, 59[`, "dump matches");
 });
 
+test("Extending duration (no children)", t => {
+    const tape = Tape();
+    const noChildren = tape.instantiate(Seq().dur(23), 17);
+    const emptyList = tape.instantiate(Seq([]).dur(23), 17);
+    Deck({ tape }).now = 41;
+    t.equal(dump(noChildren), "* Seq-0 [17, 40[ <undefined>", "no children");
+    t.equal(dump(emptyList), "* Seq-1 [17, 40[ <undefined>", "empty list");
+});
 
         </script>
     </head>

--- a/js/tests/seq-dur.html
+++ b/js/tests/seq-dur.html
@@ -95,6 +95,27 @@ test("dur(0) with only zero-duration children", t => {
   * Par-3 @17`, "dump matches");
 });
 
+test("Value when extended", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([Instant(K("A")), Delay(23), Instant(x => x + "*")]).dur(31), 17);
+    Deck({ tape }).now = 49;
+    t.equal(dump(seq),
+`* Seq-0 [17, 48[ <A*>
+  * Instant-1 @17 <A>
+  * Delay-2 [17, 40[ <A>
+  * Instant-3 @40 <A*>`, "dump matches");
+});
+
+test("Value when cut off", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([Instant(K("A")), Delay(23), Instant(x => x + "*")]).dur(19), 17);
+    Deck({ tape }).now = 37;
+    t.equal(dump(seq),
+`* Seq-0 [17, 36[ <A>
+  * Instant-1 @17 <A>
+  * Delay-2 [17, 36[ <A>`, "dump matches");
+});
+
         </script>
     </head>
     <body>

--- a/js/tests/seq-dur.html
+++ b/js/tests/seq-dur.html
@@ -41,6 +41,15 @@ test("Extending duration", t => {
   * Delay-3 [40, 59[`, "dump matches");
 });
 
+test("Extending duration (indefinite duration)", t => {
+    const seq = Tape().instantiate(Seq([Instant(), Delay(23), Delay(19)]).dur(Infinity), 17);
+    t.equal(dump(seq),
+`* Seq-0 [17, ∞[
+  * Instant-1 @17
+  * Delay-2 [17, 40[
+  * Delay-3 [40, 59[`, "dump matches");
+});
+
 test("Extending duration (no children)", t => {
     const tape = Tape();
     const noChildren = tape.instantiate(Seq().dur(23), 17);
@@ -48,6 +57,15 @@ test("Extending duration (no children)", t => {
     Deck({ tape }).now = 41;
     t.equal(dump(noChildren), "* Seq-0 [17, 40[ <undefined>", "no children");
     t.equal(dump(emptyList), "* Seq-1 [17, 40[ <undefined>", "empty list");
+});
+
+test("Extending duration (but constrained by parent)", t => {
+    const par = Tape().instantiate(Seq([Instant(), Delay(23), Delay(19)]).dur(71), 17, 51);
+    t.equal(dump(par),
+`* Seq-0 [17, 68[
+  * Instant-1 @17
+  * Delay-2 [17, 40[
+  * Delay-3 [40, 59[`, "dump matches");
 });
 
         </script>

--- a/js/tests/seq-dur.html
+++ b/js/tests/seq-dur.html
@@ -68,7 +68,7 @@ test("Extending duration (but constrained by parent)", t => {
   * Delay-3 [40, 59[`, "dump matches");
 });
 
-test("Cutting off duration (with dur)", t => {
+test("Cutting off duration (dur)", t => {
     const seq = Tape().instantiate(Seq([Instant(), Delay(23), Delay(19)]).dur(31), 17);
     t.equal(dump(seq),
 `* Seq-0 [17, 48[
@@ -77,13 +77,23 @@ test("Cutting off duration (with dur)", t => {
   * Delay-3 [40, 48[`, "dump matches");
 });
 
-test("Cutting off duration (from parent dur)", t => {
+test("Cutting off duration (parent duration)", t => {
     const seq = Tape().instantiate(Seq([Instant(), Delay(23), Delay(19)]), 17, 31);
     t.equal(dump(seq),
 `* Seq-0 [17, 48[
   * Instant-1 @17
   * Delay-2 [17, 40[
   * Delay-3 [40, 48[`, "dump matches");
+});
+
+test("dur(0)", t => {
+    const seq = Tape().instantiate(Seq([Instant(), Delay(0), Par(), Delay(23), Instant()]).dur(0), 17);
+    t.equal(dump(seq),
+`* Seq-0 @17
+  * Instant-1 @17
+  * Instant-2 @17
+  * Par-3 @17
+  * Delay-4 @17`, "dump matches");
 });
 
 test("dur(0) with only zero-duration children", t => {
@@ -95,25 +105,29 @@ test("dur(0) with only zero-duration children", t => {
   * Par-3 @17`, "dump matches");
 });
 
-test("Value when extended", t => {
+test("Seq.take(n).dur(d), cutting off the duration", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K("A")), Delay(23), Instant(x => x + "*")]).dur(31), 17);
-    Deck({ tape }).now = 49;
-    t.equal(dump(seq),
-`* Seq-0 [17, 48[ <A*>
-  * Instant-1 @17 <A>
-  * Delay-2 [17, 40[ <A>
-  * Instant-3 @40 <A*>`, "dump matches");
-});
-
-test("Value when cut off", t => {
-    const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K("A")), Delay(23), Instant(x => x + "*")]).dur(19), 17);
+    const seq = tape.instantiate(Seq([
+        Instant(K("A")), Delay(23), Instant(x => x + "*"), Delay(31), Instant(x => x + "*")
+    ]).take(3).dur(19), 17);
     Deck({ tape }).now = 37;
     t.equal(dump(seq),
 `* Seq-0 [17, 36[ <A>
   * Instant-1 @17 <A>
   * Delay-2 [17, 36[ <A>`, "dump matches");
+});
+
+test("Seq.take(n).dur(d), extending the duration", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([
+        Instant(K("A")), Delay(23), Instant(x => x + "A"), Delay(31), Instant(x => x + "*")
+    ]).take(3).dur(39), 17);
+    Deck({ tape }).now = 57;
+    t.equal(dump(seq),
+`* Seq-0 [17, 56[ <AA>
+  * Instant-1 @17 <A>
+  * Delay-2 [17, 40[ <A>
+  * Instant-3 @40 <AA>`, "dump matches");
 });
 
         </script>

--- a/js/tests/seq-dur.html
+++ b/js/tests/seq-dur.html
@@ -159,6 +159,22 @@ test("Cutoff child; unresolved duration", t => {
     * Delay-5 [17, 48[ <41>`, "dump matches");
 });
 
+test("Cutoff child; after child with unresolved duration", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(
+        Seq([Instant(K([23, 19, 41])), Par.map(Delay), Delay(31), (K("ko"))]).dur(51), 17
+    );
+    Deck({ tape }).now = 69;
+    t.equal(dump(seq),
+`* Seq-0 [17, 68[ <23,19,41>
+  * Instant-1 @17 <23,19,41>
+  * Par/map-2 [17, 58[ <23,19,41>
+    * Delay-3 [17, 40[ <23>
+    * Delay-4 [17, 36[ <19>
+    * Delay-5 [17, 58[ <41>
+  * Delay-6 [58, 68[ <23,19,41>`, "dump matches");
+});
+
 test("Extending duration; child with unresolved duration", t => {
     const tape = Tape();
     const seq = tape.instantiate(

--- a/js/tests/seq-dur.html
+++ b/js/tests/seq-dur.html
@@ -60,12 +60,39 @@ test("Extending duration (no children)", t => {
 });
 
 test("Extending duration (but constrained by parent)", t => {
-    const par = Tape().instantiate(Seq([Instant(), Delay(23), Delay(19)]).dur(71), 17, 51);
-    t.equal(dump(par),
+    const seq = Tape().instantiate(Seq([Instant(), Delay(23), Delay(19)]).dur(71), 17, 51);
+    t.equal(dump(seq),
 `* Seq-0 [17, 68[
   * Instant-1 @17
   * Delay-2 [17, 40[
   * Delay-3 [40, 59[`, "dump matches");
+});
+
+test("Cutting off duration (with dur)", t => {
+    const seq = Tape().instantiate(Seq([Instant(), Delay(23), Delay(19)]).dur(31), 17);
+    t.equal(dump(seq),
+`* Seq-0 [17, 48[
+  * Instant-1 @17
+  * Delay-2 [17, 40[
+  * Delay-3 [40, 48[`, "dump matches");
+});
+
+test("Cutting off duration (from parent dur)", t => {
+    const seq = Tape().instantiate(Seq([Instant(), Delay(23), Delay(19)]), 17, 31);
+    t.equal(dump(seq),
+`* Seq-0 [17, 48[
+  * Instant-1 @17
+  * Delay-2 [17, 40[
+  * Delay-3 [40, 48[`, "dump matches");
+});
+
+test("dur(0) with only zero-duration children", t => {
+    const seq = Tape().instantiate(Seq([Instant(), Delay(0), Par()]).dur(0), 17);
+    t.equal(dump(seq),
+`* Seq-0 @17
+  * Instant-1 @17
+  * Instant-2 @17
+  * Par-3 @17`, "dump matches");
 });
 
         </script>

--- a/js/tests/seq-dur.html
+++ b/js/tests/seq-dur.html
@@ -130,6 +130,51 @@ test("Seq.take(n).dur(d), extending the duration", t => {
   * Instant-3 @40 <AA>`, "dump matches");
 });
 
+test("Cutoff child; resolved duration", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(
+        Seq([Par([23, 19, 31].map(Delay)), Instant(K("ko"))]).dur(31), 17
+    );
+    Deck({ tape }).now = 49;
+    t.equal(dump(seq),
+`* Seq-0 [17, 48[ <,,>
+  * Par-1 [17, 48[ <,,>
+    * Delay-2 [17, 40[ <undefined>
+    * Delay-3 [17, 36[ <undefined>
+    * Delay-4 [17, 48[ <undefined>`, "dump matches");
+});
+
+test("Cutoff child; unresolved duration", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(
+        Seq([Instant(K([23, 19, 41])), Par.map(Delay), Instant(K("ko"))]).dur(31), 17
+    );
+    Deck({ tape }).now = 49;
+    t.equal(dump(seq),
+`* Seq-0 [17, 48[ <23,19,41>
+  * Instant-1 @17 <23,19,41>
+  * Par/map-2 [17, 48[ <23,19,41>
+    * Delay-3 [17, 40[ <23>
+    * Delay-4 [17, 36[ <19>
+    * Delay-5 [17, 48[ <41>`, "dump matches");
+});
+
+test("Extending duration; child with unresolved duration", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(
+        Seq([Instant(K([23, 19, 41])), Par.map(Delay), Instant(K("ok"))]).dur(71), 17
+    );
+    Deck({ tape }).now = 89;
+    t.equal(dump(seq),
+`* Seq-0 [17, 88[ <ok>
+  * Instant-1 @17 <23,19,41>
+  * Par/map-2 [17, 58[ <23,19,41>
+    * Delay-3 [17, 40[ <23>
+    * Delay-4 [17, 36[ <19>
+    * Delay-5 [17, 58[ <41>
+  * Instant-6 @58 <ok>`, "dump matches");
+});
+
         </script>
     </head>
     <body>

--- a/js/tests/seq-dur.html
+++ b/js/tests/seq-dur.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Seq.dur</title>
+        <meta charset="utf8">
+        <link rel="stylesheet" href="test.css">
+        <script type="module">
+
+import { test } from "./test.js";
+import { K } from "../lib/util.js";
+import { Instant, Delay, Par, Seq, dump } from "../lib/score.js";
+import { Tape } from "../lib/tape.js";
+import { Deck } from "../lib/deck.js";
+
+test("Seq(xs).dur(d) duration", t => {
+    t.equal(Seq().dur(29).duration, 29, "empty seq");
+    t.equal(
+        Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).dur(179).duration, 179,
+        "dur (more than natural duration)"
+    );
+    t.equal(
+        Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).dur(29).duration, 0,
+        "zero dur (less than natural duration)"
+    );
+    t.equal(
+        Seq([Delay(51), Delay(23).repeat()]).dur(179).duration, 0,
+        "zero dur (indefinite natural duration)"
+    );
+    t.equal(
+        Seq([Delay(51), Delay(23), Delay(31), Par.map(), Par.map()]).dur(179).duration, 179,
+        "dur (indefinite natural durations)"
+    );
+});
+
+test("Extending duration", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([Instant(), Delay(23), Delay(19)]).dur(51), 17);
+    t.equal(dump(seq),
+`* Seq-0 [17, 68[
+  * Instant-1 @17
+  * Delay-2 [17, 40[
+  * Delay-3 [40, 59[`, "dump matches");
+});
+
+
+        </script>
+    </head>
+    <body>
+        <p><a href="index.html">Back</a></p>
+    </body>
+</html>

--- a/js/tests/seq-fold.html
+++ b/js/tests/seq-fold.html
@@ -18,6 +18,7 @@ test("Seq.fold(g, z)", t => {
     t.typeof(fold.g, "function", "g function");
     t.equal(fold.z, 0, "initial accumulator value");
     t.undefined(fold.duration, "unresolved duration");
+    t.equal(fold.failible(), false, "not failible");
     t.equal(fold.take(0).duration, 0, "down to zero with take(0)");
 });
 
@@ -27,7 +28,7 @@ test("Seq.fold(g, z).repeat()", t => {
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, seq, "repeat child");
     t.equal(repeat.duration, Infinity, "indefinite duration");
-    t.equal(repeat.failible, false, "not failible");
+    t.equal(repeat.failible(), false, "not failible");
     t.undefined(repeat.take(3).duration, "repeat dur (limited)");
 });
 

--- a/js/tests/seq-fold.html
+++ b/js/tests/seq-fold.html
@@ -20,6 +20,7 @@ test("Seq.fold(g, z)", t => {
     t.undefined(fold.duration, "unresolved duration");
     t.equal(fold.failible(), false, "not failible");
     t.equal(fold.take(0).duration, 0, "down to zero with take(0)");
+    t.equal(Seq.fold(Instant).dur(23).duration, 23, "duration can be set with dur()");
 });
 
 test("Seq.fold(g, z).repeat()", t => {
@@ -202,6 +203,85 @@ test("Seq.fold(g, z).take(0)", t => {
   * Instant-1 @17 <1,2,3,4,5>
   * Seq/fold-2 @17 <0>
   * Delay-3 [17, 40[ <0>`, "dump matches");
+});
+
+test("Seq.fold(g, z).dur(d), extending duration", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([
+        Instant(K([23, 19, 31])),
+        Seq.fold(x => Seq([Delay(x), Instant(y => x + y)]), 0).dur(83)
+    ]), 17);
+    Deck({ tape }).now = 101;
+    t.equal(dump(seq),
+`* Seq-0 [17, 100[ <73>
+  * Instant-1 @17 <23,19,31>
+  * Seq/fold-2 [17, 100[ <73>
+    * Seq-3 [17, 40[ <23>
+      * Delay-4 [17, 40[ <0>
+      * Instant-5 @40 <23>
+    * Seq-6 [40, 59[ <42>
+      * Delay-7 [40, 59[ <23>
+      * Instant-8 @59 <42>
+    * Seq-9 [59, 90[ <73>
+      * Delay-10 [59, 90[ <42>
+      * Instant-11 @90 <73>`, "dump matches");
+});
+
+test("Seq.fold(g, z).dur(d), cutting off duration", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([
+        Instant(K([23, 19, 31])),
+        Seq.fold(x => Seq([Delay(x), Instant(y => x + y)]), 0).dur(43)
+    ]), 17);
+    Deck({ tape }).now = 61;
+    t.equal(dump(seq),
+`* Seq-0 [17, 60[ <42>
+  * Instant-1 @17 <23,19,31>
+  * Seq/fold-2 [17, 60[ <42>
+    * Seq-3 [17, 40[ <23>
+      * Delay-4 [17, 40[ <0>
+      * Instant-5 @40 <23>
+    * Seq-6 [40, 59[ <42>
+      * Delay-7 [40, 59[ <23>
+      * Instant-8 @59 <42>
+    * Seq-9 [59, 60[ <42>
+      * Delay-10 [59, 60[ <42>`, "dump matches");
+});
+
+test("Seq.fold(g, z).dur(d), cutting off parent (i.e. instantiation) duration", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([
+        Instant(K([23, 19, 31])),
+        Seq.fold(x => Seq([Delay(x), Instant(y => x + y)]), 0)
+    ]).dur(43), 17);
+    Deck({ tape }).now = 61;
+    t.equal(dump(seq),
+`* Seq-0 [17, 60[ <42>
+  * Instant-1 @17 <23,19,31>
+  * Seq/fold-2 [17, 60[ <42>
+    * Seq-3 [17, 40[ <23>
+      * Delay-4 [17, 40[ <0>
+      * Instant-5 @40 <23>
+    * Seq-6 [40, 59[ <42>
+      * Delay-7 [40, 59[ <23>
+      * Instant-8 @59 <42>
+    * Seq-9 [59, 60[ <42>
+      * Delay-10 [59, 60[ <42>`, "dump matches");
+});
+
+test("Seq.fold(g, z).dur(0), cutting off duration (???)", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([
+        Instant(K([23, 19, 31])),
+        Seq.fold(x => Seq([Delay(x), Instant(y => x + y)]), 0).dur(0)
+    ]), 17);
+    Deck({ tape }).now = 61;
+    t.equal(dump(seq),
+`* Seq-0 @17 <0>
+  * Instant-1 @17 <23,19,31>
+  * Seq/fold-2 @17 <0>
+    * Seq-3 @17 <0>
+      * Delay-4 @17 <0>`, "dump matches");
 });
 
 test("Cancel Seq.fold", t => {

--- a/js/tests/seq-fold.html
+++ b/js/tests/seq-fold.html
@@ -18,7 +18,7 @@ test("Seq.fold(g, z)", t => {
     t.typeof(fold.g, "function", "g function");
     t.equal(fold.z, 0, "initial accumulator value");
     t.undefined(fold.duration, "unresolved duration");
-    t.equal(fold.failible(), false, "not failible");
+    t.equal(!fold.failible, true, "not failible");
     t.equal(fold.take(0).duration, 0, "down to zero with take(0)");
     t.equal(Seq.fold(Instant).dur(23).duration, 23, "duration can be set with dur()");
 });
@@ -29,7 +29,7 @@ test("Seq.fold(g, z).repeat()", t => {
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, seq, "repeat child");
     t.equal(repeat.duration, Infinity, "indefinite duration");
-    t.equal(repeat.failible(), false, "not failible");
+    t.equal(!repeat.failible, true, "not failible");
     t.undefined(repeat.take(3).duration, "repeat dur (limited)");
 });
 

--- a/js/tests/seq-fold.html
+++ b/js/tests/seq-fold.html
@@ -17,8 +17,8 @@ test("Seq.fold(g, z)", t => {
     t.equal(fold.show(), "Seq/fold", "show");
     t.typeof(fold.g, "function", "g function");
     t.equal(fold.z, 0, "initial accumulator value");
-    t.undefined(fold.dur, "unresolved duration");
-    t.equal(fold.take(0).dur, 0, "down to zero with take(0)");
+    t.undefined(fold.duration, "unresolved duration");
+    t.equal(fold.take(0).duration, 0, "down to zero with take(0)");
 });
 
 test("Seq.fold(g, z).repeat()", t => {
@@ -26,9 +26,9 @@ test("Seq.fold(g, z).repeat()", t => {
     const repeat = seq.repeat();
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, seq, "repeat child");
-    t.equal(repeat.dur, Infinity, "indefinite duration");
+    t.equal(repeat.duration, Infinity, "indefinite duration");
     t.equal(repeat.failible, false, "not failible");
-    t.undefined(repeat.take(3).dur, "repeat dur (limited)");
+    t.undefined(repeat.take(3).duration, "repeat dur (limited)");
 });
 
 test("Instantiation; child of Seq", t => {

--- a/js/tests/seq-map.html
+++ b/js/tests/seq-map.html
@@ -18,6 +18,7 @@ test("Seq.map(g)", t => {
     t.typeof(map.g, "function", "g function");
     t.undefined(map.duration, "unresolved duration");
     t.equal(map.take(0).duration, 0, "down to zero with take(0)");
+    t.equal(map.failible(), false, "not failible");
 });
 
 test("Seq.map(g).repeat()", t => {
@@ -26,7 +27,7 @@ test("Seq.map(g).repeat()", t => {
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, seq, "repeat child");
     t.equal(repeat.duration, Infinity, "indefinite duration");
-    t.equal(repeat.failible, false, "not failible");
+    t.equal(repeat.failible(), false, "not failible");
     t.undefined(repeat.take(3).duration, "repeat dur (limited)");
 });
 

--- a/js/tests/seq-map.html
+++ b/js/tests/seq-map.html
@@ -18,7 +18,7 @@ test("Seq.map(g)", t => {
     t.typeof(map.g, "function", "g function");
     t.undefined(map.duration, "unresolved duration");
     t.equal(map.take(0).duration, 0, "down to zero with take(0)");
-    t.equal(map.failible(), false, "not failible");
+    t.equal(!map.failible, true, "not failible");
 });
 
 test("Seq.map(g).repeat()", t => {
@@ -27,7 +27,7 @@ test("Seq.map(g).repeat()", t => {
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, seq, "repeat child");
     t.equal(repeat.duration, Infinity, "indefinite duration");
-    t.equal(repeat.failible(), false, "not failible");
+    t.equal(!repeat.failible, true, "not failible");
     t.undefined(repeat.take(3).duration, "repeat dur (limited)");
 });
 

--- a/js/tests/seq-map.html
+++ b/js/tests/seq-map.html
@@ -16,8 +16,8 @@ test("Seq.map(g)", t => {
     const map = Seq.map(Delay);
     t.equal(map.show(), "Seq/map", "show");
     t.typeof(map.g, "function", "g function");
-    t.undefined(map.dur, "unresolved duration");
-    t.equal(map.take(0).dur, 0, "down to zero with take(0)");
+    t.undefined(map.duration, "unresolved duration");
+    t.equal(map.take(0).duration, 0, "down to zero with take(0)");
 });
 
 test("Seq.map(g).repeat()", t => {
@@ -25,9 +25,9 @@ test("Seq.map(g).repeat()", t => {
     const repeat = seq.repeat();
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, seq, "repeat child");
-    t.equal(repeat.dur, Infinity, "indefinite duration");
+    t.equal(repeat.duration, Infinity, "indefinite duration");
     t.equal(repeat.failible, false, "not failible");
-    t.undefined(repeat.take(3).dur, "repeat dur (limited)");
+    t.undefined(repeat.take(3).duration, "repeat dur (limited)");
 });
 
 test("Instantiation", t => {

--- a/js/tests/seq-map.html
+++ b/js/tests/seq-map.html
@@ -145,6 +145,54 @@ test("Seq.map(g).repeat().take(n)", t => {
       * Delay-11 [120, 143[ <23>`, "dump matches");
 });
 
+test("Seq.map(g).dur(d), extending duration", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([Instant(K([31, 19, 23])), Seq.map(Delay).dur(83)]), 17);
+    Deck({ tape }).now = 101;
+    t.equal(dump(seq),
+`* Seq-0 [17, 100[ <31,19,23>
+  * Instant-1 @17 <31,19,23>
+  * Seq/map-2 [17, 100[ <31,19,23>
+    * Delay-3 [17, 48[ <31>
+    * Delay-4 [48, 67[ <19>
+    * Delay-5 [67, 90[ <23>`, "dump matches");
+});
+
+test("Seq.map(g).dur(d), cutting off duration", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([Instant(K([31, 19, 23])), Seq.map(Delay).dur(43)]), 17);
+    Deck({ tape }).now = 61;
+    t.equal(dump(seq),
+`* Seq-0 [17, 60[ <31,19>
+  * Instant-1 @17 <31,19,23>
+  * Seq/map-2 [17, 60[ <31,19>
+    * Delay-3 [17, 48[ <31>
+    * Delay-4 [48, 60[ <19>`, "dump matches");
+});
+
+test("Seq.map(g).dur(0), cutting off duration (???)", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([Instant(K([31, 19, 23])), Seq.map(Delay).dur(0)]), 17);
+    Deck({ tape }).now = 18;
+    t.equal(dump(seq),
+`* Seq-0 @17 <31>
+  * Instant-1 @17 <31,19,23>
+  * Seq/map-2 @17 <31>
+    * Delay-3 @17 <31>`, "dump matches");
+});
+
+test("Seq.map(g).dur(d), cutting off duration during instantiation", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([Instant(K([31, 19, 23])), Seq.map(Delay)]), 17, 43);
+    Deck({ tape }).now = 61;
+    t.equal(dump(seq),
+`* Seq-0 [17, 60[ <31,19>
+  * Instant-1 @17 <31,19,23>
+  * Seq/map-2 [17, 60[ <31,19>
+    * Delay-3 [17, 48[ <31>
+    * Delay-4 [48, 60[ <19>`, "dump matches");
+});
+
 test("Cancel Seq.map", t => {
     const tape = Tape();
     const choice = tape.instantiate(Par([

--- a/js/tests/seq-repeat.html
+++ b/js/tests/seq-repeat.html
@@ -18,9 +18,9 @@ test("Seq(xs).repeat()", t => {
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, seq, "repeat child");
     t.equal(repeat.duration, Infinity, "indefinite duration");
-    t.equal(repeat.failible(), false, "not failible (when seq duration > 0)");
+    t.equal(!repeat.failible, true, "not failible (when seq duration > 0)");
     t.equal(repeat.dur(71).duration, 71, "duration constrained by dur");
-    t.equal(Seq().repeat().failible(), true, "failible (when seq duration = 0)");
+    t.equal(Seq().repeat().failible, true, "failible (when seq duration = 0)");
 });
 
 test("Instantiation", t => {

--- a/js/tests/seq-repeat.html
+++ b/js/tests/seq-repeat.html
@@ -19,6 +19,7 @@ test("Seq(xs).repeat()", t => {
     t.equal(repeat.child, seq, "repeat child");
     t.equal(repeat.duration, Infinity, "indefinite duration");
     t.equal(repeat.failible(), false, "not failible (when seq duration > 0)");
+    t.equal(repeat.dur(71).duration, 71, "duration constrained by dur");
     t.equal(Seq().repeat().failible(), true, "failible (when seq duration = 0)");
 });
 
@@ -54,6 +55,7 @@ test("Instantiation fails for zero duration", t => {
     const tape = Tape();
     t.undefined(tape.instantiate(Seq().repeat(), 17), "empty seq");
     t.undefined(tape.instantiate(Seq([Instant(), Instant()]).repeat(), 17), "zero duration seq");
+    t.undefined(tape.instantiate(Seq().repeat().dur(23), 17), "also fails with dur()");
 });
 
 test("Seq(xs).repeat().take(n)", t => {
@@ -115,6 +117,76 @@ test("Repeat with unresolved duration", t => {
     * Seq/map-13 [101, 143[
       * Delay-14 [101, 120[
       * Delay-15 [120, 143[`, "dump matches");
+});
+
+test("Repeat with dur", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([
+        Instant(K("A")),
+        Seq([Delay(7), Instant(x => x + "+")]).repeat().dur(23)
+    ]), 17);
+    Deck({ tape }).now = 41;
+    t.equal(dump(seq),
+`* Seq-0 [17, 40[ <A+++>
+  * Instant-1 @17 <A>
+  * Seq/repeat-2 [17, 40[ <A+++>
+    * Seq-3 [17, 24[ <A+>
+      * Delay-4 [17, 24[ <A>
+      * Instant-5 @24 <A+>
+    * Seq-6 [24, 31[ <A++>
+      * Delay-7 [24, 31[ <A+>
+      * Instant-8 @31 <A++>
+    * Seq-9 [31, 38[ <A+++>
+      * Delay-10 [31, 38[ <A++>
+      * Instant-11 @38 <A+++>
+    * Seq-12 [38, 40[ <A+++>
+      * Delay-13 [38, 40[ <A+++>`, "dump matches");
+});
+
+test("Repeat with dur and take (extend duration)", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([
+        Instant(K("A")),
+        Seq([Delay(7), Instant(x => x + "+")]).repeat().take(3).dur(23)
+    ]), 17);
+    Deck({ tape }).now = 41;
+    t.equal(dump(seq),
+`* Seq-0 [17, 40[ <A+++>
+  * Instant-1 @17 <A>
+  * Seq/repeat-2 [17, 40[ <A+++>
+    * Seq-3 [17, 24[ <A+>
+      * Delay-4 [17, 24[ <A>
+      * Instant-5 @24 <A+>
+    * Seq-6 [24, 31[ <A++>
+      * Delay-7 [24, 31[ <A+>
+      * Instant-8 @31 <A++>
+    * Seq-9 [31, 38[ <A+++>
+      * Delay-10 [31, 38[ <A++>
+      * Instant-11 @38 <A+++>`, "dump matches");
+});
+
+test("Repeat with dur and take (not enough iterations)", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([
+        Instant(K("A")),
+        Seq([Delay(7), Instant(x => x + "+")]).repeat().take(4).dur(23)
+    ]), 17);
+    Deck({ tape }).now = 41;
+    t.equal(dump(seq),
+`* Seq-0 [17, 40[ (failed)
+  * Instant-1 @17 <A>
+  * Seq/repeat-2 [17, 40[ (failed)
+    * Seq-3 [17, 24[ <A+>
+      * Delay-4 [17, 24[ <A>
+      * Instant-5 @24 <A+>
+    * Seq-6 [24, 31[ <A++>
+      * Delay-7 [24, 31[ <A+>
+      * Instant-8 @31 <A++>
+    * Seq-9 [31, 38[ <A+++>
+      * Delay-10 [31, 38[ <A++>
+      * Instant-11 @38 <A+++>
+    * Seq-12 [38, 40[ <A+++>
+      * Delay-13 [38, 40[ <A+++>`, "dump matches");
 });
 
         </script>

--- a/js/tests/seq-repeat.html
+++ b/js/tests/seq-repeat.html
@@ -17,7 +17,7 @@ test("Seq(xs).repeat()", t => {
     const repeat = seq.repeat();
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, seq, "repeat child");
-    t.equal(repeat.dur, Infinity, "indefinite duration");
+    t.equal(repeat.duration, Infinity, "indefinite duration");
 });
 
 test("Instantiation", t => {

--- a/js/tests/seq-repeat.html
+++ b/js/tests/seq-repeat.html
@@ -18,6 +18,8 @@ test("Seq(xs).repeat()", t => {
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, seq, "repeat child");
     t.equal(repeat.duration, Infinity, "indefinite duration");
+    t.equal(repeat.failible(), false, "not failible (when seq duration > 0)");
+    t.equal(Seq().repeat().failible(), true, "failible (when seq duration = 0)");
 });
 
 test("Instantiation", t => {

--- a/js/tests/seq-take.html
+++ b/js/tests/seq-take.html
@@ -13,17 +13,30 @@ import { Tape } from "../lib/tape.js";
 import { Deck } from "../lib/deck.js";
 
 test("Seq(xs).take(n = ∞) duration", t => {
-    t.equal(Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take().dur, 141, "dur with n = ∞");
-    t.undefined(Seq([Delay(51), Delay(23), Delay(31), Par.map(), Par.map()]).take().dur,
-        "dur with n = ∞ (indefinite durations)");
-    t.equal(Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(7).dur, 0,
-        "zero dur with n > child count (failure)");
-     t.equal(Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(3).dur, 105,
-        "dur with n < child count");
-     t.undefined(Seq([Delay(51), Delay(23), Par.map(), Delay(19)]).take(3).dur,
-        "dur with n < child count, but unresolved duration");
-    t.equal(Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(0).dur, 0,
-        "dur with n = 0");
+    t.equal(
+        Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take().duration, 141,
+        "dur with n = ∞"
+    );
+    t.undefined(
+        Seq([Delay(51), Delay(23), Delay(31), Par.map(), Par.map()]).take().duration,
+        "dur with n = ∞ (indefinite durations)"
+    );
+    t.equal(
+        Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(7).duration, 0,
+        "zero dur with n > child count (failure)"
+    );
+    t.equal(
+        Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(3).duration, 105,
+        "dur with n < child count"
+    );
+    t.undefined(
+        Seq([Delay(51), Delay(23), Par.map(), Delay(19)]).take(3).duration,
+        "dur with n < child count, but unresolved duration"
+    );
+    t.equal(
+        Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(0).duration, 0,
+        "dur with n = 0"
+    );
 });
 
 test("Instantiation, n = ∞", t => {

--- a/js/tests/seq.html
+++ b/js/tests/seq.html
@@ -16,7 +16,7 @@ test("Seq()", t => {
     const seq = Seq();
     t.equal(seq.show(), "Seq/0", "show");
     t.equal(seq.children, [], "no children");
-    t.equal(seq.dur, 0, "zero duration");
+    t.equal(seq.duration, 0, "zero duration");
 });
 
 test("Seq(xs)", t => {
@@ -27,16 +27,23 @@ test("Seq(xs)", t => {
     t.equal(seq.children, [delay, instant], "children");
     t.equal(delay.parent, seq, "parent (1)");
     t.equal(instant.parent, seq, "parent (2)");
-    t.equal(seq.dur, 17, "duration");
+    t.equal(seq.duration, 17, "duration");
 });
 
 test("Seq duration", t => {
-    t.equal(Seq([Instant(), Instant(), Par(), Seq()]).dur, 0, "non-empty but zero duration");
-    t.equal(Seq([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31).repeat()]).dur, Infinity,
-        "indefinite duration (1)");
-    t.equal(Seq([Instant(), Delay(23).repeat(), Seq.fold(), Par.map(), Delay(31)]).dur, Infinity,
-        "indefinite duration (2)");
-    t.undefined(Seq([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31)]).dur, "unresolved duration");
+    t.equal(Seq([Instant(), Instant(), Par(), Seq()]).duration, 0, "non-empty but zero duration");
+    t.equal(
+        Seq([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31).repeat()]).duration, Infinity,
+        "indefinite duration (1)"
+    );
+    t.equal(
+        Seq([Instant(), Delay(23).repeat(), Seq.fold(), Par.map(), Delay(31)]).duration, Infinity,
+        "indefinite duration (2)"
+    );
+    t.undefined(
+        Seq([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31)]).duration,
+        "unresolved duration"
+    );
 });
 
 test("Seq value", t => {

--- a/js/tests/seq.html
+++ b/js/tests/seq.html
@@ -104,7 +104,7 @@ test("Instantiation; zero duration", t => {
 
 test("Instantiation; child with infinite duration", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(), Instant(), Delay(23).repeat(), Delay(-31)]), 17);
+    const seq = tape.instantiate(Seq([Instant(), Instant(), Delay(23).repeat(), Par().take(1)]), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(seq),
 `* Seq-0 [17, ∞[

--- a/js/tests/seq.html
+++ b/js/tests/seq.html
@@ -17,6 +17,7 @@ test("Seq()", t => {
     t.equal(seq.show(), "Seq/0", "show");
     t.equal(seq.children, [], "no children");
     t.equal(seq.duration, 0, "zero duration");
+    t.equal(seq.failible(), false, "not failible");
 });
 
 test("Seq(xs)", t => {
@@ -28,6 +29,7 @@ test("Seq(xs)", t => {
     t.equal(delay.parent, seq, "parent (1)");
     t.equal(instant.parent, seq, "parent (2)");
     t.equal(seq.duration, 17, "duration");
+    t.equal(seq.failible(), false, "not failible");
 });
 
 test("Seq duration", t => {

--- a/js/tests/seq.html
+++ b/js/tests/seq.html
@@ -17,7 +17,7 @@ test("Seq()", t => {
     t.equal(seq.show(), "Seq/0", "show");
     t.equal(seq.children, [], "no children");
     t.equal(seq.duration, 0, "zero duration");
-    t.equal(seq.failible(), false, "not failible");
+    t.equal(!seq.failible, true, "not failible");
 });
 
 test("Seq(xs)", t => {
@@ -29,7 +29,7 @@ test("Seq(xs)", t => {
     t.equal(delay.parent, seq, "parent (1)");
     t.equal(instant.parent, seq, "parent (2)");
     t.equal(seq.duration, 17, "duration");
-    t.equal(seq.failible(), false, "not failible");
+    t.equal(!seq.failible, true, "not failible");
 });
 
 test("Seq duration", t => {

--- a/js/tests/seq.html
+++ b/js/tests/seq.html
@@ -128,13 +128,18 @@ test("Instantiation; child with unresolved duration", t => {
 
 test("Instantiation; child with unresolved duration; failure once the end is resolved", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([23])), Par.map(Delay), Instant(), Delay(-31)]), 17);
+    const seq = tape.instantiate(Seq([
+        Instant(K([23])), Par.map(Delay),
+        Instant(K("ko")), Par.map(Delay)
+    ]), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(seq),
 `* Seq-0 [17, 40[ (failed)
   * Instant-1 @17 <23>
   * Par/map-2 [17, 40[ <23>
-    * Delay-3 [17, 40[ <23>`, "dump matches");
+    * Delay-3 [17, 40[ <23>
+  * Instant-4 @40 <ko>
+  * Par/map-5 @40 (failed)`, "dump matches");
 });
 
 test("Instantiation failure", t => {


### PR DESCRIPTION
Add a .dur() modifier to Par and Seq. This allows setting an absolute duration for the container, either extending its duration (similar to adding a Delay at the end) or cutting it off (meaning that a final Delay may be shortened, or some other children may be pruned altogether). Dur stacks with take in that take(n) still applies when a duration is set—so that n children must succeed within the set duration.

Also update Delay so that it can only be greater than zero, replacing illegal values with a default Instant(), _i.e._, ignoring them.

This involves a lot of code changes as well as test updates, and will still require more changes to ensure that everything is consistent (_e.g._, the semantics of zero-duration Seq/Par needs to be reviewed).

222 tests!