### PR TITLE
Error result

### DIFF
--- a/lib/score.js
+++ b/lib/score.js
@@ -2,7 +2,9 @@ import { assign, create, extend, I, isNumber, nop, partition, push, remove } fro
 import { notify } from "./events.js";
 import { Tape } from "./tape.js";
 
-const Fail = Error("Instantiation failure");
+const FailureError = window.Error("failed");
+const InputError = window.Error("input");
+const TimeoutError = window.Error("timeout");
 const RepeatMax = 777;
 
 const Capacity = new Map(); // capacity for items, set by take()
@@ -23,7 +25,7 @@ export const Score = Object.assign(properties => create(properties).call(Score),
     // Instantiate the score to fill up the entire available duration.
     instantiate(instance, t, dur) {
         if (!(dur > 0)) {
-            throw Fail;
+            throw FailureError;
         }
         instance.begin = t;
         instance.end = t + dur;
@@ -227,7 +229,7 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
         const end = t + min(dur, Duration.get(this));
         if (end <= t) {
             // Duration must be greater than zero.
-            throw Fail;
+            throw FailureError;
         }
 
         if (Duration.has(this)) {
@@ -251,6 +253,12 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
                             v.push(value);
                         }
                         notify(instance.tape.deck, "await", { instance });
+                    }).catch(error => {
+                        instance.tape.removeOccurrenceForInstance(instance);
+                        instance.end = instance.tape.deck.instantAtTime(performance.now());
+                        instance.error = error;
+                        instance.parent?.item.childInstanceDidFail(instance, instance.end);
+                        notify(instance.tape.deck, "await", { instance });
                     });
                 } }),
                 // End with the stored value, or fail.
@@ -260,7 +268,7 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
                         instance.value = v[0];
                         instance.parent?.item.childInstanceDidEnd(instance, t);
                     } else {
-                        instance.failed = true;
+                        instance.error = TimeoutError;
                         instance.parent?.item.childInstanceDidFail(instance, t);
                     }
                 } })
@@ -283,7 +291,7 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
                 instance, instance.parent?.item.inputForChildInstance(instance), t, interval
             ).then(value => {
                 const deck = instance.tape.deck;
-                if (!instance.cancelled && !instance.failed) {
+                if (!instance.cancelled && !instance.error) {
                     if (hasDuration) {
                         instance.tape.removeOccurrenceForInstance(instance);
                     }
@@ -294,15 +302,20 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
                     instance.parent?.item.childInstanceDidEnd(instance, instance.end);
                 }
                 notify(deck, "await", { instance });
+            }).catch(error => {
+                instance.end = instance.tape.deck.instantAtTime(performance.now());
+                instance.error = error;
+                instance.parent?.item.childInstanceDidFail(instance, instance.end);
+                notify(instance.tape.deck, "await", { instance });
             });
         } });
 
-        // Add an extra occurrence to fail if the call did not finish on time
-        // in case of a constrained duration.
+        // Add an extra occurrence to timeout if the call did not finish on time
+        // when the duration is constrained.
         return hasDuration ? [occurrence, extend(instance, {
             t: instance.end,
             forward(t) {
-                failed(instance, t);
+                failed(instance, t, TimeoutError);
             }
         })] : occurrence;
     },
@@ -342,7 +355,7 @@ export const Event = assign((target, event) => extend(Event, { target, event }, 
         const end = t + min(dur, Duration.get(this));
         if (end <= t) {
             // Duration must be greater than zero.
-            throw Fail;
+            throw FailureError;
         }
 
         instance.begin = t;
@@ -365,7 +378,7 @@ export const Event = assign((target, event) => extend(Event, { target, event }, 
                     instance.value = value;
                     instance.parent?.item.childInstanceDidEnd(instance, t);
                 } else {
-                    instance.failed = true;
+                    instance.error = TimeoutError;
                     instance.parent?.item.childInstanceDidFail(instance, t);
                 }
             } });
@@ -373,7 +386,7 @@ export const Event = assign((target, event) => extend(Event, { target, event }, 
 
         if (isFinite(end)) {
             return extend(instance, { t: end, forward: t => {
-                failed(instance, t);
+                failed(instance, t, TimeoutError);
             } });
         }
     },
@@ -388,7 +401,7 @@ export const Event = assign((target, event) => extend(Event, { target, event }, 
             instance.delayedEvent = event;
         } else if (t > instance.end) {
             // The event occurs too late so the instance has failed.
-            console.assert(instance.failed);
+            console.assert(instance.error === TimeoutError);
         } else {
             // The instance may have a maximum duration enforced by
             // an occurrence that needs to be cleared.
@@ -490,7 +503,7 @@ export const Par = assign(children => create().call(Par, { children: children ??
 
     instantiateChildren(instance, children, t, dur) {
         if (this.failibleChildren(children)) {
-            throw Fail;
+            throw FailureError;
         }
 
         // itemDur is the duration potentially set by .dur(), which may be
@@ -680,20 +693,24 @@ export const ParMap = {
         } });
     },
 
-    // Actually instantiate the children from the input.
+    // Actually instantiate the children from the input. If the input is not
+    // an array, or an error occurs while creating the content from the input,
+    // fail with an input error.
     instantiateChildren(instance, xs, t, dur) {
         console.assert(t === instance.begin);
         if (!Array.isArray(xs)) {
-            return failed(instance, t);
+            return failed(instance, t, InputError);
         }
 
         // Get the child elements first.
-        const children = xs.map((x, i) => {
+        const children = [];
+        for (let i = 0; i < xs.length; ++i) {
             try {
-                return this.g(x, i);
-            } catch {
+                children.push(this.g(xs[i], i));
+            } catch (error) {
+                return failed(instance, t, InputError);
             }
-        });
+        }
 
         // Instantiate children, which may fail.
         try {
@@ -816,7 +833,7 @@ export const Seq = assign(children => create().call(Seq, { children: children ??
     // if any child fails.
     instantiate(instance, t, dur) {
         if (this.failible) {
-            throw Fail;
+            throw FailureError;
         }
 
         // The duration of the seq is contrained by the parent duration or the
@@ -840,7 +857,7 @@ export const Seq = assign(children => create().call(Seq, { children: children ??
                 for (const childInstance of instance.children) {
                     childInstance.item.pruneInstance(childInstance);
                 }
-                throw Fail;
+                throw FailureError;
             }
             t = endOf(push(instance.children, childInstance));
 
@@ -1060,7 +1077,7 @@ const Repeat = assign(child => extend(Repeat, { child }), {
     // single occurrence if there are no iterations.
     instantiate(instance, t, dur) {
         if (this.failible) {
-            throw Fail;
+            throw FailureError;
         }
 
         if (Capacity.get(this) === 0) {
@@ -1112,7 +1129,7 @@ const Repeat = assign(child => extend(Repeat, { child }), {
 
         if (instance.children.length > RepeatMax) {
             // This is just for debug purposes and should be removed eventually.
-            throw Error("Too many repeats");
+            throw window.Error("Too many repeats");
         }
         if (instance.children.length === instance.capacity) {
             instance.parent?.item.childInstanceEndWasResolved(instance, t);
@@ -1197,7 +1214,7 @@ const SeqFold = {
     instantiateChildren(instance, xs, t, dur) {
         console.assert(t === instance.begin);
         if (!Array.isArray(xs)) {
-            return failed(instance, t);
+            return failed(instance, t, InputError);
         }
 
         const end = t + min(dur, Duration.get(this));
@@ -1216,7 +1233,14 @@ const SeqFold = {
         instance.children = [];
         instance.capacity = instance.input.length;
         for (let i = 0; i < instance.capacity && t <= end; ++i) {
-            const childInstance = instance.tape.instantiate(this.g(xs[i]), t, end - t, instance);
+            let childItem;
+            try {
+                childItem = this.g(xs[i], i);
+            } catch {
+                return failed(instance, t, InputError);
+            }
+
+            const childInstance = instance.tape.instantiate(childItem, t, end - t, instance);
             if (!childInstance) {
                 for (const childInstance of instance.children) {
                     childInstance.item.pruneInstance(childInstance, t);
@@ -1290,8 +1314,14 @@ const SeqFold = {
             // Constinue instantiation starting from the next child.
             const m = instance.children.length;
             for (let i = m; i < instance.capacity && t <= instance.maxEnd; ++i) {
+                let childItem;
+                try {
+                    childItem = this.g(instance.input[i], i);
+                } catch {
+                    return failed(instance, t, InputError);
+                }
                 const childInstance = instance.tape.instantiate(
-                    this.g(instance.input[i]), t, instance.maxEnd - t, instance
+                    childItem, t, instance.maxEnd - t, instance
                 );
                 if (!childInstance) {
                     for (let j = m; j < i; ++j) {
@@ -1361,7 +1391,11 @@ export function dump(instance, indent = "* ") {
             isFinite(instance.end) ? instance.end : "∞"
         }[` : `@${instance.t}`
     }${
-        instance.failed ? " (failed)" : instance.cancelled ? " (cancelled)" :
+        instance.cancelled ? " (cancelled)" :
+        instance.error === FailureError ? " (failed)" :
+        instance.error === InputError ? " (input error)" :
+        instance.error === TimeoutError ? " (timeout)" :
+        Object.hasOwn(instance, "error") ? ` error<${instance.error.message ?? instance.error}>` :
         Object.hasOwn(instance, "value") ? ` <${instance.value}>` : ""
     }`;
     if (!instance.children) {
@@ -1424,10 +1458,15 @@ function forward(t, interval) {
     }
 
     const item = instance.item;
-    instance.value = item.valueForInstance.call(
-        instance, instance.parent?.item.inputForChildInstance(instance), t, interval
-    );
-    instance.parent?.item.childInstanceDidEnd(instance, endOf(instance));
+    try {
+        instance.value = item.valueForInstance.call(
+            instance, instance.parent?.item.inputForChildInstance(instance), t, interval
+        );
+        instance.parent?.item.childInstanceDidEnd(instance, endOf(instance));
+    } catch (error) {
+        instance.error = error;
+        instance.parent?.item.childInstanceDidFail(instance, t);
+    }
 }
 
 // When an instance is pruned, it erases its occurrence from the tape.
@@ -1444,10 +1483,11 @@ function cancelled(instance, t) {
     instance.tape.removeOccurrenceForInstance(instance);
 }
 
-// When an instance fails, it ends and gets marked as such, notify its parent.
-function failed(instance, t) {
+// An instance may fail with or without an error. In both cases it ends and
+// notifies its parent.
+function failed(instance, t, error = FailureError) {
     ended(instance, t);
-    instance.failed = true;
+    instance.error = error;
     instance.parent?.item.childInstanceDidFail(instance, t);
 }
 

--- a/lib/score.js
+++ b/lib/score.js
@@ -2,6 +2,7 @@ import { assign, create, extend, I, isNumber, nop, partition, push, remove } fro
 import { notify } from "./events.js";
 import { Tape } from "./tape.js";
 
+const CancelError = window.Error("cancel");
 const FailureError = window.Error("failed");
 const InputError = window.Error("input");
 const TimeoutError = window.Error("timeout");
@@ -249,7 +250,7 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
                     this.instanceDidBegin.call(
                         instance, instance.parent?.item.inputForChildInstance(instance), t, interval
                     ).then(value => {
-                        if (!instance.cancelled) {
+                        if (!(instance.error === CancelError)) {
                             v.push(value);
                         }
                         notify(instance.tape.deck, "await", { instance });
@@ -289,7 +290,7 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
                 instance, instance.parent?.item.inputForChildInstance(instance), t, interval
             ).then(value => {
                 const deck = instance.tape.deck;
-                if (!instance.cancelled && !instance.error) {
+                if (!instance.error) {
                     if (hasDuration) {
                         instance.tape.removeOccurrenceForInstance(instance);
                     }
@@ -415,7 +416,7 @@ export const Event = assign((target, event) => extend(Event, { target, event }, 
     // remove the event listener.
     cancelInstance(instance, t) {
         ended(instance, t);
-        instance.cancelled = true;
+        instance.error = CancelError;
         instance.tape.deck.removeEventTarget(instance);
     },
 
@@ -631,7 +632,7 @@ export const Par = assign(children => create().call(Par, { children: children ??
                 }
             }
             ended(instance, t);
-            instance.cancelled = true;
+            instance.error = CancelError;
             // No occurrence to remove for the instance itself.
         }
     },
@@ -1009,7 +1010,7 @@ export const Seq = assign(children => create().call(Seq, { children: children ??
         }
         instance.children.length = instance.currentChildIndex + 1;
         ended(instance, t);
-        instance.cancelled = true;
+        instance.error = CancelError;
     },
 
     // Prune the instance and its children.
@@ -1151,7 +1152,7 @@ const Repeat = assign(child => extend(Repeat, { child }), {
         const currentChild = instance.children.at(-1);
         currentChild.item.cancelInstance(currentChild, t);
         ended(instance, t);
-        instance.cancelled = true;
+        instance.error = CancelError;
     },
 
     // Pruning is even simpler since there are no scheduled children that have
@@ -1387,7 +1388,7 @@ export function dump(instance, indent = "* ") {
             isFinite(instance.end) ? instance.end : "∞"
         }[` : `@${instance.t}`
     }${
-        instance.cancelled ? " (cancelled)" :
+        instance.error === CancelError ? " (cancelled)" :
         instance.error === FailureError ? " (failed)" :
         instance.error === InputError ? " (input error)" :
         instance.error === TimeoutError ? " (timeout)" :
@@ -1475,7 +1476,7 @@ function pruned(instance) {
 // its occurrence from the tape.
 function cancelled(instance, t) {
     ended(instance, t);
-    instance.cancelled = true;
+    instance.error = CancelError;
     instance.tape.removeOccurrenceForInstance(instance);
 }
 

--- a/lib/score.js
+++ b/lib/score.js
@@ -254,10 +254,8 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
                         }
                         notify(instance.tape.deck, "await", { instance });
                     }).catch(error => {
+                        failed(instance, instance.tape.deck.instantAtTime(performance.now()), error);
                         instance.tape.removeOccurrenceForInstance(instance);
-                        instance.end = instance.tape.deck.instantAtTime(performance.now());
-                        instance.error = error;
-                        instance.parent?.item.childInstanceDidFail(instance, instance.end);
                         notify(instance.tape.deck, "await", { instance });
                     });
                 } }),
@@ -303,9 +301,7 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
                 }
                 notify(deck, "await", { instance });
             }).catch(error => {
-                instance.end = instance.tape.deck.instantAtTime(performance.now());
-                instance.error = error;
-                instance.parent?.item.childInstanceDidFail(instance, instance.end);
+                failed(instance, instance.tape.deck.instantAtTime(performance.now()), error);
                 notify(instance.tape.deck, "await", { instance });
             });
         } });
@@ -1483,8 +1479,8 @@ function cancelled(instance, t) {
     instance.tape.removeOccurrenceForInstance(instance);
 }
 
-// An instance may fail with or without an error. In both cases it ends and
-// notifies its parent.
+// When an instance fails, it ends, store the error that caused the failure in
+// the error property and notifies its parent.
 function failed(instance, t, error = FailureError) {
     ended(instance, t);
     instance.error = error;

--- a/tests/await.html
+++ b/tests/await.html
@@ -138,7 +138,7 @@ test("Await(f) constrained by parent; call ends late", async t => {
     t.equal(dump(score.instance),
 `* Score-0 [0, ∞[
   * Par-1 [17, 36[ (failed)
-    * Await-2 [17, 36[ (failed)`, "dump matches");
+    * Await-2 [17, 36[ (timeout)`, "dump matches");
 });
 
 test("Await(f).dur(0)", t => {
@@ -184,7 +184,7 @@ test("Await(f).dur(d); call ends late", async t => {
     await notification(deck, "await");
     t.equal(dump(score.instance),
 `* Score-0 [0, ∞[
-  * Await-1 [17, 40[ (failed)`, "dump matches");
+  * Await-1 [17, 40[ (timeout)`, "dump matches");
 });
 
 test("Await(f).dur(d) constrained by parent; call ends early", async t => {
@@ -211,7 +211,7 @@ test("Await(f).dur(d) constrained by parent; call ends late", async t => {
     t.equal(dump(score.instance),
 `* Score-0 [0, ∞[
   * Par-1 [17, 36[ (failed)
-    * Await-2 [17, 36[ (failed)`, "dump matches");
+    * Await-2 [17, 36[ (timeout)`, "dump matches");
 });
 
 test("Cancel", async t => {
@@ -270,6 +270,31 @@ test("Prune", t => {
   * Seq-4 [17, 36[ (cancelled)
     * Delay-5 [17, 36[ (cancelled)`, "dump matches");
     t.equal(tape.show(), "Tape<17,17,36>", "occurrences were removed from the tape");
+});
+
+test("Runtime error", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    score.add(Await(async () => { throw window.Error("Augh!"); }), 17);
+    deck.now = 18;
+    await notification(deck, "await");
+    t.equal(dump(score.instance),
+`* Score-0 [0, ∞[
+  * Await-1 [17, 18[ error<Augh!>`, "dump matches");
+});
+
+test("Runtime error (with dur)", async t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    score.add(Await(async () => { throw window.Error("Augh!"); }).dur(23), 17);
+    deck.now = 18;
+    await notification(deck, "await");
+    t.equal(dump(score.instance),
+`* Score-0 [0, ∞[
+  * Await-1 [17, 18[ error<Augh!>`, "dump matches");
+    t.equal(tape.show(), "Tape<>", "occurrences were removed from the tape");
 });
 
         </script>

--- a/tests/event.html
+++ b/tests/event.html
@@ -73,7 +73,7 @@ test("Event(target, type) constrained by parent; event occurs late", async t => 
     window.dispatchEvent(new window.Event("synth"));
     t.equal(dump(par),
 `* Par-0 [17, 40[ (failed)
-  * Event-1 [17, 40[ (failed)`, "dump matches");
+  * Event-1 [17, 40[ (timeout)`, "dump matches");
 });
 
 test("Event(target, type).dur(d); event occurs early", async t => {
@@ -92,7 +92,7 @@ test("Event(target, type).dur(d); event occurs late", async t => {
     const event = tape.instantiate(Event(window, "synth").dur(23), 17);
     deck.now = 51;
     window.dispatchEvent(new window.Event("synth"));
-    t.equal(dump(event), "* Event-0 [17, 40[ (failed)", "dump matches");
+    t.equal(dump(event), "* Event-0 [17, 40[ (timeout)", "dump matches");
 });
 
 test("Cancel", t => {

--- a/tests/instant.html
+++ b/tests/instant.html
@@ -135,6 +135,20 @@ test("Effect(f).dur(d)", t => {
   * Effect-2 @40 <ok>`, "dump matches");
 });
 
+test("Runtime error (Instant)", t => {
+    const tape = Tape();
+    const instance = tape.instantiate(Instant(() => { throw window.Error("Augh!"); }), 17);
+    Deck({ tape }).now = 18;
+    t.equal(dump(instance), "* Instant-0 @17 error<Augh!>", "dump matches");
+});
+
+test("Runtime error (Effect)", t => {
+    const tape = Tape();
+    const instance = tape.instantiate(Effect(() => { throw window.Error("Augh!"); }), 17);
+    Deck({ tape }).now = 18;
+    t.equal(dump(instance), "* Effect-0 @17 error<Augh!>", "dump matches");
+});
+
         </script>
     </head>
     <body>

--- a/tests/par-map.html
+++ b/tests/par-map.html
@@ -78,7 +78,7 @@ test("Par.map(g).take(n); fails at runtime when n > input length", t => {
         Instant(xs => xs.map(([i]) => i))
     ]), 17);
     Deck({ tape }).now = 18;
-    t.equal(instance.failed, true, "failed to instantiate map");
+    t.equal(instance.error.message, "failed", "failed to instantiate map");
 });
 
 test("Par.map(g).take(n); n < input length", t => {
@@ -185,7 +185,7 @@ test("Par.map(g).take(n).dur(d); extending duration", t => {
     * Delay-5 [17, 36[ <19>`, "dump matches");
 });
 
-test("Par.map(g) failure", t => {
+test("Par.map(g) failure: input is not an array", t => {
     const tape = Tape();
     const instance = tape.instantiate(Seq([
         Instant(K("oops")),
@@ -195,7 +195,20 @@ test("Par.map(g) failure", t => {
     t.equal(dump(instance),
 `* Seq-0 @17 (failed)
   * Instant-1 @17 <oops>
-  * Par/map-2 @17 (failed)`, "dump matches");
+  * Par/map-2 @17 (input error)`, "dump matches");
+});
+
+test("Par.map(g) failure: could not instantiate input", t => {
+    const tape = Tape();
+    const instance = tape.instantiate(Seq([
+        Instant(K([1, 2, 3])),
+        Par.map(() => { throw window.Error("Augh!"); })
+    ]), 17);
+    Deck({ tape }).now = 18;
+    t.equal(dump(instance),
+`* Seq-0 @17 (failed)
+  * Instant-1 @17 <1,2,3>
+  * Par/map-2 @17 (input error)`, "dump matches");
 });
 
 test("Par.map(g).repeat()", t => {
@@ -298,6 +311,13 @@ test("Prune Par.map", t => {
   * Seq-4 [17, 36[ (cancelled)
     * Delay-5 [17, 36[ (cancelled)`, "dump matches");
     t.equal(tape.show(), "Tape<17,17,36>", "occurrences where removed from the tape");
+});
+
+test("Input error", t => {
+    const tape = Tape();
+    const instance = tape.instantiate(Par.map(Delay), 17);
+    Deck({ tape }).now = 18;
+    t.equal(dump(instance), "* Par/map-0 @17 (input error)", "dump matches");
 });
 
         </script>

--- a/tests/seq-fold.html
+++ b/tests/seq-fold.html
@@ -107,7 +107,7 @@ test("Instantiation failure; child of Seq", t => {
     t.equal(dump(seq),
 `* Seq-0 @17 (failed)
   * Instant-1 @17 <oops>
-  * Seq/fold-2 @17 (failed)`, "dump matches");
+  * Seq/fold-2 @17 (input error)`, "dump matches");
 });
 
 test("Instantiation failure; child of Par", t => {
@@ -121,7 +121,21 @@ test("Instantiation failure; child of Par", t => {
   * Instant-1 @17 <oops>
   * Par-2 @17 (failed)
     * Delay-3 @17 (cancelled)
-    * Seq/fold-4 @17 (failed)`, "dump matches");
+    * Seq/fold-4 @17 (input error)`, "dump matches");
+});
+
+test("Instantiation failure; could not instantiate input", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([
+        Instant(K([1, 2, 3])),
+        Seq.fold(() => { throw window.Error("Augh!"); }),
+        Delay(23)
+    ]), 17);
+    Deck({ tape }).now = 18;
+    t.equal(dump(seq),
+`* Seq-0 @17 (failed)
+  * Instant-1 @17 <1,2,3>
+  * Seq/fold-2 @17 (input error)`, "dump matches");
 });
 
 test("Seq.fold(g, z).repeat(); instantiation failure", t => {
@@ -138,7 +152,7 @@ test("Seq.fold(g, z).repeat(); instantiation failure", t => {
       * Instant-4 @17 <1>
       * Instant-5 @17 <3>
       * Instant-6 @17 <6>
-    * Seq/fold-7 @17 (failed)`, "dump matches");
+    * Seq/fold-7 @17 (input error)`, "dump matches");
 });
 
 test("Seq.fold(g, z).take(n = ∞)", t => {
@@ -169,7 +183,7 @@ test("Seq.fold(g, z).take(n); fails at runtime when n > input length", t => {
         Delay(23)
     ]), 17);
     Deck({ tape }).now = 18;
-    t.equal(seq.failed, true, "failed to instantiate map");
+    t.equal(seq.error.message, "failed", "failed to instantiate map");
 });
 
 test("Seq.fold(g, z).take(n); n < child count", t => {

--- a/tests/seq-map.html
+++ b/tests/seq-map.html
@@ -8,7 +8,7 @@
 
 import { test } from "./test.js";
 import { K } from "../lib/util.js";
-import { Instant, Delay, Par, Seq, dump } from "../lib/score.js";
+import { Instant, Delay, Event, Par, Seq, dump } from "../lib/score.js";
 import { Tape } from "../lib/tape.js";
 import { Deck } from "../lib/deck.js";
 
@@ -70,7 +70,7 @@ test("Seq.map(g).take(n); fails at runtime when n > input length", t => {
     const tape = Tape();
     const seq = tape.instantiate(Seq([Instant(K([31, 19, 23, 41, 37])), Seq.map(Delay).take(7)]), 17);
     Deck({ tape }).now = 18;
-    t.equal(seq.failed, true, "failed to instantiate map");
+    t.equal(seq.error.message, "failed", "failed to instantiate map");
 });
 
 test("Seq.map(g).take(n); n < input length", t => {
@@ -97,6 +97,47 @@ test("Seq.map(g).take(0)", t => {
     t.equal(seq.value, [], "empty list");
 });
 
+test("Seq.map(g) failure; input is not an array", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([Instant(K("oops")), Seq.map(Delay)]), 17);
+    Deck({ tape }).now = 18;
+    t.equal(dump(seq),
+`* Seq-0 @17 (failed)
+  * Instant-1 @17 <oops>
+  * Seq/map-2 @17 (input error)`, "dump matches");
+});
+
+test("Seq.map(g) failure; could not instantiate input", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq([
+        Instant(K([1, 2, 3])),
+        Seq.map(() => { throw window.Error("Augh!"); })
+    ]), 17);
+    Deck({ tape }).now = 18;
+    t.equal(dump(seq),
+`* Seq-0 @17 (failed)
+  * Instant-1 @17 <1,2,3>
+  * Seq/map-2 @17 (input error)`, "dump matches");
+});
+
+test("Seq.map(g) failure; could not instantiate input (after an unresolved duration)", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const seq = tape.instantiate(Seq([
+        Instant(K([1, 2, 3])),
+        Seq.map((_, i) => {
+            if (i > 0) {
+                throw window.Error("Augh!");
+            }
+            return Event(window, "synth");
+        })
+    ]), 17);
+    deck.now = 51;
+    window.dispatchEvent(new window.Event("synth"));
+    deck.now = 52;
+    t.match(dump(seq), /^\* Seq-0 \[17, 51\[ \(failed\)\n  \* Instant-1 @17 <1,2,3>\n  \* Seq\/map-2 \[17, 51\[ \(input error\)\n    \* Event-3 \[17, 51\[ <[^>]+>$/, "dump matches");
+});
+
 test("Seq.map(g) failure", t => {
     const tape = Tape();
     const seq = tape.instantiate(Seq([Instant(K("oops")), Seq.map(Delay)]), 17);
@@ -104,7 +145,7 @@ test("Seq.map(g) failure", t => {
     t.equal(dump(seq),
 `* Seq-0 @17 (failed)
   * Instant-1 @17 <oops>
-  * Seq/map-2 @17 (failed)`, "dump matches");
+  * Seq/map-2 @17 (input error)`, "dump matches");
 });
 
 test("Seq.map(g).repeat(); instantiation", t => {

--- a/tests/seq-map.html
+++ b/tests/seq-map.html
@@ -138,16 +138,6 @@ test("Seq.map(g) failure; could not instantiate input (after an unresolved durat
     t.match(dump(seq), /^\* Seq-0 \[17, 51\[ \(failed\)\n  \* Instant-1 @17 <1,2,3>\n  \* Seq\/map-2 \[17, 51\[ \(input error\)\n    \* Event-3 \[17, 51\[ <[^>]+>$/, "dump matches");
 });
 
-test("Seq.map(g) failure", t => {
-    const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K("oops")), Seq.map(Delay)]), 17);
-    Deck({ tape }).now = 18;
-    t.equal(dump(seq),
-`* Seq-0 @17 (failed)
-  * Instant-1 @17 <oops>
-  * Seq/map-2 @17 (input error)`, "dump matches");
-});
-
 test("Seq.map(g).repeat(); instantiation", t => {
     const tape = Tape();
     const seq = tape.instantiate(Seq([Instant(K([19, 23])), Seq.map(Delay).repeat()]), 17);

--- a/tests/seq.html
+++ b/tests/seq.html
@@ -140,7 +140,7 @@ test("Instantiation; child with unresolved duration; failure once the end is res
   * Par/map-2 [17, 40[ <23>
     * Delay-3 [17, 40[ <23>
   * Instant-4 @40 <ko>
-  * Par/map-5 @40 (failed)`, "dump matches");
+  * Par/map-5 @40 (input error)`, "dump matches");
 });
 
 test("Instantiation failure", t => {
@@ -164,7 +164,7 @@ test("Child failure (not the last child)", async t => {
     await notification(deck, "await");
     t.equal(dump(seq),
 `* Seq-0 [17, 36[ (failed)
-  * Await-1 [17, 36[ (failed)`, "dump matches");
+  * Await-1 [17, 36[ (timeout)`, "dump matches");
 });
 
 test("Cancel Seq", t => {


### PR DESCRIPTION
Instead of simply failing, items can have an error result. Five kinds of errors are introduced: runtime errors (for Instant, Effect and Await; these can occur if the corresponding function throws an exception), input errors (for Par.map, Seq.fold and Seq.map; these can occur if the input is not an array, or the items for the input cannot be created), timeout errors (for Await and Event; there can occur when the item is cut off before the call finishes or the event occurs), CancelError (for any cancelled instance), and FailureError (for failible items).

When such an error occurs, the instance ends with its `error` property set to the underlying error instead, instead of simply setting `failed` to true.