### PR TITLE
Handle children with unresolved duration in Seq.fold

### DIFF
--- a/lib/score.js
+++ b/lib/score.js
@@ -777,7 +777,7 @@ export const Seq = assign(children => create().call(Seq, { children: children ??
             } else {
                 instance.end = t;
             }
-            this.parent?.childInstanceEndWasResolved(instance, t);
+            instance.parent?.item.childInstanceEndWasResolved(instance, t);
         } else if (t === Infinity) {
             instance.end = t;
         }
@@ -951,7 +951,7 @@ const Repeat = assign(child => extend(Repeat, { child }), {
             throw Error("Too many repeats");
         }
         if (instance.children.length === instance.capacity) {
-            this.parent?.childInstanceEndWasResolved(instance, t);
+            instance.parent?.item.childInstanceEndWasResolved(instance, t);
             ended(instance, t, childInstance.value);
         } else {
             instance.children.push(
@@ -1092,7 +1092,7 @@ const SeqFold = {
         }
 
         if (isNumber(t)) {
-            this.parent?.childInstanceEndWasResolved(instance, t);
+            instance.parent?.item.childInstanceEndWasResolved(instance, t);
         }
         instance.currentChildIndex = 0;
         if (instance.children.length < instance.input.length) {
@@ -1109,6 +1109,61 @@ const SeqFold = {
         return instance.currentChildIndex === 0 ?
             this.z :
             instance.children[instance.currentChildIndex - 1].value;
+    },
+
+    // Resume instantiation of children.
+    childInstanceEndWasResolved(childInstance, t) {
+        const instance = childInstance.parent;
+        console.assert(instance.item === this);
+        console.assert(instance.children.at(-1) === childInstance);
+
+        if (childInstance.cutoff) {
+            // Stop instantiation here.
+            delete childInstance.cutoff;
+            instance.capacity = min(instance.input.length, n);
+            instance.cutoff = true;
+        } else {
+            // Constinue instantiation starting from the next child.
+            const m = instance.children.length;
+            for (let i = m; i < instance.capacity && t <= instance.maxEnd; ++i) {
+                const childInstance = instance.tape.instantiate(
+                    this.g(instance.input[i]), t, instance.maxEnd - t, instance
+                );
+                if (!childInstance) {
+                    for (let j = m; j < i; ++j) {
+                        instance.children[j].item.pruneInstance(instance.children[j]);
+                    }
+                    instance.children.length = m;
+                    failed(instance, t);
+                    return;
+                }
+                t = endOf(push(instance.children, childInstance));
+
+                // If a child instance is cut off then we cannot go any further
+                if (childInstance.cutoff) {
+                    delete childInstance.cutoff;
+                    instance.capacity = min(instance.children.length, Capacity.get(this));
+                    instance.cutoff = true;
+                }
+            }
+        }
+
+        if (Duration.has(this)) {
+            // The end was already set.
+            return;
+        }
+
+        if (instance.children.length === instance.input.length && isNumber(t)) {
+            if (instance.begin === t) {
+                delete instance.begin;
+                instance.t = t;
+            } else {
+                instance.end = t;
+            }
+            instance.parent?.item.childInstanceEndWasResolved(instance, t);
+        } else if (t === Infinity) {
+            instance.end = t;
+        }
     },
 
     childInstanceDidEnd: Seq.childInstanceDidEnd,

--- a/tests/manual/images.html
+++ b/tests/manual/images.html
@@ -8,7 +8,6 @@
 
 img {
     width: 200px;
-    height: 200px;
     margin: 4px;
 }
 
@@ -29,14 +28,11 @@ score.add(Seq([
     DOMEvent(button, "click").repeat().take(3),
     Effect(() => { button.disabled = true; }),
     Effect((_, t) => { document.querySelector("p").textContent += ` started at time ${t}...`; }),
-    Seq([...range(2, 6)].map(size => Seq([
-        Await(async () => {
-            const s = size * 100;
-            const image = await imagePromise(`https://placekitten.com/${s}/${s}`);
-            document.body.appendChild(image);
-        }),
+    Await(async () => await (await fetch("images.json")).json()),
+    Seq.map(url => Seq([
+        Await(async () => { document.body.appendChild(await imagePromise(url)); }),
         Delay.until(500),
-    ]))),
+    ])),
     Effect((_, t) => { document.querySelector("p").textContent += ` ended at time ${t}.`; })
 ]));
 

--- a/tests/manual/images.json
+++ b/tests/manual/images.json
@@ -1,0 +1,7 @@
+[
+    "https://placekitten.com/400/300",
+    "https://placekitten.com/500/300",
+    "https://placekitten.com/300/400",
+    "https://placekitten.com/400/400",
+    "https://placekitten.com/600/300"
+]

--- a/tests/seq-map.html
+++ b/tests/seq-map.html
@@ -193,6 +193,31 @@ test("Seq.map(g).dur(d), cutting off duration during instantiation", t => {
     * Delay-4 [48, 60[ <19>`, "dump matches");
 });
 
+test("Children with unresolved duration", t => {
+    const tape = Tape();
+    const instance = tape.instantiate(Seq([
+        Instant(K([23, 19, 31])),
+        Seq.fold(x => Seq([Instant(K([x])), Par.map(Delay)]))
+    ]), 17);
+    Deck({ tape }).now = 91;
+    t.equal(dump(instance),
+`* Seq-0 [17, 90[ <31>
+  * Instant-1 @17 <23,19,31>
+  * Seq/fold-2 [17, 90[ <31>
+    * Seq-3 [17, 40[ <23>
+      * Instant-4 @17 <23>
+      * Par/map-5 [17, 40[ <23>
+        * Delay-6 [17, 40[ <23>
+    * Seq-7 [40, 59[ <19>
+      * Instant-8 @40 <19>
+      * Par/map-9 [40, 59[ <19>
+        * Delay-10 [40, 59[ <19>
+    * Seq-11 [59, 90[ <31>
+      * Instant-12 @59 <31>
+      * Par/map-13 [59, 90[ <31>
+        * Delay-14 [59, 90[ <31>`, "dump matches")
+});
+
 test("Cancel Seq.map", t => {
     const tape = Tape();
     const choice = tape.instantiate(Par([


### PR DESCRIPTION
Seq.fold() (and map) did not handle children with unresolved duration correctly, so this is fixed (as in Seq, it means instantiating the following children). The images example is updated to fetch a list of URLs first, then showing the images.