### PR TITLE
Do not reorder Par children

### DIFF
--- a/lib/score.js
+++ b/lib/score.js
@@ -92,7 +92,11 @@ export const Instant = assign(f => f ? extend(Instant, { valueForInstance: f }) 
 });
 
 // Effect is similar to Instant but has side effects.
-export const Effect = assign(f => extend(Instant, { valueForInstance: f, tag: "Effect" }));
+export const Effect = assign(f => extend(Instant, {
+    valueForInstance: f,
+    tag: "Effect",
+    hasEffect: true
+}));
 
 // Create a new delay (see below) with duration as a read-only property.
 // Treat any illegal value as 0, which defaults to an Instant().
@@ -244,17 +248,16 @@ export const Par = assign(children => create().call(Par, { children: children ??
             return Duration.get(this);
         }
         const children = itemsByDuration(this.children, Capacity.get(this));
-        const firstDuration = children[0]?.[0];
-        const lastDuration = children.at(-1)?.[0];
-        return children.length === 0 ? 0 :
-            // If the last child has an indefinite duration then the par has
-            // an indefinite duration. Otherwise the duration may be unresolved,
-            // which depends on whether the first item has an unresolved
-            // duration or not; if the first child has a resolved duration, then
-            // the last one is the longest, otherwise the duration is
-            // unresolved.
-            lastDuration === Infinity ? Infinity :
-            isNaN(firstDuration) ? firstDuration : lastDuration;
+        let duration = 0;
+        for (const [d] of children) {
+            if (d === Infinity) {
+                return Infinity;
+            }
+            if (isNaN(d) || duration < d) {
+                duration = d;
+            }
+        }
+        return duration;
     },
 
     // Fail if not enough children can be instantiated.
@@ -1198,20 +1201,29 @@ const min = (x, y) => isNumber(y) ? Math.min(x, y) : x;
 // is considered higher than any definite number (for unresolved durations).
 const max = (x, y) => isNumber(y) ? Math.max(x, y) : x === Infinity ? x : y;
 
-// Sort a list of items by their duration, optionally capping the list at a
-// maximum of n items. Failible items (at instantiation) are filtered out first.
-// Items with an unresolved duration or with an effect do not count toward the
-// duration. Return a list of [duration, item] pairs sorted by duration, with
-// items with unresolved duration coming before any other.
+// Select at least n items from the list according to their duration, keeping
+// them in their original order, and return [duration, item] pairs. Failible
+// items are sorted out. Note that more than n items may be returned since
+// items with unresolved duration and items with effect still begin; and zero
+// items are returned when there is an insufficient number of items to fulfill
+// the constraint.
 function itemsByDuration(items, n) {
     if (n === 0) {
         return [];
     }
     const itemsWithDuration = items.filter(item => !item.failible).map(item => [item.duration, item]);
-    if (isFinite(n) && n > itemsWithDuration.length) {
+    const m = itemsWithDuration.length;
+    if (!isFinite(n) || n === m) {
+        return itemsWithDuration;
+    }
+    if (n > m) {
         return [];
     }
-    const [resolved, unresolved] = partition(itemsWithDuration, ([duration]) => duration >= 0);
+    const [resolved, unresolved] = partition(itemsWithDuration,
+        ([duration, item]) => duration >= 0 && !item.hasEffect
+    );
     resolved.sort(([a], [b]) => a - b);
-    return unresolved.concat(n < itemsWithDuration.length ? resolved.slice(0, n) : resolved);
+    const selectedItems = new Set(unresolved.concat(resolved.slice(0, n)));
+    return selectedItems.length === m ?
+        itemsWithDuration : itemsWithDuration.filter(item => selectedItems.has(item));
 }

--- a/lib/score.js
+++ b/lib/score.js
@@ -95,7 +95,10 @@ export const Instant = assign(f => f ? extend(Instant, { valueForInstance: f }) 
 export const Effect = assign(f => extend(Instant, {
     valueForInstance: f,
     tag: "Effect",
-    hasEffect: true
+    hasEffect: true,
+
+    // Effect cannot be cancelled (but can be pruned of course).
+    cancelInstance: nop,
 }));
 
 // Create a new delay (see below) with duration as a read-only property.
@@ -361,6 +364,10 @@ export const Par = assign(children => create().call(Par, { children: children ??
     childInstanceDidEnd(childInstance, t) {
         const instance = childInstance.parent;
         console.assert(instance.item === this);
+        if (!instance.finished) {
+            // The instance has already finished (this is a lingering effect).
+            return;
+        }
         instance.finished.push(childInstance);
         if (instance.finished.length === instance.capacity) {
             for (const child of instance.children) {

--- a/tests/delay-until.html
+++ b/tests/delay-until.html
@@ -89,8 +89,8 @@ test("Cancel delay", t => {
     Deck({ tape }).now = 18;
     t.equal(dump(choice),
 `* Par-0 @17 <ok>
-  * Delay/until-1 @17 (cancelled)
-  * Instant-2 @17 <ok>`, "dump matches");
+  * Instant-1 @17 <ok>
+  * Delay/until-2 @17 (cancelled)`, "dump matches");
     t.equal(tape.show(), "Tape<17>", "no occurrence on tape");
 });
 

--- a/tests/instant.html
+++ b/tests/instant.html
@@ -18,6 +18,7 @@ test("Instant()", t => {
     t.equal(instant.valueForInstance(17), 17, "valueForInstance defaults to I");
     t.equal(instant.duration, 0, "zero duration");
     t.equal(!instant.failible, true, "infailible (at instantiation)");
+    t.equal(!instant.hasEffect, true, "has no effect");
 });
 
 test("Instant(f)", t => {
@@ -96,6 +97,7 @@ test("Effect(f)", t => {
     t.equal(effect.show(), "Effect", "show");
     t.equal(effect.duration, 0, "zero duration");
     t.equal(!effect.failible, true, "infailible (at instantiation)");
+    t.equal(effect.hasEffect, true, "has effect");
 
     const tape = Tape();
     const instance = tape.instantiate(effect, 17);

--- a/tests/par-dur.html
+++ b/tests/par-dur.html
@@ -156,13 +156,13 @@ test("Par.take(n).dur(d), cutting off the duration", t => {
     Deck({ tape }).now = 38;
     t.equal(dump(par),
 `* Par-0 [17, 37[ <B,D,A>
-  * Instant-1 @17 <B>
-  * Seq-2 [17, 36[ <D>
-    * Instant-3 @17 <D>
-    * Delay-4 [17, 36[ <D>
-  * Seq-5 [17, 37[ <A>
-    * Instant-6 @17 <A>
-    * Delay-7 [17, 37[ <A>`, "dump matches");
+  * Seq-1 [17, 37[ <A>
+    * Instant-2 @17 <A>
+    * Delay-3 [17, 37[ <A>
+  * Instant-4 @17 <B>
+  * Seq-5 [17, 36[ <D>
+    * Instant-6 @17 <D>
+    * Delay-7 [17, 36[ <D>`, "dump matches");
 });
 
 test("Par.take(n).dur(d), extending the duration", t => {
@@ -176,13 +176,13 @@ test("Par.take(n).dur(d), extending the duration", t => {
     Deck({ tape }).now = 49;
     t.equal(dump(par),
 `* Par-0 [17, 48[ <B,D,A>
-  * Instant-1 @17 <B>
-  * Seq-2 [17, 36[ <D>
-    * Instant-3 @17 <D>
-    * Delay-4 [17, 36[ <D>
-  * Seq-5 [17, 40[ <A>
-    * Instant-6 @17 <A>
-    * Delay-7 [17, 40[ <A>`, "dump matches");
+  * Seq-1 [17, 40[ <A>
+    * Instant-2 @17 <A>
+    * Delay-3 [17, 40[ <A>
+  * Instant-4 @17 <B>
+  * Seq-5 [17, 36[ <D>
+    * Instant-6 @17 <D>
+    * Delay-7 [17, 36[ <D>`, "dump matches");
 });
 
         </script>

--- a/tests/par-map.html
+++ b/tests/par-map.html
@@ -181,8 +181,8 @@ test("Par.map(g).take(n).dur(d); extending duration", t => {
   * Instant-1 @17 <19,37,31,19,51>
   * Par/map-2 [17, 88[ <19,19,31>
     * Delay-3 [17, 36[ <19>
-    * Delay-4 [17, 36[ <19>
-    * Delay-5 [17, 48[ <31>`, "dump matches");
+    * Delay-4 [17, 48[ <31>
+    * Delay-5 [17, 36[ <19>`, "dump matches");
 });
 
 test("Par.map(g) failure", t => {

--- a/tests/par-take.html
+++ b/tests/par-take.html
@@ -86,10 +86,10 @@ test("Instantiation; unresolved durations result in more than n children", t => 
     ]).take(3), 17);
     t.equal(dump(par),
 `* Par-0 [17, ∞[
-  * Par/map-1 [17, ∞[
-  * Delay-2 [17, 36[
-  * Delay-3 [17, 40[
-  * Delay-4 [17, 48[`, "dump matches");
+  * Delay-1 [17, 40[
+  * Delay-2 [17, 48[
+  * Par/map-3 [17, ∞[
+  * Delay-4 [17, 36[`, "dump matches");
 });
 
 test("Instantiation failure in child after nth", t => {
@@ -128,9 +128,9 @@ test("Allowing failure during instantiation", t => {
     ]).take(3), 17);
     t.equal(dump(par),
 `* Par-0 [17, 48[
-  * Delay-1 [17, 36[
-  * Delay-2 [17, 40[
-  * Delay-3 [17, 48[`, "dump matches");
+  * Delay-1 [17, 40[
+  * Delay-2 [17, 48[
+  * Delay-3 [17, 36[`, "dump matches");
 });
 
         </script>

--- a/tests/par-take.html
+++ b/tests/par-take.html
@@ -8,7 +8,7 @@
 
 import { test } from "./test.js";
 import { K } from "../lib/util.js";
-import { Instant, Delay, Par, Seq, dump } from "../lib/score.js";
+import { Instant, Effect, Delay, Par, Seq, dump } from "../lib/score.js";
 import { Tape } from "../lib/tape.js";
 import { Deck } from "../lib/deck.js";
 
@@ -131,6 +131,22 @@ test("Allowing failure during instantiation", t => {
   * Delay-1 [17, 40[
   * Delay-2 [17, 48[
   * Delay-3 [17, 36[`, "dump matches");
+});
+
+test("Effects", t => {
+    const tape = Tape();
+    const par = tape.instantiate(Par([
+        Instant(K("ok")),
+        Effect(() => {
+            console.warn("Some effect");
+            return "ko";
+        })
+    ]).take(1), 17);
+    t.warns(() => { Deck({ tape }).now = 18; }, "effect occurred");
+    t.equal(dump(par),
+`* Par-0 @17 <ok>
+  * Instant-1 @17 <ok>
+  * Effect-2 @17 <ko>`, "dump matches");
 });
 
         </script>


### PR DESCRIPTION
Do not reorder children of a Par that is constrained by take. Additionally, make sure that Effects still run at the end of a Par.