### PR TITLE
DOMEvent

### DIFF
--- a/lib/deck.js
+++ b/lib/deck.js
@@ -1,4 +1,4 @@
-import { assign, create, isNumber } from "./util.js";
+import { assign, create, get, isNumber } from "./util.js";
 import { notify } from "./events.js";
 
 // The deck records to and plays a tape.
@@ -175,6 +175,31 @@ export const Deck = assign(properties => create(properties).call(Deck), {
                 instance.parent?.item.childInstanceDidEnd(instance, t);
                 instances.delete(instance);
             }
+        }
+    },
+
+    // Add an event target for an instance, using this as the event handler.
+    // If this is the first instance for the target/event pair, add an event
+    // listener.
+    addEventTarget(instance) {
+        const item = instance.item;
+        const targets = get(this.eventTargets, item.target, () => ({}));
+        if (!Object.hasOwn(targets, item.event)) {
+            targets[item.event] = new Set();
+            item.target.addEventListener(item.event, this);
+        }
+        targets[item.event].add(instance);
+    },
+
+    // Remove the instance from the event handler, possibly removing the event
+    // listener itself.
+    removeEventTarget(instance) {
+        const item = instance.item;
+        const instances = this.eventTargets.get(item.target)[item.event];
+        instances.delete(instance);
+        if (instances.size === 0) {
+            item.target.removeEventListener(item.event, this);
+            delete this.eventTargets.get(item.target)[item.event];
         }
     },
 

--- a/lib/deck.js
+++ b/lib/deck.js
@@ -8,6 +8,10 @@ export const Deck = assign(properties => create(properties).call(Deck), {
         this.speed ??= 1;
         this.lastUpdateTime = 0;
         this.intervals = [];
+        // This is a two-level map: keys are target objects, and values are
+        // objects that have vent names as keys, and sets of instances as
+        // values.
+        this.eventTargets = new Map();
         if (this.tape) {
             this.tape.deck = this;
         }
@@ -151,5 +155,27 @@ export const Deck = assign(properties => create(properties).call(Deck), {
                 occurrence.forward(occurrence.t, interval);
             }
         }
-    }
+    },
+
+    // Generic event handler: for all instances that have begun before the event
+    // occurred in the targets maps that have the event name as key, set the
+    // end time and value of the instance.
+    handleEvent(event) {
+        const targets = this.eventTargets.get(event.target);
+        const instances = targets[event.type];
+        this.eventTargets.delete(event.target);
+        event.target.removeEventListener(event.type, this);
+        const t = this.instantAtTime(performance.now());
+        for (const instance of instances) {
+            if (t >= instance.begin) {
+                console.assert(isNaN(instance.end));
+                instance.value = event;
+                instance.end = t;
+                instance.parent?.item.childInstanceEndWasResolved(instance, t);
+                instance.parent?.item.childInstanceDidEnd(instance, t);
+                instances.delete(instance);
+            }
+        }
+    },
+
 });

--- a/lib/score.js
+++ b/lib/score.js
@@ -1,4 +1,4 @@
-import { assign, create, extend, get, I, isNumber, nop, partition, push, remove } from "./util.js";
+import { assign, create, extend, I, isNumber, nop, partition, push, remove } from "./util.js";
 import { notify } from "./events.js";
 import { Tape } from "./tape.js";
 
@@ -243,21 +243,7 @@ export const DOMEvent = assign((target, event) => extend(DOMEvent, { target, eve
     // and does not create any new occurrence.
     instantiate(instance, t) {
         instance.begin = t;
-        const targets = get(instance.tape.deck.eventTargets, this.target, () => ({}));
-        if (!Object.hasOwn(targets, this.event)) {
-            targets[this.event] = new Set();
-            this.target.addEventListener(this.event, instance.tape.deck);
-        }
-        targets[this.event].add(instance);
-    },
-
-    removedInstance(instance) {
-        const instances = instance.tape.deck.eventTargets.get(this.target)[this.event];
-        instances.delete(instance);
-        if (instances.size === 0) {
-            this.target.removeEventListener(this.event, instance.tape.deck);
-            delete instance.tape.deck.eventTargets.get(this.target)[this.event];
-        }
+        instance.tape.deck.addEventTarget(instance);
     },
 
     // When cancelling, there is no occurrence to remove, but we may need to
@@ -265,12 +251,14 @@ export const DOMEvent = assign((target, event) => extend(DOMEvent, { target, eve
     cancelInstance(instance, t) {
         ended(instance, t);
         instance.cancelled = true;
-        this.removedInstance(instance);
+        instance.tape.deck.removeEventTarget(instance);
     },
 
+    // When pruning, there is no occurrence to remove, but we may need to
+    // remove the event listener.
     pruneInstance(instance) {
         delete instance.parent;
-        this.removedInstance(instance);
+        instance.tape.deck.removeEventTarget(instance);
     }
 }));
 

--- a/lib/score.js
+++ b/lib/score.js
@@ -230,26 +230,8 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
     pruneInstance: pruned,
 });
 
-const EventHandler = {
-    targets: new Map(),
-
-    handleEvent(event) {
-        const instances = this.targets.get(event.target)[event.type];
-        const now = performance.now();
-        for (const instance of instances) {
-            const t = instance.tape.deck.instantAtTime(now);
-            if (t >= instance.begin) {
-                console.assert(isNaN(instance.end));
-                instance.value = event;
-                instance.end = t;
-                instance.parent?.item.childInstanceEndWasResolved(instance, t);
-                instance.parent?.item.childInstanceDidEnd(instance, t);
-                instances.delete(instance);
-            }
-        }
-    }
-};
-
+// DOMEvent ends when the first occurrence of an event occurs with the event
+// object as its value. This relies on the deck’s event handler.
 export const DOMEvent = assign((target, event) => extend(DOMEvent, { target, event }, {
     tag: "DOMEvent",
 
@@ -257,14 +239,38 @@ export const DOMEvent = assign((target, event) => extend(DOMEvent, { target, eve
         return `${this.tag}<${this.target}, ${this.event}>`;
     },
 
+    // Instantiate simply registers the instance wit the generic event handler
+    // and does not create any new occurrence.
     instantiate(instance, t) {
         instance.begin = t;
-        const targets = get(EventHandler.targets, this.target, () => ({}));
+        const targets = get(instance.tape.deck.eventTargets, this.target, () => ({}));
         if (!Object.hasOwn(targets, this.event)) {
             targets[this.event] = new Set();
-            this.target.addEventListener(this.event, EventHandler);
+            this.target.addEventListener(this.event, instance.tape.deck);
         }
         targets[this.event].add(instance);
+    },
+
+    removedInstance(instance) {
+        const instances = instance.tape.deck.eventTargets.get(this.target)[this.event];
+        instances.delete(instance);
+        if (instances.size === 0) {
+            this.target.removeEventListener(this.event, instance.tape.deck);
+            delete instance.tape.deck.eventTargets.get(this.target)[this.event];
+        }
+    },
+
+    // When cancelling, there is no occurrence to remove, but we may need to
+    // remove the event listener.
+    cancelInstance(instance, t) {
+        ended(instance, t);
+        instance.cancelled = true;
+        this.removedInstance(instance);
+    },
+
+    pruneInstance(instance) {
+        delete instance.parent;
+        this.removedInstance(instance);
     }
 }));
 

--- a/lib/score.js
+++ b/lib/score.js
@@ -1,4 +1,4 @@
-import { assign, create, extend, I, isNumber, nop, partition, push, remove } from "./util.js";
+import { assign, create, extend, get, I, isNumber, nop, partition, push, remove } from "./util.js";
 import { notify } from "./events.js";
 import { Tape } from "./tape.js";
 
@@ -229,6 +229,44 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
     cancelInstance: cancelled,
     pruneInstance: pruned,
 });
+
+const EventHandler = {
+    targets: new Map(),
+
+    handleEvent(event) {
+        const instances = this.targets.get(event.target)[event.type];
+        const now = performance.now();
+        for (const instance of instances) {
+            const t = instance.tape.deck.instantAtTime(now);
+            if (t >= instance.begin) {
+                console.assert(isNaN(instance.end));
+                instance.value = event;
+                instance.end = t;
+                instance.parent?.item.childInstanceEndWasResolved(instance, t);
+                instance.parent?.item.childInstanceDidEnd(instance, t);
+                instances.delete(instance);
+            }
+        }
+    }
+};
+
+export const DOMEvent = assign((target, event) => extend(DOMEvent, { target, event }, {
+    tag: "DOMEvent",
+
+    show() {
+        return `${this.tag}<${this.target}, ${this.event}>`;
+    },
+
+    instantiate(instance, t) {
+        instance.begin = t;
+        const targets = get(EventHandler.targets, this.target, () => ({}));
+        if (!Object.hasOwn(targets, this.event)) {
+            targets[this.event] = new Set();
+            this.target.addEventListener(this.event, EventHandler);
+        }
+        targets[this.event].add(instance);
+    }
+}));
 
 // Par is a container for items that all begin at the same time, ending when
 // all children have ended. The value is the list of all values of the

--- a/tests/await.html
+++ b/tests/await.html
@@ -95,7 +95,6 @@ test("Await in parallel", async t => {
     * Await-4 [17, 41[ <ok>`, "dump matches");
 });
 
-
 test("Cancel", async t => {
     const tape = Tape();
     const deck = Deck({ tape });

--- a/tests/await.html
+++ b/tests/await.html
@@ -95,6 +95,7 @@ test("Await in parallel", async t => {
     * Await-4 [17, 41[ <ok>`, "dump matches");
 });
 
+
 test("Cancel", async t => {
     const tape = Tape();
     const deck = Deck({ tape });

--- a/tests/dom-event.html
+++ b/tests/dom-event.html
@@ -7,7 +7,7 @@
         <script type="module">
 
 import { test } from "./test.js";
-import { timeout } from "../lib/util.js";
+import { K, timeout } from "../lib/util.js";
 import { DOMEvent, Instant, Delay, Par, Seq, dump } from "../lib/score.js";
 import { Tape } from "../lib/tape.js";
 import { Deck } from "../lib/deck.js";
@@ -21,12 +21,49 @@ test("DOMEvent(target, event)", t => {
 
 test("Instantiation", async t => {
     const tape = Tape();
+    const deck = Deck({ tape });
     const instance = tape.instantiate(DOMEvent(window, "synth"), 17);
-    Deck({ tape }).now = 27;
+    deck.now = 27;
     const event = new Event("synth");
     window.dispatchEvent(event);
     t.equal(instance.value, event, "instance value");
     t.match(dump(instance), /^\* DOMEvent-0 \[17, 27\[ <[^>]+>$/, "dump matches");
+});
+
+test("Cancel", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const instance = tape.instantiate(Par([
+        Seq([Instant(K([19])), Par.map(Delay)]),
+        DOMEvent(window, "synth")
+    ]).take(1), 17);
+    deck.now = 37;
+    t.equal(dump(instance),
+`* Par-0 [17, 36[ <19>
+  * Seq-1 [17, 36[ <19>
+    * Instant-2 @17 <19>
+    * Par/map-3 [17, 36[ <19>
+      * Delay-5 [17, 36[ <19>
+  * DOMEvent-4 [17, 36[ (cancelled)`, "dump matches");
+});
+
+test("Prune", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const choice = tape.instantiate(Par([
+        Seq([Instant(K([19])), Par.map(Delay)]),
+        Seq([Delay(23), DOMEvent(window, "synth")]),
+    ]).take(1), 17);
+    deck.now = 37;
+    t.equal(dump(choice),
+`* Par-0 [17, 36[ <19>
+  * Seq-1 [17, 36[ <19>
+    * Instant-2 @17 <19>
+    * Par/map-3 [17, 36[ <19>
+      * Delay-7 [17, 36[ <19>
+  * Seq-4 [17, 36[ (cancelled)
+    * Delay-5 [17, 36[ (cancelled)`, "dump matches");
+    t.equal(tape.show(), "Tape<17,17,36>", "occurrences were removed from the tape");
 });
 
         </script>

--- a/tests/dom-event.html
+++ b/tests/dom-event.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>DOMEvent</title>
+        <meta charset="utf8">
+        <link rel="stylesheet" href="test.css">
+        <script type="module">
+
+import { test } from "./test.js";
+import { timeout } from "../lib/util.js";
+import { DOMEvent, Instant, Delay, Par, Seq, dump } from "../lib/score.js";
+import { Tape } from "../lib/tape.js";
+import { Deck } from "../lib/deck.js";
+
+test("DOMEvent(target, event)", t => {
+    const item = DOMEvent(window, "synth");
+    t.match(item.show(), /Event<[^,]+, synth>/, `show (${item.show()})`);
+    t.undefined(item.duration, "unresolved duration");
+    t.equal(!item.failible, true, "infailible (at instantiation)");
+});
+
+test("Instantiation", async t => {
+    const tape = Tape();
+    const instance = tape.instantiate(DOMEvent(window, "synth"), 17);
+    Deck({ tape }).now = 27;
+    const event = new Event("synth");
+    window.dispatchEvent(event);
+    t.equal(instance.value, event, "instance value");
+    t.match(dump(instance), /^\* DOMEvent-0 \[17, 27\[ <[^>]+>$/, "dump matches");
+});
+
+        </script>
+    </head>
+    <body>
+        <p><a href="index.html">Back</a></p>
+    </body>
+</html>

--- a/tests/index.html
+++ b/tests/index.html
@@ -19,6 +19,7 @@
             <li>delay.html</li>
             <li>delay-until.html</li>
             <li>await.html</li>
+            <li>dom-event.html</li>
             <li>par.html</li>
             <li>par-take.html</li>
             <li>par-dur.html</li>

--- a/tests/manual/images.html
+++ b/tests/manual/images.html
@@ -40,7 +40,6 @@ score.add(Seq([
 
 deck.start();
 
-
         </script>
     </head>
     <body>

--- a/tests/manual/images.html
+++ b/tests/manual/images.html
@@ -16,7 +16,7 @@ img {
         <script type="module">
 
 import { Deck } from "../../lib/deck.js";
-import { Await, Delay, Effect, Instant, Par, Score, Seq, dump } from "../../lib/score.js";
+import { Await, Delay, DOMEvent, Effect, Instant, Par, Score, Seq, dump } from "../../lib/score.js";
 import { Tape } from "../../lib/tape.js";
 import { imagePromise, K, range } from "../../lib/util.js";
 
@@ -25,6 +25,8 @@ const deck = Deck({ tape });
 const score = Score({ tape });
 
 score.add(Seq([
+    DOMEvent(document.querySelector("button"), "click"),
+    Effect((_, t) => document.querySelector("p").textContent += ` started at time ${t}...`),
     Seq([...range(2, 6)].map(size => Seq([
         Await(async () => {
             const s = size * 100;
@@ -38,10 +40,12 @@ score.add(Seq([
 
 deck.start();
 
+
         </script>
     </head>
     <body>
         <p>Fetch images of increasing size, waiting 500ms after each one...</p>
         <p><a href="../">Back</a></p>
+        <p><button type="button">Begin</button></p>
     </body>
 </html>


### PR DESCRIPTION
Introduce DOMEvent as a specialised way to handle events from DOM elements. This item is similar to Await except that it waits for an event from a target to end, with the event object itself as its value. The Deck provides support for this feature by centralising event listeners, adding/removing as necessary, and translating event times to logical times. The manual images test adds a button that needs to be clicked for the images to show up.

Follow-up note: DOMEvent, like Await, should be repeatable, but repeat() does not handle unresolved children correctly yet so this will all be fixed in a forthcoming PR.