### PR TITLE
Implement dur() for Instant and Effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,11 @@ elements by default.
     same as just `Seq(xs)`.
     * It is possible to limit the number of occurrences of `repeat()` with `take(n)`:
     `x.repeate().take(3)` is the same as `Seq([x, x, x])`.
-* `dur(d)` applies to Par, Seq or repeat, and sets the duration to exactly _d_ ≥ 0. If the natural duration
-of the element is less than _d_, then it is padded as if a Delay was added to it. If the natural duration
-of the element is more than _d_, then it is cut off earlier and the children that have not finished yet
-are pruned.
+* `dur(d)` applies to any item (except Delay), and sets the duration to exactly _d_ ≥ 0. If the natural
+duration of the element is less than _d_, then it is padded as if a Delay was added to it. If the natural
+duration of the element is more than _d_, then it is cut off earlier and the children that have not
+finished yet are pruned.
+    * `Instant(f).dur(d)` delays the return value of _f_ by _d_.
     * `Par(xs).dur(d)` sets the duration of the par to _d_ and returns the elements that have finished
     in the order in which they finished.
     * `Seq(xs).dur(d)` sets the duration of the seq to _d_ and returns the last value that finished by _d_.
@@ -197,7 +198,15 @@ until _f_ is actually evaluated.
 when an event notification is received.
 
 These elements can be combined with the synchronous elements defined above, and accept the `repeat()`
-modifier. `Effect` comes with two modifiers of its own and will be detailed when describing the execution
+modifier. The `dur(d)` modified also applies as follows:
+
+* `Effect(f).dur(d)` applies the effect of _f_ after the duration _d_.
+* `Await(f).dur(d)` delays the return of _f_ if it ends before the duration _d_, and fails if the call does
+not finish by that time.
+* `DOMEvent(target, type).dur(d)` delays the event value it occurs before the duration _d_, and fails if
+the event does not occur by that time.
+
+`Effect` comes with two modifiers of its own and will be detailed when describing the execution
 model below:
 
 * `undo(g)` provides an undo function for the effect if it is evaluated again backward;

--- a/lib/score.js
+++ b/lib/score.js
@@ -71,6 +71,11 @@ export const Instant = assign(f => f ? extend(Instant, { valueForInstance: f }) 
     show,
     repeat,
 
+    // If a valid duration is set, then this is wrapped into a Seq.
+    dur(d) {
+        return d > 0 ? Seq([Delay(d), this]) : this;
+    },
+
     // An instant has no duration.
     get duration() {
         return 0;

--- a/tests/instant.html
+++ b/tests/instant.html
@@ -49,6 +49,23 @@ test("Instantiatiation", t => {
     t.equal(instance.value, "ok", "instance value");
 });
 
+test("Instant(f).dur(d)", t => {
+    const tape = Tape();
+    const instance = tape.instantiate(Instant(K("ok")).dur(23), 17);
+    Deck({ tape }).now = 41;
+    t.equal(dump(instance),
+`* Seq-0 [17, 40[ <ok>
+  * Delay-1 [17, 40[ <undefined>
+  * Instant-2 @40 <ok>`, "dump matches");
+});
+
+test("Instant(f).dur(0) has no effect", t => {
+    const tape = Tape();
+    const instance = tape.instantiate(Instant(K("ok")).dur(0), 17);
+    Deck({ tape }).now = 18;
+    t.equal(dump(instance), "* Instant-0 @17 <ok>", "dump matches");
+});
+
 test("Instantiation with parent duration", t => {
     t.equal(dump(Tape().instantiate(Instant(), 17, 31)), "* Instant-0 @17", "cap is always high enough");
 });
@@ -103,6 +120,19 @@ test("Effect(f)", t => {
     const instance = tape.instantiate(effect, 17);
     t.warns(() => { Deck({ tape }).now = 18; }, "has effect when running");
     t.equal(dump(instance), "* Effect-0 @17 <ok>", "dump matches");
+});
+
+test("Effect(f).dur(d)", t => {
+    const tape = Tape();
+    const instance = tape.instantiate(Effect(() => {
+        console.warn("Some effect");
+        return "ok";
+    }).dur(23), 17);
+    t.warns(() => { Deck({ tape }).now = 41; }, "has effect when running");
+    t.equal(dump(instance),
+`* Seq-0 [17, 40[ <ok>
+  * Delay-1 [17, 40[ <undefined>
+  * Effect-2 @40 <ok>`, "dump matches");
 });
 
         </script>


### PR DESCRIPTION
Wrap Instant/Effect in a Seq with a Delay (if the duration is non-zero, otherwise do nothing). This means that an Effect occurs at the _end_ of the duration.

Update the README to document the effect of .dur() for Instant, Effect, but also Await and DOMEvent.