### PR TITLE
Delay.until(t)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ are pruned.
     finished, then the element fails, otherwise only the first _n_ child elements that have finished are
     returned.
 * `Delay.until(t)` is a dynamic variant of `Delay`. Instead of waiting for a set duration, this waits for
-the time `t` from the beginning of the parent container; _i.e._, if the parent `Seq` or `Par` began at time
-`t0`, then `Delay.until(t)` is the same as `Delay(t - t0)`. If this value is negative, then the Delay has
-no effect.
+the time `t` from the beginning of the parent container (usually a `Seq`, since it behaves like a regular
+delay inside a `Par`). If the delay begins _after_ the time _t_, then it has no effect. This is *not*
+repeatable since the delay can occur at most once.
 * `Par.map(g)` and `Seq.map(g)` map the function _g_ to an input list in parallel or in sequence.
 * `Seq.fold(g, z)` folds over an input list with the function _g_ and an initial value _z_ in sequence.
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ are pruned.
     * Both `take(n)` and `dur(d)` can apply to an element; if by _d_ less than _n_ child elements have
     finished, then the element fails, otherwise only the first _n_ child elements that have finished are
     returned.
+* `Delay.until(t)` is a dynamic variant of `Delay`. Instead of waiting for a set duration, this waits for
+the time `t` from the beginning of the parent container; _i.e._, if the parent `Seq` or `Par` began at time
+`t0`, then `Delay.until(t)` is the same as `Delay(t - t0)`. If this value is negative, then the Delay has
+no effect.
 * `Par.map(g)` and `Seq.map(g)` map the function _g_ to an input list in parallel or in sequence.
 * `Seq.fold(g, z)` folds over an input list with the function _g_ and an initial value _z_ in sequence.
 

--- a/js/lib/score.js
+++ b/js/lib/score.js
@@ -78,6 +78,11 @@ export const Delay = Object.assign(createDelay, {
 
     repeat,
 
+    until(t) {
+        console.assert(this === Delay);
+        return t > 0 ? DelayUntil(t) : Instant();
+    },
+
     // The instance for a delay is an interval, with an occurrence at the end
     // of the interval. The parent duration may cut off the delay, which is
     // reported by the instance.
@@ -102,6 +107,29 @@ export const Delay = Object.assign(createDelay, {
 
     cancelInstance: cancelled,
     pruneInstance: pruned,
+});
+
+const DelayUntil = assign(t => extend(DelayUntil, { t }), {
+    tag: "Delay/until",
+
+    get duration() {},
+
+    show() {
+        return `${this.tag}<${this.t}>`;
+    },
+
+    valueForInstance: I,
+
+    instantiate(instance, t, dur) {
+        const begin = instance.parent ? beginOf(instance.parent) : t;
+        const itemDur = min(this.t - begin, dur);
+        if (itemDur <= 0) {
+            return Object.assign(instance, { t, forward });
+        }
+        instance.begin = t;
+        instance.end = t + itemDur;
+        return extend(instance, { t: instance.end, forward });
+    },
 });
 
 // Par is a container for items that all begin at the same time, ending when

--- a/js/lib/score.js
+++ b/js/lib/score.js
@@ -122,14 +122,18 @@ const DelayUntil = assign(t => extend(DelayUntil, { t }), {
         return `${this.tag}<${this.t}>`;
     },
 
+    // Instantiate an interval, unless the time for the delay has already
+    // passed, in which case this is just an instant.
     instantiate(instance, t, dur, parent) {
         const maxEnd = t + dur;
         const itemEnd = (beginOf(parent) ?? t) + this.t;
         const end = min(itemEnd, maxEnd);
         if (itemEnd > maxEnd) {
+            // There is a delay but it is cutoff from the desired duration.
             instance.cutoff = true;
         }
         if (end <= t) {
+            // The time has already passed.
             return Object.assign(instance, { t, forward });
         }
         instance.begin = t;

--- a/js/lib/score.js
+++ b/js/lib/score.js
@@ -78,6 +78,7 @@ export const Delay = Object.assign(createDelay, {
 
     repeat,
 
+    // Create a new DelayUntil item.
     until(t) {
         console.assert(this === Delay);
         return t > 0 ? DelayUntil(t) : Instant();
@@ -109,6 +110,9 @@ export const Delay = Object.assign(createDelay, {
     pruneInstance: pruned,
 });
 
+// Delay until time t relative to the begin of the parent. If the delay begins
+// after the requested time, this acts just like an Instant. Not failible, and
+// *not* repeatable (since the delay can apply at most once).
 const DelayUntil = assign(t => extend(DelayUntil, { t }), {
     tag: "Delay/until",
 

--- a/js/lib/tape.js
+++ b/js/lib/tape.js
@@ -18,7 +18,7 @@ export const Tape = Object.assign(() => create().call(Tape), {
     // Instantiate an item beginning at time t with a maximum duration dur, and
     // commit its occurrences to this tape. Return an instance on success or
     // nothing on failure.
-    instantiate(item, t, dur = Infinity) {
+    instantiate(item, t, dur, parent) {
         // An instance points to this tape (so that its children can be
         // instantiated in the same tape), its item, and is given an ID for
         // debugging purposes.
@@ -26,9 +26,13 @@ export const Tape = Object.assign(() => create().call(Tape), {
         try {
             // Item-specific instantiation may return an occurrence to be added
             // to the tape.
-            const occurrence = item.instantiate(instance, t, dur);
+            const occurrence = item.instantiate(instance, t, dur ?? Infinity, parent);
             if (occurrence) {
                 this.instances.set(instance, this.addOccurrence(occurrence));
+            }
+            // Set the parent before returning the instance.
+            if (parent) {
+                instance.parent = parent;
             }
             return instance;
         } catch (_) {

--- a/js/tests/delay-until.html
+++ b/js/tests/delay-until.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Delay.until</title>
+        <meta charset="utf8">
+        <link rel="stylesheet" href="test.css">
+        <script type="module">
+
+import { test } from "./test.js";
+import { K } from "../lib/util.js";
+import { Instant, Delay, Par, Seq, dump } from "../lib/score.js";
+import { Tape } from "../lib/tape.js";
+import { Deck } from "../lib/deck.js";
+
+test("Delay.until(t)", t => {
+    const delay = Delay.until(23);
+    t.equal(delay.show(), "Delay/until<23>", "show");
+    t.undefined(delay.duration, "unresolved duration");
+    t.equal(!delay.failible, true, "not failible");
+});
+
+test("Instantiation (delay applies)", t => {
+    const tape = Tape();
+    const delay = tape.instantiate(Delay.until(23), 17);
+    Deck({ tape }).now = 24;
+    t.equal(dump(delay), "* Delay/until-0 [17, 23[ <undefined>", "dump matches");
+});
+
+test("Instantiation (delay does not apply)", t => {
+    const tape = Tape();
+    const delay = tape.instantiate(Delay.until(23), 31);
+    Deck({ tape }).now = 32;
+    t.equal(dump(delay), "* Delay/until-0 @31 <undefined>", "dump matches");
+});
+
+test("Instantiation (inside a container; applies)", t => {
+    t.equal(dump(Tape().instantiate(Seq([Delay(23), Delay.until(31), Delay(19)]), 17)),
+`* Seq-0 [17, 67[
+  * Delay-1 [17, 40[
+  * Delay/until-2 [40, 48[
+  * Delay-3 [48, 67[`, "dump matches");
+});
+
+        </script>
+    </head>
+    <body>
+        <p><a href="index.html">Back</a></p>
+    </body>
+</html>

--- a/js/tests/delay-until.html
+++ b/js/tests/delay-until.html
@@ -56,6 +56,19 @@ test("Instantiation (delay does not apply)", t => {
   * Delay-4 [40, 59[ <ok>`, "dump matches");
 });
 
+test("Instantiation after an unresolved duration", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([Instant(K([23])), Par.map(Delay), Delay.until(31), Delay(19)]), 17);
+    Deck({ tape }).now = 68;
+    t.equal(dump(seq),
+`* Seq-0 [17, 67[ <23>
+  * Instant-1 @17 <23>
+  * Par/map-2 [17, 40[ <23>
+    * Delay-3 [17, 40[ <23>
+  * Delay/until-4 [40, 48[ <23>
+  * Delay-5 [48, 67[ <23>`, "dump matches");
+});
+
 test("Cancel delay", t => {
     const tape = Tape();
     const choice = tape.instantiate(Par([

--- a/js/tests/delay-until.html
+++ b/js/tests/delay-until.html
@@ -21,24 +21,62 @@ test("Delay.until(t)", t => {
 
 test("Instantiation (delay applies)", t => {
     const tape = Tape();
-    const delay = tape.instantiate(Delay.until(23), 17);
-    Deck({ tape }).now = 24;
-    t.equal(dump(delay), "* Delay/until-0 [17, 23[ <undefined>", "dump matches");
+    const seq = tape.instantiate(Seq([Instant(K("ok")), Delay(23), Delay.until(31), Delay(19)]), 17);
+    Deck({ tape }).now = 68;
+    t.equal(dump(seq),
+`* Seq-0 [17, 67[ <ok>
+  * Instant-1 @17 <ok>
+  * Delay-2 [17, 40[ <ok>
+  * Delay/until-3 [40, 48[ <ok>
+  * Delay-4 [48, 67[ <ok>`, "dump matches");
+});
+
+test("Instantiation (delay applies but is cutoff)", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(
+        Seq([Instant(K("ok")), Delay(23), Delay.until(31), Delay(19)]).dur(29), 17
+    );
+    Deck({ tape }).now = 47;
+    t.equal(dump(seq),
+`* Seq-0 [17, 46[ <ok>
+  * Instant-1 @17 <ok>
+  * Delay-2 [17, 40[ <ok>
+  * Delay/until-3 [40, 46[ <ok>`, "dump matches");
 });
 
 test("Instantiation (delay does not apply)", t => {
     const tape = Tape();
-    const delay = tape.instantiate(Delay.until(23), 31);
-    Deck({ tape }).now = 32;
-    t.equal(dump(delay), "* Delay/until-0 @31 <undefined>", "dump matches");
+    const seq = tape.instantiate(Seq([Instant(K("ok")), Delay(23), Delay.until(19), Delay(19)]), 17);
+    Deck({ tape }).now = 60;
+    t.equal(dump(seq),
+`* Seq-0 [17, 59[ <ok>
+  * Instant-1 @17 <ok>
+  * Delay-2 [17, 40[ <ok>
+  * Delay/until-3 @40 <ok>
+  * Delay-4 [40, 59[ <ok>`, "dump matches");
 });
 
-test("Instantiation (inside a container; applies)", t => {
-    t.equal(dump(Tape().instantiate(Seq([Delay(23), Delay.until(31), Delay(19)]), 17)),
-`* Seq-0 [17, 67[
-  * Delay-1 [17, 40[
-  * Delay/until-2 [40, 48[
-  * Delay-3 [48, 67[`, "dump matches");
+test("Cancel delay", t => {
+    const tape = Tape();
+    const choice = tape.instantiate(Par([
+        Instant(K("ok")), Delay.until(23)
+    ]).take(1), 17);
+    Deck({ tape }).now = 18;
+    t.equal(dump(choice),
+`* Par-0 @17 <ok>
+  * Delay/until-1 @17 (cancelled)
+  * Instant-2 @17 <ok>`, "dump matches");
+    t.equal(tape.show(), "Tape<17>", "no occurrence on tape");
+});
+
+test("Prune delay", t => {
+    const tape = Tape();
+    t.undefined(tape.instantiate(Seq([
+        Delay.until(1),
+        Par().take(1)
+    ]), 17), "instantiation failed");
+    Deck({ tape }).now = 18;
+    t.equal(tape.occurrences, [], "no occurrence on tape");
 });
 
         </script>

--- a/js/tests/delay-until.html
+++ b/js/tests/delay-until.html
@@ -69,6 +69,18 @@ test("Instantiation after an unresolved duration", t => {
   * Delay-5 [48, 67[ <23>`, "dump matches");
 });
 
+test("Instantiation inside Par (same as regular delay)", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([Instant(K("ok")), Par([Delay(23), Delay.until(31)])]), 17);
+    Deck({ tape }).now = 49;
+    t.equal(dump(seq),
+`* Seq-0 [17, 48[ <ok,ok>
+  * Instant-1 @17 <ok>
+  * Par-2 [17, 48[ <ok,ok>
+    * Delay-3 [17, 40[ <ok>
+    * Delay/until-4 [17, 48[ <ok>`, "dump matches");
+});
+
 test("Cancel delay", t => {
     const tape = Tape();
     const choice = tape.instantiate(Par([

--- a/js/tests/delay.html
+++ b/js/tests/delay.html
@@ -102,13 +102,19 @@ test("Delay value", t => {
 test("Cancel delay", t => {
     const tape = Tape();
     const choice = tape.instantiate(Par([
-        Instant(K("ok")), Delay(23)
+        Seq([Instant(K([19])), Par.map(Delay)]),
+        Seq([Delay(23), Instant(K("ko"))]),
     ]).take(1), 17);
-    Deck({ tape }).now = 18;
+    Deck({ tape }).now = 37;
     t.equal(dump(choice),
-`* Par-0 @17 <ok>
-  * Instant-1 @17 <ok>`, "dump matches");
-    t.equal(tape.show(), "Tape<17>", "no occurrence on tape");
+`* Par-0 [17, 36[ <19>
+  * Seq-1 [17, 36[ <19>
+    * Instant-2 @17 <19>
+    * Par/map-3 [17, 36[ <19>
+      * Delay-7 [17, 36[ <19>
+  * Seq-4 [17, 36[ (cancelled)
+    * Delay-5 [17, 36[ (cancelled)`, "dump matches");
+    t.equal(tape.show(), "Tape<17,17,36>", "occurrences were deleted");
 });
 
 test("Prune delay", t => {

--- a/js/tests/index.html
+++ b/js/tests/index.html
@@ -17,6 +17,7 @@
             <li>score.html</li>
             <li>instant.html</li>
             <li>delay.html</li>
+            <li>delay-until.html</li>
             <li>par.html</li>
             <li>par-take.html</li>
             <li>par-dur.html</li>


### PR DESCRIPTION
Add a new modifier to Delay for a dynamic delay _until_ a given time from the parent begin time, and having no effect if the time has passed. Instantiating this item requires to pass the parent item when instantiating children, which is a very small change in the end.