### PR TITLE
Instantiating the score

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,11 @@ occurrences and play them back at different speeds.
 * A `Score` is a kind of `Par` element to which new elements can be added with a time offset. It never
 finishes, so that new elements can be added at any time. This also means that a `Score` can be nested
 in another `Score`, which will be explored in the future.
+    * Items are added to the score with `Score.add(item)`; the begin time of the item is the time at
+    which it was added.
+    * When an item ends, the tape to which the score was instantiated sends an `end` notification with
+    the value of the instance of the item that ended.
+    * When an item fails, the tape to which the score was instantiated sends a `fail` notification.
 * A `Tape` is used to `instantiate` elements from a score; because of repetition, the same element may have more than one occurrences at different times. An instance can be an instant at a given time, or an interval
 with a begin and end time.
 * A `Deck` is used to record and play a tape. It is where the conversion between physical and logical time

--- a/js/lib/deck.js
+++ b/js/lib/deck.js
@@ -8,6 +8,9 @@ export const Deck = assign(properties => create(properties).call(Deck), {
         this.speed ??= 1;
         this.lastUpdateTime = 0;
         this.intervals = [];
+        if (this.tape) {
+            this.tape.deck = this;
+        }
     },
 
     // Get the current time.

--- a/js/lib/score.js
+++ b/js/lib/score.js
@@ -34,11 +34,9 @@ export const Score = Object.assign(properties => create(properties).call(Score),
         console.assert(!Object.hasOwn(item, parent));
         this.children.push(item);
         item.parent = this;
-        if (this.tape.deck) {
-            this.instance.children.push(this.tape.instantiate(
-                item, this.tape.deck.now, this.instance.end - this.instance.begin, this.instance
-            ));
-        }
+        this.instance.children.push(this.tape.instantiate(
+            item, this.tape.deck?.now ?? 0, this.instance.end - this.instance.begin, this.instance
+        ));
         return item;
     },
 

--- a/js/lib/score.js
+++ b/js/lib/score.js
@@ -1,4 +1,5 @@
 import { assign, create, extend, I, isNumber, nop, partition, push, remove } from "./util.js";
+import { notify } from "./events.js";
 import { Tape } from "./tape.js";
 
 const Fail = Error("Instantiation failure");
@@ -40,10 +41,27 @@ export const Score = Object.assign(properties => create(properties).call(Score),
         return item;
     },
 
+    // Send a notification with the value of the child instance when it ends.
+    childInstanceDidEnd(childInstance) {
+        console.assert(childInstance.parent === this.instance);
+        notify(this.tape, "end", {
+            t: endOf(childItem),
+            item: childInstance.item,
+            value: childInstance.value,
+        });
+    },
+
+    // Send a notification for a child that fails.
+    childInstanceDidFail(childInstance) {
+        console.assert(childInstance.parent === this.instance);
+        notify(this.tape, "fail", {
+            t: endOf(childItem),
+            item: childInstance.item
+        });
+    },
+
     inputForChildInstance: nop,
-    childInstanceDidEnd: nop,
     childInstanceEndWasResolved: nop,
-    childInstanceDidFail: nop,
 });
 
 // Instant(f) evaluates f instantly. f should not have any side effect and

--- a/js/lib/score.js
+++ b/js/lib/score.js
@@ -31,12 +31,12 @@ export const Score = Object.assign(properties => create(properties).call(Score),
     },
 
     // Add an item to the score and instantiate it. The item is returned.
-    add(item) {
+    add(item, at) {
         console.assert(!Object.hasOwn(item, parent));
         this.children.push(item);
         item.parent = this;
         this.instance.children.push(this.tape.instantiate(
-            item, this.tape.deck?.now ?? 0, this.instance.end - this.instance.begin, this.instance
+            item, at ?? this.tape.deck?.now ?? 0, this.instance.end - this.instance.begin, this.instance
         ));
         return item;
     },
@@ -45,7 +45,7 @@ export const Score = Object.assign(properties => create(properties).call(Score),
     childInstanceDidEnd(childInstance) {
         console.assert(childInstance.parent === this.instance);
         notify(this.tape, "end", {
-            t: endOf(childItem),
+            t: endOf(childInstance),
             item: childInstance.item,
             value: childInstance.value,
         });
@@ -55,7 +55,7 @@ export const Score = Object.assign(properties => create(properties).call(Score),
     childInstanceDidFail(childInstance) {
         console.assert(childInstance.parent === this.instance);
         notify(this.tape, "fail", {
-            t: endOf(childItem),
+            t: endOf(childInstance),
             item: childInstance.item
         });
     },

--- a/js/tests/deck.html
+++ b/js/tests/deck.html
@@ -109,11 +109,13 @@ test("running updates (end with success)", async t => {
     const seq = score.add(Seq([Delay(100), Instant(K("ok"))]));
     const phi = performance.now();
     deck.start();
-    const { item, value } = await notification(tape, "end");
+    const event = await notification(tape, "end");
     const end = performance.now() - phi;
-    t.atLeast(end, 100, `Item ended at φ = ${end}`);
-    t.equal(item, seq, "Seq ended");
-    t.equal(value, "ok", "with the correct value");
+    t.equal(event.t, 100, "Item ended at the expected time");
+    t.atLeast(end, event.t, ` φ = ${end} ≥ ${event.t}`);
+    t.equal(event.item, seq, "Seq ended");
+    t.equal(event.value, "ok", "with the correct value");
+    deck.stop();
 });
 
 test("running updates (failure)", async t => {
@@ -129,8 +131,25 @@ test("running updates (failure)", async t => {
     t.equal(item, seq, "Seq failed");
 });
 
-
-
+test("running updates (after the tape has started)", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    const phi = performance.now();
+    const seq = Seq([Delay(100), Instant(K("ok"))]);
+    deck.start();
+    tape.addOccurrence({
+        t: 50,
+        forward: async at => { score.add(seq, at); }
+    });
+    const event = await notification(tape, "end");
+    const end = performance.now() - phi;
+    t.equal(event.t, 150, "Item ended at the expected time");
+    t.atLeast(end, event.t, ` φ = ${end} ≥ ${event.t}`);
+    t.equal(event.item, seq, "Seq ended");
+    t.equal(event.value, "ok", "with the correct value");
+    deck.stop();
+});
 
         </script>
     </head>

--- a/js/tests/deck.html
+++ b/js/tests/deck.html
@@ -7,10 +7,11 @@
         <script type="module">
 
 import { test } from "./test.js";
-import { timeout } from "../lib/util.js";
+import { K, timeout } from "../lib/util.js";
 import { on, notification, notifications } from "../lib/events.js";
 import { Deck } from "../lib/deck.js";
 import { Tape } from "../lib/tape.js";
+import { Delay, Instant, Par, Score, Seq } from "../lib/score.js";
 
 test("Deck({ now?, speed?, tape? })", t => {
     const deck = Deck();
@@ -100,6 +101,36 @@ test("now (not playing)", t => {
     deck.now = 27;
     t.equal(updates, [[0, 23, true], [23, 37, true], [37, 27, false]], "now (backward)");
 });
+
+test("running updates (end with success)", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    const seq = score.add(Seq([Delay(100), Instant(K("ok"))]));
+    const phi = performance.now();
+    deck.start();
+    const { item, value } = await notification(tape, "end");
+    const end = performance.now() - phi;
+    t.atLeast(end, 100, `Item ended at φ = ${end}`);
+    t.equal(item, seq, "Seq ended");
+    t.equal(value, "ok", "with the correct value");
+});
+
+test("running updates (failure)", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    const seq = score.add(Seq([Delay(100), Instant(), Par.map(Delay)]));
+    const phi = performance.now();
+    deck.start();
+    const { item } = await notification(tape, "fail");
+    const end = performance.now() - phi;
+    t.atLeast(end, 100, `Item ended at φ = ${end}`);
+    t.equal(item, seq, "Seq failed");
+});
+
+
+
 
         </script>
     </head>

--- a/js/tests/deck.html
+++ b/js/tests/deck.html
@@ -10,13 +10,17 @@ import { test } from "./test.js";
 import { timeout } from "../lib/util.js";
 import { on, notification, notifications } from "../lib/events.js";
 import { Deck } from "../lib/deck.js";
+import { Tape } from "../lib/tape.js";
 
-test("Deck({ now?, speed? })", t => {
+test("Deck({ now?, speed?, tape? })", t => {
     const deck = Deck();
     t.equal(deck.speed, 1, "default speed");
     t.equal(deck.now, 0, "start at 0");
     t.equal(deck.playing, false, "not playing by default");
-    const d = Deck({ speed: -1, now: 23, intervals: 17, foo: "bar" });
+    const tape = Tape();
+    const d = Deck({ tape, speed: -1, now: 23, intervals: 17, foo: "bar" });
+    t.equal(d.tape, tape, "tape");
+    t.equal(tape.deck, d, "tape points back to deck");
     t.equal(d.speed, -1, "custom speed");
     t.equal(d.now, 23, "now is later");
     t.equal(d.foo, "bar", "custom property");

--- a/js/tests/score.html
+++ b/js/tests/score.html
@@ -7,26 +7,31 @@
         <script type="module">
 
 import { test } from "./test.js";
-import { Score, Instant, Delay, Seq, Par } from "../lib/score.js";
+import { Deck } from "../lib/deck.js";
+import { Tape } from "../lib/tape.js";
+import { Score, Instant, Delay, dump } from "../lib/score.js";
 
 test("Score()", t => {
     const score = Score();
     t.equal(score.show(), "Score/0", "show");
     t.equal(score.children, [], "no children");
+    t.equal(score.tape.show(), "Tape<>", "default tape");
+    t.equal(dump(score.instance), "* Score-0 [0, ∞[", "dump matches");
 });
 
-test("Score(xs)", t => {
-    const delay = Delay(23);
-    const instant = Instant();
-    const score = Score([delay, instant]);
-    t.equal(score.show(), "Score/2", "show");
-    t.equal(score.children, [delay, instant], "children");
-    t.equal(delay.parent, score, "parent (1)");
-    t.equal(instant.parent, score, "parent (2)");
+test("Score({ tape })", t => {
+    const tape = Tape();
+    const score = Score({ tape });
+    t.equal(score.show(), "Score/0", "show");
+    t.equal(score.children, [], "no children");
+    t.equal(score.tape, tape, "tape");
+    t.equal(dump(score.instance), "* Score-0 [0, ∞[", "dump matches");
 });
 
 test("Score.add(child)", t => {
-    const score = Score();
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
     const delay = score.add(Delay(23));
     const instant = score.add(Instant());
     t.equal(instant.show(), "Instant", "show added child");
@@ -34,6 +39,10 @@ test("Score.add(child)", t => {
     t.equal(score.children, [delay, instant], "children after add");
     t.equal(delay.parent, score, "parent (1)");
     t.equal(instant.parent, score, "parent (2)");
+    t.equal(dump(score.instance),
+`* Score-0 [0, ∞[
+  * Delay-1 [0, 23[
+  * Instant-2 @0`, "dump matches");
 });
 
         </script>

--- a/js/tests/score.html
+++ b/js/tests/score.html
@@ -58,6 +58,19 @@ test("Score.add(child), with deck", t => {
   * Delay-2 [17, 40[ <undefined>`, "dump matches");
 });
 
+test("Score.add(child, at)", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    const instant = score.add(Instant(K("ok")));
+    const delay = score.add(Delay(23), 17);
+    deck.now = 41;
+    t.equal(dump(score.instance),
+`* Score-0 [0, ∞[
+  * Instant-1 @0 <ok>
+  * Delay-2 [17, 40[ <undefined>`, "dump matches");
+});
+
         </script>
     </head>
     <body>

--- a/js/tests/score.html
+++ b/js/tests/score.html
@@ -58,7 +58,6 @@ test("Score.add(child), with deck", t => {
   * Delay-2 [17, 40[ <undefined>`, "dump matches");
 });
 
-
         </script>
     </head>
     <body>

--- a/js/tests/score.html
+++ b/js/tests/score.html
@@ -7,6 +7,7 @@
         <script type="module">
 
 import { test } from "./test.js";
+import { K } from "../lib/util.js";
 import { Deck } from "../lib/deck.js";
 import { Tape } from "../lib/tape.js";
 import { Score, Instant, Delay, dump } from "../lib/score.js";
@@ -28,10 +29,8 @@ test("Score({ tape })", t => {
     t.equal(dump(score.instance), "* Score-0 [0, ∞[", "dump matches");
 });
 
-test("Score.add(child)", t => {
-    const tape = Tape();
-    const deck = Deck({ tape });
-    const score = Score({ tape });
+test("Score.add(child), no deck", t => {
+    const score = Score();
     const delay = score.add(Delay(23));
     const instant = score.add(Instant());
     t.equal(instant.show(), "Instant", "show added child");
@@ -42,8 +41,23 @@ test("Score.add(child)", t => {
     t.equal(dump(score.instance),
 `* Score-0 [0, ∞[
   * Delay-1 [0, 23[
-  * Instant-2 @0`, "dump matches");
+  * Instant-2 @0`, "children are instantiated");
 });
+
+test("Score.add(child), with deck", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    const instant = score.add(Instant(K("ok")));
+    deck.now = 17;
+    const delay = score.add(Delay(23));
+    deck.now = 41;
+    t.equal(dump(score.instance),
+`* Score-0 [0, ∞[
+  * Instant-1 @0 <ok>
+  * Delay-2 [17, 40[ <undefined>`, "dump matches");
+});
+
 
         </script>
     </head>


### PR DESCRIPTION
The score itself gets instantiated, as well as its children at the time at which they are added. The addition time can be set with the extra parameter `at`, otherwise the current deck time is used (or zero if no deck is set yet). In order to keep track of the current time, both deck and score point to the tape used for instantiation.

Async tests are added to test this feature, making use of two events from the tape, `end` and `fail`, occurring when a child instance of the score instance finishes with a value or with a failure.