### PR TITLE
Repeat for Await and DOMEvent; cancelling and pruning

### DIFF
--- a/lib/deck.js
+++ b/lib/deck.js
@@ -161,7 +161,7 @@ export const Deck = assign(properties => create(properties).call(Deck), {
     // occurred in the targets maps that have the event name as key, set the
     // end time and value of the instance.
     handleEvent(event) {
-        const targets = this.eventTargets.get(event.target);
+        const targets = this.eventTargets.get(event.currentTarget);
         const instances = targets[event.type];
         this.eventTargets.delete(event.target);
         event.target.removeEventListener(event.type, this);

--- a/lib/score.js
+++ b/lib/score.js
@@ -3,7 +3,7 @@ import { notify } from "./events.js";
 import { Tape } from "./tape.js";
 
 const Fail = Error("Instantiation failure");
-const RepeatMax = 17;
+const RepeatMax = 777;
 
 const Capacity = new Map(); // capacity for items, set by take()
 const Duration = new Map(); // duration for items, set by dur()
@@ -876,6 +876,12 @@ const Repeat = assign(child => extend(Repeat, { child }), {
         }
     },
 
+    // A repeat may have an indefinite duration, but is considered to have
+    // effect if its child has effect.
+    get hasEffect() {
+        return isNaN(this.child.duration) || this.child.hasEffect;
+    },
+
     // Fails if the inner item fails, or if it has zero duration and repeats
     // indefinitely.
     get failible() {
@@ -960,6 +966,21 @@ const Repeat = assign(child => extend(Repeat, { child }), {
         console.assert(instance.item === this);
         console.assert(childInstance === instance.children.at(-1));
         failed(instance, t);
+    },
+
+    // Cancelling a repeat is a simpler version of cancelling a Seq as only
+    // the last child instance needs to be cancelled.
+    cancelInstance(instance, t) {
+        const currentChild = instance.children.at(-1);
+        currentChild.item.cancelInstance(currentChild, t);
+        ended(instance, t);
+        instance.cancelled = true;
+    },
+
+    // Pruning is even simpler since there are no scheduled children that have
+    // not started yet.
+    pruneInstance(instance, t) {
+        delete instance.parent;
     },
 
     valueForInstance: I,

--- a/lib/score.js
+++ b/lib/score.js
@@ -199,6 +199,7 @@ const DelayUntil = assign(t => extend(DelayUntil, { t }), {
 export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
     tag: "Await",
     show,
+    repeat,
 
     // The duration is unresolved.
     get duration() {},
@@ -238,6 +239,8 @@ export const DOMEvent = assign((target, event) => extend(DOMEvent, { target, eve
     show() {
         return `${this.tag}<${this.target}, ${this.event}>`;
     },
+
+    repeat,
 
     // Instantiate simply registers the instance wit the generic event handler
     // and does not create any new occurrence.
@@ -942,6 +945,7 @@ const Repeat = assign(child => extend(Repeat, { child }), {
             throw Error("Too many repeats");
         }
         if (instance.children.length === instance.capacity) {
+            this.parent?.childInstanceEndWasResolved(instance, t);
             ended(instance, t, childInstance.value);
         } else {
             instance.children.push(

--- a/tests/await.html
+++ b/tests/await.html
@@ -59,6 +59,25 @@ test("Stopped deck", async t => {
   * Await-1 [17, 18[ <ok>`, "dump matches");
 });
 
+test("Repeat", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    score.add(Await(ok).repeat().take(3), 17);
+    deck.now = 27;
+    await notification(deck, "await");
+    deck.now = 37;
+    await notification(deck, "await");
+    deck.now = 47;
+    await notification(deck, "await");
+    t.equal(dump(score.instance),
+`* Score-0 [0, ∞[
+  * Seq/repeat-1 [17, 47[ <ok>
+    * Await-2 [17, 27[ <ok>
+    * Await-3 [27, 37[ <ok>
+    * Await-4 [37, 47[ <ok>`, "dump matches");
+});
+
 test("Await in sequence", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
@@ -94,7 +113,6 @@ test("Await in parallel", async t => {
     * Delay-3 [17, 40[ <undefined>
     * Await-4 [17, 41[ <ok>`, "dump matches");
 });
-
 
 test("Cancel", async t => {
     const tape = Tape();

--- a/tests/dom-event.html
+++ b/tests/dom-event.html
@@ -19,7 +19,7 @@ test("DOMEvent(target, event)", t => {
     t.equal(!item.failible, true, "infailible (at instantiation)");
 });
 
-test("Instantiation", async t => {
+test("Instantiation", t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const instance = tape.instantiate(DOMEvent(window, "synth"), 17);
@@ -30,7 +30,24 @@ test("Instantiation", async t => {
     t.match(dump(instance), /^\* DOMEvent-0 \[17, 27\[ <[^>]+>$/, "dump matches");
 });
 
-test("Cancel", async t => {
+test("Repeat", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const seq = tape.instantiate(Seq([
+        DOMEvent(window, "synth").repeat().take(3),
+        Instant(K("ok"))
+    ]), 17);
+    deck.now = 27;
+    window.dispatchEvent(new Event("synth"));
+    deck.now = 37;
+    window.dispatchEvent(new Event("synth"));
+    deck.now = 47;
+    window.dispatchEvent(new Event("synth"));
+    deck.now = 48;
+    t.match(dump(seq), /^\* Seq-0 \[17, 47\[ <ok>\n  \* Seq\/repeat-1 \[17, 47\[ <[^>]+>\n    \* DOMEvent-2 \[17, 27\[ <[^>]+>\n    \* DOMEvent-3 \[27, 37\[ <[^>]+>\n    \* DOMEvent-4 \[37, 47\[ <[^>]+>\n  \* Instant-5 @47 <ok>$/, "dump matches");
+});
+
+test("Cancel", t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const instance = tape.instantiate(Par([

--- a/tests/dom-event.html
+++ b/tests/dom-event.html
@@ -64,6 +64,22 @@ test("Cancel", t => {
   * DOMEvent-4 [17, 36[ (cancelled)`, "dump matches");
 });
 
+test("Cancel with repeat", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const par = tape.instantiate(Par([
+        DOMEvent(window, "synth").repeat(),
+        Delay(23),
+    ]).take(1), 17);
+    deck.now = 27;
+    window.dispatchEvent(new Event("synth"));
+    deck.now = 37;
+    window.dispatchEvent(new Event("synth"));
+    deck.now = 47;
+    window.dispatchEvent(new Event("synth"));
+    t.match(dump(par), /^\* Par-0 \[17, 40\[ <>\n  \* Seq\/repeat-1 \[17, 40\[ \(cancelled\)\n    \* DOMEvent-2 \[17, 27\[ <[^>]+>\n    \* DOMEvent-4 \[27, 37\[ <[^>]+>\n    \* DOMEvent-5 \[37, 40\[ \(cancelled\)\n  \* Delay-3 \[17, 40\[ <undefined>$/, "dump matches");
+});
+
 test("Prune", t => {
     const tape = Tape();
     const deck = Deck({ tape });
@@ -78,6 +94,25 @@ test("Prune", t => {
     * Instant-2 @17 <19>
     * Par/map-3 [17, 36[ <19>
       * Delay-7 [17, 36[ <19>
+  * Seq-4 [17, 36[ (cancelled)
+    * Delay-5 [17, 36[ (cancelled)`, "dump matches");
+    t.equal(tape.show(), "Tape<17,17,36>", "occurrences were removed from the tape");
+});
+
+test("Prune with repeat", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const choice = tape.instantiate(Par([
+        Seq([Instant(K([19])), Par.map(Delay)]),
+        Seq([Delay(23), DOMEvent(window, "synth").repeat()]),
+    ]).take(1), 17);
+    deck.now = 37;
+    t.equal(dump(choice),
+`* Par-0 [17, 36[ <19>
+  * Seq-1 [17, 36[ <19>
+    * Instant-2 @17 <19>
+    * Par/map-3 [17, 36[ <19>
+      * Delay-8 [17, 36[ <19>
   * Seq-4 [17, 36[ (cancelled)
     * Delay-5 [17, 36[ (cancelled)`, "dump matches");
     t.equal(tape.show(), "Tape<17,17,36>", "occurrences were removed from the tape");

--- a/tests/index.html
+++ b/tests/index.html
@@ -49,6 +49,7 @@
 
         <h2>Manual tests</h2>
         <ul>
+            <li><a href="manual/drag.html">Drag (DOMEvent)</a></li>
             <li><a href="manual/images.html">Images (Await)</a></li>
         </ul>
     </body>

--- a/tests/manual/drag.html
+++ b/tests/manual/drag.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Drag</title>
+        <meta charset="utf8">
+        <link rel="stylesheet" href="../test.css">
+        <style>
+
+div {
+    width: 300px;
+    height: 200px;
+    position: absolute;
+    background-color: pink;
+    padding: 16px;
+    border-radius: 8px;
+    box-sizing: border-box;
+}
+
+        </style>
+        <script type="module">
+
+import { Deck } from "../../lib/deck.js";
+import { Await, Delay, DOMEvent, Effect, Instant, Par, Score, Seq, dump } from "../../lib/score.js";
+import { Tape } from "../../lib/tape.js";
+import { imagePromise, K, range } from "../../lib/util.js";
+
+const tape = Tape();
+const deck = Deck({ tape });
+const score = Score({ tape });
+const box = document.querySelector("div");
+
+score.add(Seq([
+    DOMEvent(box, "pointerdown"),
+    Effect(event => { console.log(">>> Drag start", event); }),
+    Par([
+        Seq([
+            DOMEvent(document, "pointermove"),
+            Effect(event => { console.log("... dragging", event); })
+        ]).repeat(),
+        Seq([
+            DOMEvent(document, "pointerup"),
+            Effect(event => { console.log("<<< Drag end", event); })
+        ])
+    ]).take(1)
+]).repeat());
+
+deck.start();
+
+        </script>
+    </head>
+    <body>
+        <div>Drag me!</div>
+    </body>
+</html>

--- a/tests/manual/images.html
+++ b/tests/manual/images.html
@@ -23,10 +23,12 @@ import { imagePromise, K, range } from "../../lib/util.js";
 const tape = Tape();
 const deck = Deck({ tape });
 const score = Score({ tape });
+const button = document.querySelector("button");
 
 score.add(Seq([
-    DOMEvent(document.querySelector("button"), "click"),
-    Effect((_, t) => document.querySelector("p").textContent += ` started at time ${t}...`),
+    DOMEvent(button, "click").repeat().take(3),
+    Effect(() => { button.disabled = true; }),
+    Effect((_, t) => { document.querySelector("p").textContent += ` started at time ${t}...`; }),
     Seq([...range(2, 6)].map(size => Seq([
         Await(async () => {
             const s = size * 100;
@@ -35,7 +37,7 @@ score.add(Seq([
         }),
         Delay.until(500),
     ]))),
-    Effect((_, t) => document.querySelector("p").textContent += ` ended at time ${t}.`)
+    Effect((_, t) => { document.querySelector("p").textContent += ` ended at time ${t}.`; })
 ]));
 
 deck.start();
@@ -45,6 +47,6 @@ deck.start();
     <body>
         <p>Fetch images of increasing size, waiting 500ms after each one...</p>
         <p><a href="../">Back</a></p>
-        <p><button type="button">Begin</button></p>
+        <p><button type="button">Begin</button> (press three times!)</p>
     </body>
 </html>


### PR DESCRIPTION
Await and DOMEvent are repeatable, and repeat itself handles children with unresolved duration correctly, along with cancelling and pruning (which are simplified versions of Seq cancelling and pruning since there is only a single active child and no further children scheduled).

A new manual test/demo for dragging is also added, but is not completely functional yet.