### PR TITLE
Implement dur() for Await and DOMEvent()

### DIFF
--- a/lib/deck.js
+++ b/lib/deck.js
@@ -158,9 +158,8 @@ export const Deck = assign(properties => create(properties).call(Deck), {
     },
 
     // Generic event handler: for all instances that have begun before the event
-    // occurred in the targets maps that have the event name as key, set the
-    // end time and value of the instance. If the instance has a duration,
-    // then just store the event value for later in the appropriate property.
+    // occurred in the targets maps that have the event name as key, pass the
+    // event value to the instance.
     handleEvent(event) {
         const targets = this.eventTargets.get(event.currentTarget);
         const instances = targets[event.type];
@@ -169,19 +168,7 @@ export const Deck = assign(properties => create(properties).call(Deck), {
         const t = this.instantAtTime(performance.now());
         for (const instance of instances) {
             if (t >= instance.begin) {
-                if (Object.hasOwn(instance, "delayedEvent")) {
-                    instance.delayedEvent = event;
-                } else if (t > instance.end) {
-                    console.assert(instance.failed);
-                } else {
-                    if (t <= instance.end) {
-                        instance.tape.removeOccurrenceForInstance(instance);
-                    }
-                    instance.value = event;
-                    instance.end = t;
-                    instance.parent?.item.childInstanceEndWasResolved(instance, t);
-                    instance.parent?.item.childInstanceDidEnd(instance, t);
-                }
+                instance.item.eventDidOccur(instance, event, t);
                 instances.delete(instance);
             }
         }

--- a/lib/deck.js
+++ b/lib/deck.js
@@ -12,7 +12,6 @@ export const Deck = assign(properties => create(properties).call(Deck), {
         // objects that have vent names as keys, and sets of instances as
         // values.
         this.eventTargets = new Map();
-        this.delayedEvents = new Map();
         if (this.tape) {
             this.tape.deck = this;
         }
@@ -160,8 +159,8 @@ export const Deck = assign(properties => create(properties).call(Deck), {
 
     // Generic event handler: for all instances that have begun before the event
     // occurred in the targets maps that have the event name as key, set the
-    // end time and value of the instance. If the instance has a duration (and
-    // thus a resolved end time), then just store the event value for later.
+    // end time and value of the instance. If the instance has a duration,
+    // then just store the event value for later in the appropriate property.
     handleEvent(event) {
         const targets = this.eventTargets.get(event.currentTarget);
         const instances = targets[event.type];
@@ -170,13 +169,18 @@ export const Deck = assign(properties => create(properties).call(Deck), {
         const t = this.instantAtTime(performance.now());
         for (const instance of instances) {
             if (t >= instance.begin) {
-                if (isNaN(instance.end)) {
+                if (Object.hasOwn(instance, "delayedEvent")) {
+                    instance.delayedEvent = event;
+                } else if (t > instance.end) {
+                    console.assert(instance.failed);
+                } else {
+                    if (t <= instance.end) {
+                        instance.tape.removeOccurrenceForInstance(instance);
+                    }
                     instance.value = event;
                     instance.end = t;
                     instance.parent?.item.childInstanceEndWasResolved(instance, t);
                     instance.parent?.item.childInstanceDidEnd(instance, t);
-                } else if (!instance.failed) {
-                    this.delayedEvents.set(instance, event);
                 }
                 instances.delete(instance);
             }
@@ -205,15 +209,6 @@ export const Deck = assign(properties => create(properties).call(Deck), {
         if (instances.size === 0) {
             item.target.removeEventListener(item.event, this);
             delete this.eventTargets.get(item.target)[item.event];
-        }
-    },
-
-    // Get the delayed event for the instance and delete it.
-    getDelayedEvent(instance) {
-        if (this.delayedEvents.has(instance)) {
-            const event = this.delayedEvents.get(instance);
-            this.delayedEvents.delete(instance)
-            return event;
         }
     },
 

--- a/lib/deck.js
+++ b/lib/deck.js
@@ -12,6 +12,7 @@ export const Deck = assign(properties => create(properties).call(Deck), {
         // objects that have vent names as keys, and sets of instances as
         // values.
         this.eventTargets = new Map();
+        this.delayedEvents = new Map();
         if (this.tape) {
             this.tape.deck = this;
         }
@@ -159,7 +160,8 @@ export const Deck = assign(properties => create(properties).call(Deck), {
 
     // Generic event handler: for all instances that have begun before the event
     // occurred in the targets maps that have the event name as key, set the
-    // end time and value of the instance.
+    // end time and value of the instance. If the instance has a duration (and
+    // thus a resolved end time), then just store the event value for later.
     handleEvent(event) {
         const targets = this.eventTargets.get(event.currentTarget);
         const instances = targets[event.type];
@@ -168,11 +170,14 @@ export const Deck = assign(properties => create(properties).call(Deck), {
         const t = this.instantAtTime(performance.now());
         for (const instance of instances) {
             if (t >= instance.begin) {
-                console.assert(isNaN(instance.end));
-                instance.value = event;
-                instance.end = t;
-                instance.parent?.item.childInstanceEndWasResolved(instance, t);
-                instance.parent?.item.childInstanceDidEnd(instance, t);
+                if (isNaN(instance.end)) {
+                    instance.value = event;
+                    instance.end = t;
+                    instance.parent?.item.childInstanceEndWasResolved(instance, t);
+                    instance.parent?.item.childInstanceDidEnd(instance, t);
+                } else if (!instance.failed) {
+                    this.delayedEvents.set(instance, event);
+                }
                 instances.delete(instance);
             }
         }
@@ -200,6 +205,15 @@ export const Deck = assign(properties => create(properties).call(Deck), {
         if (instances.size === 0) {
             item.target.removeEventListener(item.event, this);
             delete this.eventTargets.get(item.target)[item.event];
+        }
+    },
+
+    // Get the delayed event for the instance and delete it.
+    getDelayedEvent(instance) {
+        if (this.delayedEvents.has(instance)) {
+            const event = this.delayedEvents.get(instance);
+            this.delayedEvents.delete(instance)
+            return event;
         }
     },
 

--- a/lib/score.js
+++ b/lib/score.js
@@ -200,20 +200,78 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
     tag: "Await",
     show,
     repeat,
+    dur,
 
-    // The duration is unresolved.
-    get duration() {},
+    // The duration is unresolved unless it was explicitly set with dur().
+    get duration() {
+        if (Duration.has(this)) {
+            return Duration.get(this);
+        }
+    },
+
+    // Await fails if its duration is 0.
+    get failible() {
+        return Duration.get(this) === 0;
+    },
 
     // Schedule f to run when the instance begins.
     instantiate(instance, t, dur) {
         instance.begin = t;
+        const end = t + min(dur, Duration.get(this));
+        if (end === t) {
+            throw Fail;
+        }
+
+        if (Duration.has(this)) {
+            // Await has an exact duration; if the call finishes earlier, its
+            // value is stored and the instance will finish at the end of its
+            // duration with that value. If the call does not finish on time,
+            // the instance fails and the return value is ignored.
+            instance.end = end;
+            return extend(instance, { t, forward: (t, interval) => {
+                console.assert(t === instance.begin);
+                const v = [];
+                this.instanceDidBegin.call(
+                    instance, instance.parent?.item.inputForChildInstance(instance), t, interval
+                ).then(value => {
+                    if (!instance.cancelled) {
+                        v.push(value);
+                    }
+                    notify(instance.tape.deck, "await", { instance });
+                });
+                instance.tape.addOccurrenceForInstance(extend(instance, {
+                    t: instance.end,
+                    forward: (t, interval) => {
+                        console.assert(t === instance.end);
+                        if (v.length === 1) {
+                            instance.value = v[0];
+                            instance.parent?.item.childInstanceDidEnd(instance, t);
+                        } else {
+                            instance.failed = true;
+                            instance.parent?.item.childInstanceDidFail(instance, t);
+                        }
+                    }
+                }), instance);
+            } });
+        }
+
+        // The duration may be constained by the parent, so the instance still
+        // fails if the call does not return on time. Otherwise, it finishes as
+        // soon as the call returns.
+        const hasDuration = isFinite(end);
+        if (hasDuration) {
+            instance.end = end;
+        }
         return extend(instance, { t, forward: (t, interval) => {
             console.assert(t === instance.begin);
             this.instanceDidBegin.call(
                 instance, instance.parent?.item.inputForChildInstance(instance), t, interval
             ).then(value => {
                 const deck = instance.tape.deck;
-                if (!instance.cancelled) {
+                if (!instance.cancelled && !instance.failed) {
+                    if (hasDuration) {
+                        instance.tape.removeOccurrenceForInstance(instance);
+                    }
                     instance.value = value;
                     instance.end = deck.instantAtTime(performance.now());
                     console.assert(instance.end > instance.begin);
@@ -224,6 +282,12 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
                 // not (useful for testing or integration with the outside).
                 notify(deck, "await", { instance });
             });
+            if (hasDuration) {
+                instance.tape.addOccurrenceForInstance(extend(instance, {
+                    t: instance.end,
+                    forward: t => { failed(instance, t); }
+                }), instance);
+            }
         } });
     },
 
@@ -422,13 +486,17 @@ export const Par = assign(children => create().call(Par, { children: children ??
         console.assert(instance.item === this);
         const end = instance.children.reduce((end, child) => max(end, endOf(child)), -Infinity);
         if (isNumber(end) && end >= t) {
-            if (instance.begin === end) {
-                delete instance.begin;
-                instance.t = end;
+            if (isNumber(instance.end)) {
+                console.assert(instance.end >= t);
             } else {
-                instance.end = end;
+                if (instance.begin === end) {
+                    delete instance.begin;
+                    instance.t = end;
+                } else {
+                    instance.end = end;
+                }
+                instance.parent?.item.childInstanceEndWasResolved(instance, end);
             }
-            instance.parent?.item.childInstanceEndWasResolved(instance, end);
         }
     },
 

--- a/lib/score.js
+++ b/lib/score.js
@@ -329,6 +329,9 @@ export const DOMEvent = assign((target, event) => extend(DOMEvent, { target, eve
         }
 
         instance.begin = t;
+        if (isFinite(end)) {
+            instance.end = end;
+        }
         instance.tape.deck.addEventTarget(instance);
 
         if (Duration.has(this)) {
@@ -337,10 +340,11 @@ export const DOMEvent = assign((target, event) => extend(DOMEvent, { target, eve
             // duration with that event as value. If the event does not occur
             // by the scheduled end of the instance, then it fails and the event
             // listener can be removed.
-            instance.end = end;
+            instance.delayedEvent = null;
             return extend(instance, { t: end, forward: t => {
                 console.assert(t === instance.end);
-                const value = instance.tape.deck.getDelayedEvent(instance);
+                const value = instance.delayedEvent;
+                delete instance.delayedEvent;
                 if (value) {
                     instance.value = value;
                     instance.parent?.item.childInstanceDidEnd(instance, t);
@@ -348,6 +352,12 @@ export const DOMEvent = assign((target, event) => extend(DOMEvent, { target, eve
                     instance.failed = true;
                     instance.parent?.item.childInstanceDidFail(instance, t);
                 }
+            } });
+        }
+
+        if (isFinite(end)) {
+            return extend(instance, { t: end, forward: t => {
+                failed(instance, t);
             } });
         }
     },

--- a/lib/score.js
+++ b/lib/score.js
@@ -305,12 +305,51 @@ export const DOMEvent = assign((target, event) => extend(DOMEvent, { target, eve
     },
 
     repeat,
+    dur,
+
+    // The duration is unresolved unless it was explicitly set with dur().
+    get duration() {
+        if (Duration.has(this)) {
+            return Duration.get(this);
+        }
+    },
+
+    // DOMEvent fails if its duration is 0.
+    get failible() {
+        return Duration.get(this) === 0;
+    },
 
     // Instantiate simply registers the instance wit the generic event handler
-    // and does not create any new occurrence.
-    instantiate(instance, t) {
+    // and does not create any new occurrence, unless the duration is
+    // constrained (either by dur() or the parent container).
+    instantiate(instance, t, dur) {
+        const end = t + min(dur, Duration.get(this));
+        if (end === t) {
+            throw Fail;
+        }
+
         instance.begin = t;
         instance.tape.deck.addEventTarget(instance);
+
+        if (Duration.has(this)) {
+            // DOMEvent has an exact duration; if the event occurs earlier, it
+            // is stored and the instance will finish at the end of its
+            // duration with that event as value. If the event does not occur
+            // by the scheduled end of the instance, then it fails and the event
+            // listener can be removed.
+            instance.end = end;
+            return extend(instance, { t: end, forward: t => {
+                console.assert(t === instance.end);
+                const value = instance.tape.deck.getDelayedEvent(instance);
+                if (value) {
+                    instance.value = value;
+                    instance.parent?.item.childInstanceDidEnd(instance, t);
+                } else {
+                    instance.failed = true;
+                    instance.parent?.item.childInstanceDidFail(instance, t);
+                }
+            } });
+        }
     },
 
     // When cancelling, there is no occurrence to remove, but we may need to

--- a/lib/score.js
+++ b/lib/score.js
@@ -228,31 +228,30 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
             // duration with that value. If the call does not finish on time,
             // the instance fails and the return value is ignored.
             instance.end = end;
-            return extend(instance, { t, forward: (t, interval) => {
-                console.assert(t === instance.begin);
-                const v = [];
-                this.instanceDidBegin.call(
-                    instance, instance.parent?.item.inputForChildInstance(instance), t, interval
-                ).then(value => {
-                    if (!instance.cancelled) {
-                        v.push(value);
-                    }
-                    notify(instance.tape.deck, "await", { instance });
-                });
-                instance.tape.addOccurrenceForInstance(extend(instance, {
-                    t: instance.end,
-                    forward: (t, interval) => {
-                        console.assert(t === instance.end);
-                        if (v.length === 1) {
-                            instance.value = v[0];
-                            instance.parent?.item.childInstanceDidEnd(instance, t);
-                        } else {
-                            instance.failed = true;
-                            instance.parent?.item.childInstanceDidFail(instance, t);
+            const v = [];
+            return [
+                extend(instance, { t, forward: (t, interval) => {
+                    console.assert(t === instance.begin);
+                    this.instanceDidBegin.call(
+                        instance, instance.parent?.item.inputForChildInstance(instance), t, interval
+                    ).then(value => {
+                        if (!instance.cancelled) {
+                            v.push(value);
                         }
+                        notify(instance.tape.deck, "await", { instance });
+                    });
+                } }),
+                extend(instance, { t: instance.end, forward(t) {
+                    console.assert(t === instance.end);
+                    if (v.length === 1) {
+                        instance.value = v[0];
+                        instance.parent?.item.childInstanceDidEnd(instance, t);
+                    } else {
+                        instance.failed = true;
+                        instance.parent?.item.childInstanceDidFail(instance, t);
                     }
-                }), instance);
-            } });
+                } })
+            ];
         }
 
         // The duration may be constained by the parent, so the instance still
@@ -262,7 +261,7 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
         if (hasDuration) {
             instance.end = end;
         }
-        return extend(instance, { t, forward: (t, interval) => {
+        const occurrence = extend(instance, { t, forward: (t, interval) => {
             console.assert(t === instance.begin);
             this.instanceDidBegin.call(
                 instance, instance.parent?.item.inputForChildInstance(instance), t, interval
@@ -282,13 +281,13 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
                 // not (useful for testing or integration with the outside).
                 notify(deck, "await", { instance });
             });
-            if (hasDuration) {
-                instance.tape.addOccurrenceForInstance(extend(instance, {
-                    t: instance.end,
-                    forward: t => { failed(instance, t); }
-                }), instance);
-            }
         } });
+        return hasDuration ? [occurrence, extend(instance, {
+            t: instance.end,
+            forward(t) {
+                failed(instance, t);
+            }
+        })] : occurrence;
     },
 
     cancelInstance: cancelled,

--- a/lib/score.js
+++ b/lib/score.js
@@ -339,7 +339,6 @@ export const DOMEvent = assign((target, event) => extend(DOMEvent, { target, eve
             // duration with that event as value. If the event does not occur
             // by the scheduled end of the instance, then it fails and the event
             // listener can be removed.
-            instance.delayedEvent = null;
             return extend(instance, { t: end, forward: t => {
                 console.assert(t === instance.end);
                 const value = instance.delayedEvent;
@@ -358,6 +357,30 @@ export const DOMEvent = assign((target, event) => extend(DOMEvent, { target, eve
             return extend(instance, { t: end, forward: t => {
                 failed(instance, t);
             } });
+        }
+    },
+
+    // The event has occurred for an instance at time t. It ends now with the
+    // event as value, unless it has a duration, in which case it holds to that
+    // value (unless the event occurs too late, but the instance already
+    // failed).
+    eventDidOccur(instance, event, t) {
+        if (Duration.has(this)) {
+            // Store the event value until the instance ends.
+            instance.delayedEvent = event;
+        } else if (t > instance.end) {
+            // The event occurs too late so the instance has failed.
+            console.assert(instance.failed);
+        } else {
+            // The instance may have a maximum duration enforced by
+            // an occurrence that needs to be cleared.
+            if (t <= instance.end) {
+                instance.tape.removeOccurrenceForInstance(instance);
+            }
+            instance.value = event;
+            instance.end = t;
+            instance.parent?.item.childInstanceEndWasResolved(instance, t);
+            instance.parent?.item.childInstanceDidEnd(instance, t);
         }
     },
 

--- a/lib/score.js
+++ b/lib/score.js
@@ -928,10 +928,17 @@ export const Seq = assign(children => create().call(Seq, { children: children ??
         }
     },
 
-    // Fail if a child fails.
+    // Fail if a child fails; prune all children following the failed child.
     childInstanceDidFail(childInstance, t) {
         const instance = childInstance.parent;
-        console.assert(instance.currentChildIndex === instance.children.length - 1);
+        console.assert(instance.item === this);
+        const n = instance.currentChildIndex + 1;
+        for (let i = n; i < instance.children.length; ++i) {
+            const child = instance.children[i];
+            child.item.pruneInstance(child, t);
+            delete child.parent;
+        }
+        instance.children.length = n;
         delete instance.currentChildIndex;
         failed(instance, t);
     },

--- a/lib/score.js
+++ b/lib/score.js
@@ -214,11 +214,14 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
         return Duration.get(this) === 0;
     },
 
-    // Schedule f to run when the instance begins.
+    // Schedule f to run when the instance begins and wait for the return value.
+    // The deck will send an `await` notification when the call ends, regardless
+    // of whether this is a success or failure.
     instantiate(instance, t, dur) {
         instance.begin = t;
         const end = t + min(dur, Duration.get(this));
-        if (end === t) {
+        if (end <= t) {
+            // Duration must be greater than zero.
             throw Fail;
         }
 
@@ -226,10 +229,14 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
             // Await has an exact duration; if the call finishes earlier, its
             // value is stored and the instance will finish at the end of its
             // duration with that value. If the call does not finish on time,
-            // the instance fails and the return value is ignored.
+            // the instance fails and the return value is ignored. This requires
+            // an extra occurrence at the end of the interval.
             instance.end = end;
+            // A cheap way to represent an optional value which can still be
+            // undefined.
             const v = [];
             return [
+                // Call the async function and store its return value.
                 extend(instance, { t, forward: (t, interval) => {
                     console.assert(t === instance.begin);
                     this.instanceDidBegin.call(
@@ -241,6 +248,7 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
                         notify(instance.tape.deck, "await", { instance });
                     });
                 } }),
+                // End with the stored value, or fail.
                 extend(instance, { t: instance.end, forward(t) {
                     console.assert(t === instance.end);
                     if (v.length === 1) {
@@ -261,6 +269,9 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
         if (hasDuration) {
             instance.end = end;
         }
+
+        // Call the async function on begin and wait for its return value to
+        // resolve the instance.
         const occurrence = extend(instance, { t, forward: (t, interval) => {
             console.assert(t === instance.begin);
             this.instanceDidBegin.call(
@@ -277,11 +288,12 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
                     instance.parent?.item.childInstanceEndWasResolved(instance, instance.end);
                     instance.parent?.item.childInstanceDidEnd(instance, instance.end);
                 }
-                // Send a notification whether the instance was cancelled or
-                // not (useful for testing or integration with the outside).
                 notify(deck, "await", { instance });
             });
         } });
+
+        // Add an extra occurrence to fail if the call did not finish on time
+        // in case of a constrained duration.
         return hasDuration ? [occurrence, extend(instance, {
             t: instance.end,
             forward(t) {
@@ -323,7 +335,8 @@ export const DOMEvent = assign((target, event) => extend(DOMEvent, { target, eve
     // constrained (either by dur() or the parent container).
     instantiate(instance, t, dur) {
         const end = t + min(dur, Duration.get(this));
-        if (end === t) {
+        if (end <= t) {
+            // Duration must be greater than zero.
             throw Fail;
         }
 
@@ -334,7 +347,7 @@ export const DOMEvent = assign((target, event) => extend(DOMEvent, { target, eve
         instance.tape.deck.addEventTarget(instance);
 
         if (Duration.has(this)) {
-            // DOMEvent has an exact duration; if the event occurs earlier, it
+            // DOMEvent has a definite duration; if the event occurs earlier, it
             // is stored and the instance will finish at the end of its
             // duration with that event as value. If the event does not occur
             // by the scheduled end of the instance, then it fails and the event

--- a/lib/tape.js
+++ b/lib/tape.js
@@ -76,6 +76,14 @@ export const Tape = Object.assign(() => create().call(Tape), {
         return occurrence;
     },
 
+    // Add a new occurrence to the tape for an instance, replacing the
+    // previously set occurrence for that instance.
+    addOccurrenceForInstance(occurrence, instance) {
+        console.assert(this.instances.has(instance));
+        console.assert(this.instances.get(instance) !== occurrence);
+        this.instances.set(instance, this.addOccurrence(occurrence));
+    },
+
     // Remove an occurrence from the tape (this is used when cancelling).
     removeOccurrence(occurrence) {
         const index = this.occurrences.indexOf(occurrence);

--- a/lib/tape.js
+++ b/lib/tape.js
@@ -24,10 +24,15 @@ export const Tape = Object.assign(() => create().call(Tape), {
         // debugging purposes.
         const instance = { tape: this, item, id: `${item.tag}-${this.idCounter++}` };
         try {
-            // Item-specific instantiation may return an occurrence to be added
-            // to the tape.
+            // Item-specific instantiation may return an occurrence or an array
+            // of occurrences to be added to the tape.
             const occurrence = item.instantiate(instance, t, dur ?? Infinity, parent);
-            if (occurrence) {
+            if (Array.isArray(occurrence)) {
+                for (const o of occurrence) {
+                    this.addOccurrence(o);
+                }
+                this.instances.set(instance, occurrence);
+            } else if (occurrence) {
                 this.instances.set(instance, this.addOccurrence(occurrence));
             }
             // Set the parent before returning the instance.
@@ -76,14 +81,6 @@ export const Tape = Object.assign(() => create().call(Tape), {
         return occurrence;
     },
 
-    // Add a new occurrence to the tape for an instance, replacing the
-    // previously set occurrence for that instance.
-    addOccurrenceForInstance(occurrence, instance) {
-        console.assert(this.instances.has(instance));
-        console.assert(this.instances.get(instance) !== occurrence);
-        this.instances.set(instance, this.addOccurrence(occurrence));
-    },
-
     // Remove an occurrence from the tape (this is used when cancelling).
     removeOccurrence(occurrence) {
         const index = this.occurrences.indexOf(occurrence);
@@ -94,7 +91,14 @@ export const Tape = Object.assign(() => create().call(Tape), {
     // Remove the occurrence for an instance by looking it up in the
     // instance map.
     removeOccurrenceForInstance(instance) {
-        const occurrence = this.removeOccurrence(this.instances.get(instance));
+        const occurrence = this.instances.get(instance);
+        if (Array.isArray(occurrence)) {
+            for (const o of occurrence) {
+                this.removeOccurrence(o);
+            }
+        } else {
+            this.removeOccurrence(occurrence);
+        }
         this.instances.delete(instance);
         return occurrence;
     }

--- a/tests/await.html
+++ b/tests/await.html
@@ -172,7 +172,7 @@ test("Await(f).dur(d); followed by instant", async t => {
 `* Score-0 [0, ∞[
   * Seq-1 [17, 40[ <ok!>
     * Await-2 [17, 40[ <ok>
-    * Instant-3 @17 <ok!>`, "dump matches");
+    * Instant-3 @40 <ok!>`, "dump matches");
 });
 
 test("Await(f).dur(d); call ends late", async t => {

--- a/tests/await.html
+++ b/tests/await.html
@@ -114,6 +114,91 @@ test("Await in parallel", async t => {
     * Await-4 [17, 41[ <ok>`, "dump matches");
 });
 
+test("Await(f) constrained by parent; call ends early", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    score.add(Par([Await(ok)]).dur(19), 17);
+    deck.now = 18;
+    await notification(deck, "await");
+    deck.now = 37;
+    t.equal(dump(score.instance),
+`* Score-0 [0, ∞[
+  * Par-1 [17, 36[ <ok>
+    * Await-2 [17, 18[ <ok>`, "dump matches");
+});
+
+test("Await(f) constrained by parent; call ends late", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    score.add(Par([Await(ok)]).dur(19), 17);
+    deck.now = 39;
+    await notification(deck, "await");
+    t.equal(dump(score.instance),
+`* Score-0 [0, ∞[
+  * Par-1 [17, 36[ (failed)
+    * Await-2 [17, 36[ (failed)`, "dump matches");
+});
+
+test("Await(f).dur(0)", t => {
+    const zero = Await(ok).dur(0);
+    t.equal(zero.duration, 0, "zero duration");
+    t.undefined(Tape().instantiate(zero, 17), "fails to instantiate");
+});
+
+test("Await(f).dur(d); call ends early", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    score.add(Await(ok).dur(23), 17);
+    deck.now = 18;
+    await notification(deck, "await");
+    deck.now = 41;
+    t.equal(dump(score.instance),
+`* Score-0 [0, ∞[
+  * Await-1 [17, 40[ <ok>`, "dump matches");
+});
+
+test("Await(f).dur(d); call ends late", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    score.add(Await(ok).dur(23), 17);
+    deck.now = 51;
+    await notification(deck, "await");
+    t.equal(dump(score.instance),
+`* Score-0 [0, ∞[
+  * Await-1 [17, 40[ (failed)`, "dump matches");
+});
+
+test("Await(f).dur(d) constrained by parent; call ends early", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    score.add(Par([Await(ok).dur(23)]).dur(19), 17);
+    deck.now = 18;
+    await notification(deck, "await");
+    deck.now = 37;
+    t.equal(dump(score.instance),
+`* Score-0 [0, ∞[
+  * Par-1 [17, 36[ <ok>
+    * Await-2 [17, 36[ <ok>`, "dump matches");
+});
+
+test("Await(f).dur(d) constrained by parent; call ends late", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    score.add(Par([Await(ok).dur(23)]).dur(19), 17);
+    deck.now = 39;
+    await notification(deck, "await");
+    t.equal(dump(score.instance),
+`* Score-0 [0, ∞[
+  * Par-1 [17, 36[ (failed)
+    * Await-2 [17, 36[ (failed)`, "dump matches");
+});
+
 test("Cancel", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
@@ -123,6 +208,26 @@ test("Cancel", async t => {
         Await(() => timeout(100))
     ]).take(1), 17);
     deck.now = 37;
+    await notification(deck, "await");
+    t.equal(dump(score.instance),
+`* Score-0 [0, ∞[
+  * Par-1 [17, 36[ <19>
+    * Seq-2 [17, 36[ <19>
+      * Instant-3 @17 <19>
+      * Par/map-4 [17, 36[ <19>
+        * Delay-6 [17, 36[ <19>
+    * Await-5 [17, 36[ (cancelled)`, "dump matches");
+});
+
+test("Cancel Await(f).dur(d)", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    score.add(Par([
+        Seq([Instant(K([19])), Par.map(Delay)]),
+        Await(ok).dur(23)
+    ]).take(1), 17);
+    deck.now = 39;
     await notification(deck, "await");
     t.equal(dump(score.instance),
 `* Score-0 [0, ∞[

--- a/tests/await.html
+++ b/tests/await.html
@@ -160,6 +160,21 @@ test("Await(f).dur(d); call ends early", async t => {
   * Await-1 [17, 40[ <ok>`, "dump matches");
 });
 
+test("Await(f).dur(d); followed by instant", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    score.add(Seq([Await(ok).dur(23), Instant(x => x + "!")]), 17);
+    deck.now = 18;
+    await notification(deck, "await");
+    deck.now = 41;
+    t.equal(dump(score.instance),
+`* Score-0 [0, ∞[
+  * Seq-1 [17, 40[ <ok!>
+    * Await-2 [17, 40[ <ok>
+    * Instant-3 @17 <ok!>`, "dump matches");
+});
+
 test("Await(f).dur(d); call ends late", async t => {
     const tape = Tape();
     const deck = Deck({ tape });

--- a/tests/dom-event.html
+++ b/tests/dom-event.html
@@ -47,6 +47,33 @@ test("Repeat", t => {
     t.match(dump(seq), /^\* Seq-0 \[17, 47\[ <ok>\n  \* Seq\/repeat-1 \[17, 47\[ <[^>]+>\n    \* DOMEvent-2 \[17, 27\[ <[^>]+>\n    \* DOMEvent-3 \[27, 37\[ <[^>]+>\n    \* DOMEvent-4 \[37, 47\[ <[^>]+>\n  \* Instant-5 @47 <ok>$/, "dump matches");
 });
 
+test("Event(target, type).dur(0)", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const zero = DOMEvent(window, "synth").dur(0);
+    t.equal(zero.duration, 0, "zero duration");
+    t.undefined(tape.instantiate(zero, 17), "fails to instantiate");
+});
+
+test("DOMEvent(target, type).dur(d); event occurs early", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const event = tape.instantiate(DOMEvent(window, "synth").dur(23), 17);
+    deck.now = 18;
+    window.dispatchEvent(new Event("synth"));
+    deck.now = 41;
+    t.match(dump(event), /^\* DOMEvent-0 \[17, 40\[ <[^>]+>$/, "dump matches");
+});
+
+test("DOMEvent(target, type).dur(d); event occurs late", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const event = tape.instantiate(DOMEvent(window, "synth").dur(23), 17);
+    deck.now = 51;
+    window.dispatchEvent(new Event("synth"));
+    t.equal(dump(event), "* DOMEvent-0 [17, 40[ (failed)", "dump matches");
+});
+
 test("Cancel", t => {
     const tape = Tape();
     const deck = Deck({ tape });

--- a/tests/dom-event.html
+++ b/tests/dom-event.html
@@ -55,25 +55,6 @@ test("Event(target, type).dur(0)", t => {
     t.undefined(tape.instantiate(zero, 17), "fails to instantiate");
 });
 
-test("DOMEvent(target, type).dur(d); event occurs early", async t => {
-    const tape = Tape();
-    const deck = Deck({ tape });
-    const event = tape.instantiate(DOMEvent(window, "synth").dur(23), 17);
-    deck.now = 18;
-    window.dispatchEvent(new Event("synth"));
-    deck.now = 41;
-    t.match(dump(event), /^\* DOMEvent-0 \[17, 40\[ <[^>]+>$/, "dump matches");
-});
-
-test("DOMEvent(target, type).dur(d); event occurs late", async t => {
-    const tape = Tape();
-    const deck = Deck({ tape });
-    const event = tape.instantiate(DOMEvent(window, "synth").dur(23), 17);
-    deck.now = 51;
-    window.dispatchEvent(new Event("synth"));
-    t.equal(dump(event), "* DOMEvent-0 [17, 40[ (failed)", "dump matches");
-});
-
 test("DOMEvent(target, type) constrained by parent; event occurs early", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
@@ -93,6 +74,25 @@ test("DOMEvent(target, type) constrained by parent; event occurs late", async t 
     t.equal(dump(par),
 `* Par-0 [17, 40[ (failed)
   * DOMEvent-1 [17, 40[ (failed)`, "dump matches");
+});
+
+test("DOMEvent(target, type).dur(d); event occurs early", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const event = tape.instantiate(DOMEvent(window, "synth").dur(23), 17);
+    deck.now = 18;
+    window.dispatchEvent(new Event("synth"));
+    deck.now = 41;
+    t.match(dump(event), /^\* DOMEvent-0 \[17, 40\[ <[^>]+>$/, "dump matches");
+});
+
+test("DOMEvent(target, type).dur(d); event occurs late", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const event = tape.instantiate(DOMEvent(window, "synth").dur(23), 17);
+    deck.now = 51;
+    window.dispatchEvent(new Event("synth"));
+    t.equal(dump(event), "* DOMEvent-0 [17, 40[ (failed)", "dump matches");
 });
 
 test("Cancel", t => {

--- a/tests/dom-event.html
+++ b/tests/dom-event.html
@@ -74,6 +74,27 @@ test("DOMEvent(target, type).dur(d); event occurs late", async t => {
     t.equal(dump(event), "* DOMEvent-0 [17, 40[ (failed)", "dump matches");
 });
 
+test("DOMEvent(target, type) constrained by parent; event occurs early", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const par = tape.instantiate(Par([DOMEvent(window, "synth")]).dur(23), 17);
+    deck.now = 18;
+    window.dispatchEvent(new Event("synth"));
+    deck.now = 41;
+    t.match(dump(par), /^\* Par-0 \[17, 40\[ <[^>]+>\n  \* DOMEvent-1 \[17, 18\[ <[^>]+>$/, "dump matches");
+});
+
+test("DOMEvent(target, type) constrained by parent; event occurs late", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const par = tape.instantiate(Par([DOMEvent(window, "synth")]).dur(23), 17);
+    deck.now = 51;
+    window.dispatchEvent(new Event("synth"));
+    t.equal(dump(par),
+`* Par-0 [17, 40[ (failed)
+  * DOMEvent-1 [17, 40[ (failed)`, "dump matches");
+});
+
 test("Cancel", t => {
     const tape = Tape();
     const deck = Deck({ tape });

--- a/tests/manual/images.html
+++ b/tests/manual/images.html
@@ -17,7 +17,7 @@ img {
 import { Deck } from "../../lib/deck.js";
 import { Await, Delay, DOMEvent, Effect, Instant, Par, Score, Seq, dump } from "../../lib/score.js";
 import { Tape } from "../../lib/tape.js";
-import { imagePromise, K, range } from "../../lib/util.js";
+import { imagePromise, K, range, timeout } from "../../lib/util.js";
 
 const tape = Tape();
 const deck = Deck({ tape });
@@ -32,11 +32,13 @@ score.add(Seq([
         document.body.appendChild(await imagePromise(url));
         return url;
     }).dur(500)),
+    Effect(() => {
+        setTimeout(() => { console.log(dump(score.instance)); });
+        return "ok";
+    })
 ]));
 
 deck.start();
-
-window.$ = () => { console.log(dump(score.instance)); console.log(tape.show()); };
 
         </script>
     </head>

--- a/tests/manual/images.html
+++ b/tests/manual/images.html
@@ -27,22 +27,22 @@ const button = document.querySelector("button");
 score.add(Seq([
     DOMEvent(button, "click").repeat().take(3),
     Effect(() => { button.disabled = true; }),
-    Effect((_, t) => { document.querySelector("p").textContent += ` started at time ${t}...`; }),
     Await(async () => await (await fetch("images.json")).json()),
-    Seq.map(url => Seq([
-        Await(async () => { document.body.appendChild(await imagePromise(url)); }),
-        Delay.until(500),
-    ])),
-    Effect((_, t) => { document.querySelector("p").textContent += ` ended at time ${t}.`; })
+    Seq.map(url => Await(async () => {
+        document.body.appendChild(await imagePromise(url));
+        return url;
+    }).dur(500)),
 ]));
 
 deck.start();
 
+window.$ = () => { console.log(dump(score.instance)); console.log(tape.show()); };
+
         </script>
     </head>
     <body>
-        <p>Fetch images of increasing size, waiting 500ms after each one...</p>
         <p><a href="../">Back</a></p>
+        <p>Fetch images of increasing size, waiting 500ms after each one.</p>
         <p><button type="button">Begin</button> (press three times!)</p>
     </body>
 </html>

--- a/tests/seq.html
+++ b/tests/seq.html
@@ -7,8 +7,9 @@
         <script type="module">
 
 import { test } from "./test.js";
-import { K } from "../lib/util.js";
-import { Instant, Delay, Par, Seq, dump } from "../lib/score.js";
+import { K, timeout } from "../lib/util.js";
+import { notification } from "../lib/events.js";
+import { Await, Instant, Delay, Par, Seq, dump } from "../lib/score.js";
 import { Tape } from "../lib/tape.js";
 import { Deck } from "../lib/deck.js";
 
@@ -150,6 +151,20 @@ test("Instantiation failure", t => {
         Instant(() => { throw Error("should not be intantiated"); })
     ]), 17), "failed to instantiate seq");
     t.equal(tape.occurrences.length, 0, "no occurrences on tape");
+});
+
+test("Child failure (not the last child)", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const seq = tape.instantiate(Seq([
+        Await(async () => await timeout(10)).dur(19),
+        Instant(K("ok"))
+    ]), 17);
+    deck.now = 51;
+    await notification(deck, "await");
+    t.equal(dump(seq),
+`* Seq-0 [17, 36[ (failed)
+  * Await-1 [17, 36[ (failed)`, "dump matches");
 });
 
 test("Cancel Seq", t => {


### PR DESCRIPTION
Await and DOMEvent can be modified with dur(), which ensures that they end at an exact time. If the function call finishes or the event occurs early (within the given duration), then the value is held until the end of the item; otherwise, the item fails.

The duration of Await and DOMEvent can also be constrained by the parent container: the item still ends as soon as possible, but it may fail if it does not by the time the parent itself ends.

The images example is simplified, new tests are added, and a bug with handling a child failure in Seq is fixed.