### PR TITLE
Remove childInstanceDidFail

### DIFF
--- a/lib/score.js
+++ b/lib/score.js
@@ -47,20 +47,13 @@ export const Score = Object.assign(properties => create(properties).call(Score),
     // Send a notification with the value of the child instance when it ends.
     childInstanceDidEnd(childInstance) {
         console.assert(childInstance.parent === this.instance);
-        notify(this.tape, "end", {
-            t: endOf(childInstance),
-            item: childInstance.item,
-            value: childInstance.value,
-        });
-    },
-
-    // Send a notification for a child that fails.
-    childInstanceDidFail(childInstance) {
-        console.assert(childInstance.parent === this.instance);
-        notify(this.tape, "fail", {
-            t: endOf(childInstance),
-            item: childInstance.item
-        });
+        const event = { t: endOf(childInstance), item: childInstance.item };
+        if (childInstance.error) {
+            event.error = childInstance.error;
+        } else {
+            event.value = childInstance.value;
+        }
+        notify(this.tape, "end", event);
     },
 
     inputForChildInstance: nop,
@@ -265,11 +258,10 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
                     console.assert(t === instance.end);
                     if (v.length === 1) {
                         instance.value = v[0];
-                        instance.parent?.item.childInstanceDidEnd(instance, t);
                     } else {
                         instance.error = TimeoutError;
-                        instance.parent?.item.childInstanceDidFail(instance, t);
                     }
+                    instance.parent?.item.childInstanceDidEnd(instance, t);
                 } })
             ];
         }
@@ -373,11 +365,10 @@ export const Event = assign((target, event) => extend(Event, { target, event }, 
                 delete instance.delayedEvent;
                 if (value) {
                     instance.value = value;
-                    instance.parent?.item.childInstanceDidEnd(instance, t);
                 } else {
                     instance.error = TimeoutError;
-                    instance.parent?.item.childInstanceDidFail(instance, t);
                 }
+                instance.parent?.item.childInstanceDidEnd(instance, t);
             } });
         }
 
@@ -566,14 +557,34 @@ export const Par = assign(children => create().call(Par, { children: children ??
             // The instance has already finished (this is a lingering effect).
             return;
         }
-        instance.finished.push(childInstance);
-        if (instance.finished.length === instance.capacity) {
-            for (const child of instance.children) {
-                if (instance.finished.indexOf(child) < 0) {
-                    child.item.cancelInstance(child, t);
+
+        // When a child fails at runtime, the par itself may fail if not enough
+        // children can succeed to fill its capacity.
+        if (instance.error) {
+            const n = Capacity.get(this);
+            if (instance.children.length - 1 >= n) {
+                // It is still possible to recover from this failure
+                remove(instance.children, childInstance);
+            } else {
+                // Cancel all the other children and fail
+                for (const child of instance.children) {
+                    if (child !== childInstance && !Object.hasOwn(child, "value")) {
+                        child.item.cancelInstance(child, t);
+                    }
                 }
+                delete instance.finished;
+                failed(instance, t);
             }
-            ended(instance, t, this.valueForInstance.call(instance));
+        } else {
+            instance.finished.push(childInstance);
+            if (instance.finished.length === instance.capacity) {
+                for (const child of instance.children) {
+                    if (instance.finished.indexOf(child) < 0) {
+                        child.item.cancelInstance(child, t);
+                    }
+                }
+                ended(instance, t, this.valueForInstance.call(instance));
+            }
         }
     },
 
@@ -596,27 +607,6 @@ export const Par = assign(children => create().call(Par, { children: children ??
                 }
                 instance.parent?.item.childInstanceEndWasResolved(instance, end);
             }
-        }
-    },
-
-    // When a child fails at runtime, the par itself may fail if not enough
-    // children can succeed to fill its capacity.
-    childInstanceDidFail(childInstance, t) {
-        const instance = childInstance.parent;
-        console.assert(instance.item === this);
-        const n = Capacity.get(this);
-        if (instance.children.length - 1 >= n) {
-            // It is still possible to recover from this failure
-            remove(instance.children, childInstance);
-        } else {
-            // Cancel all the other children and fail
-            for (const child of instance.children) {
-                if (child !== childInstance && !Object.hasOwn(child, "value")) {
-                    child.item.cancelInstance(child, t);
-                }
-            }
-            delete instance.finished;
-            failed(instance, t);
         }
     },
 
@@ -971,31 +961,30 @@ export const Seq = assign(children => create().call(Seq, { children: children ??
     childInstanceDidEnd(childInstance, t) {
         const instance = childInstance.parent;
         console.assert(instance.item === this);
-        console.assert(instance.children[instance.currentChildIndex] === childInstance);
-        instance.currentChildIndex += 1;
-        if (instance.currentChildIndex === instance.capacity) {
-            instance.value = this.valueForInstance.call(instance);
-            if (!Duration.has(instance.item)) {
-                instance.end = t;
-            }
-            instance.parent?.item.childInstanceDidEnd(instance, instance.end);
-            delete instance.currentChildIndex;
-        }
-    },
 
-    // Fail if a child fails; prune all children following the failed child.
-    childInstanceDidFail(childInstance, t) {
-        const instance = childInstance.parent;
-        console.assert(instance.item === this);
-        const n = instance.currentChildIndex + 1;
-        for (let i = n; i < instance.children.length; ++i) {
-            const child = instance.children[i];
-            child.item.pruneInstance(child, t);
-            delete child.parent;
+        // Fail if a child fails; prune all children following the failed child.
+        if (childInstance.error) {
+            const n = instance.currentChildIndex + 1;
+            for (let i = n; i < instance.children.length; ++i) {
+                const child = instance.children[i];
+                child.item.pruneInstance(child, t);
+                delete child.parent;
+            }
+            instance.children.length = n;
+            failed(instance, t);
+            delete instance.currentChildIndex;
+        } else {
+            console.assert(instance.children[instance.currentChildIndex] === childInstance);
+            instance.currentChildIndex += 1;
+            if (instance.currentChildIndex === instance.capacity) {
+                instance.value = this.valueForInstance.call(instance);
+                if (!Duration.has(instance.item)) {
+                    instance.end = t;
+                }
+                instance.parent?.item.childInstanceDidEnd(instance, instance.end);
+                delete instance.currentChildIndex;
+            }
         }
-        instance.children.length = n;
-        delete instance.currentChildIndex;
-        failed(instance, t);
     },
 
     // Cancel the current child instance and prune the following ones. There is
@@ -1115,35 +1104,34 @@ const Repeat = assign(child => extend(Repeat, { child }), {
     childInstanceDidEnd(childInstance, t) {
         const instance = childInstance.parent;
         console.assert(instance.item === this);
-        if (childInstance.cutoff) {
-            delete childInstance.cutoff;
-            if (isFinite(instance.capacity)) {
-                return failed(instance, t);
-            }
-            instance.cutoff = true;
-            return ended(instance, t, childInstance.value);
-        }
 
-        if (instance.children.length > RepeatMax) {
-            // This is just for debug purposes and should be removed eventually.
-            throw window.Error("Too many repeats");
-        }
-        if (instance.children.length === instance.capacity) {
-            instance.parent?.item.childInstanceEndWasResolved(instance, t);
-            ended(instance, t, childInstance.value);
+        // Fail if the child fails.
+        if (childInstance.error) {
+            console.assert(childInstance === instance.children.at(-1));
+            failed(instance, t);
         } else {
-            instance.children.push(
-                instance.tape.instantiate(this.child, t, instance.maxEnd - t, instance)
-            );
-        }
-    },
+            if (childInstance.cutoff) {
+                delete childInstance.cutoff;
+                if (isFinite(instance.capacity)) {
+                    return failed(instance, t);
+                }
+                instance.cutoff = true;
+                return ended(instance, t, childInstance.value);
+            }
 
-    // Fail if the child fails.
-    childInstanceDidFail(childInstance, t) {
-        const instance = childInstance.parent;
-        console.assert(instance.item === this);
-        console.assert(childInstance === instance.children.at(-1));
-        failed(instance, t);
+            if (instance.children.length > RepeatMax) {
+                // This is just for debug purposes and should be removed eventually.
+                throw window.Error("Too many repeats");
+            }
+            if (instance.children.length === instance.capacity) {
+                instance.parent?.item.childInstanceEndWasResolved(instance, t);
+                ended(instance, t, childInstance.value);
+            } else {
+                instance.children.push(
+                    instance.tape.instantiate(this.child, t, instance.maxEnd - t, instance)
+                );
+            }
+        }
     },
 
     // Cancelling a repeat is a simpler version of cancelling a Seq as only
@@ -1358,7 +1346,6 @@ const SeqFold = {
     },
 
     childInstanceDidEnd: Seq.childInstanceDidEnd,
-    childInstanceDidFail: Seq.childInstanceDidFail,
     cancelInstance: Seq.cancelInstance,
     pruneInstance: Seq.pruneInstance,
 };
@@ -1459,11 +1446,10 @@ function forward(t, interval) {
         instance.value = item.valueForInstance.call(
             instance, instance.parent?.item.inputForChildInstance(instance), t, interval
         );
-        instance.parent?.item.childInstanceDidEnd(instance, endOf(instance));
     } catch (error) {
         instance.error = error;
-        instance.parent?.item.childInstanceDidFail(instance, t);
     }
+    instance.parent?.item.childInstanceDidEnd(instance, endOf(instance));
 }
 
 // When an instance is pruned, it erases its occurrence from the tape.
@@ -1485,7 +1471,7 @@ function cancelled(instance, t) {
 function failed(instance, t, error = FailureError) {
     ended(instance, t);
     instance.error = error;
-    instance.parent?.item.childInstanceDidFail(instance, t);
+    instance.parent?.item.childInstanceDidEnd(instance, t);
 }
 
 // When an instance has ended, its end or t property gets updated and its value

--- a/lib/score.js
+++ b/lib/score.js
@@ -560,7 +560,7 @@ export const Par = assign(children => create().call(Par, { children: children ??
 
         // When a child fails at runtime, the par itself may fail if not enough
         // children can succeed to fill its capacity.
-        if (instance.error) {
+        if (childInstance.error) {
             const n = Capacity.get(this);
             if (instance.children.length - 1 >= n) {
                 // It is still possible to recover from this failure

--- a/tests/deck.html
+++ b/tests/deck.html
@@ -125,10 +125,11 @@ test("running updates (failure)", async t => {
     const seq = score.add(Seq([Delay(100), Instant(), Par.map(Delay)]));
     const phi = performance.now();
     deck.start();
-    const { item } = await notification(tape, "fail");
+    const { item, error } = await notification(tape, "end");
     const end = performance.now() - phi;
     t.atLeast(end, 100, `Item ended at φ = ${end}`);
     t.equal(item, seq, "Seq failed");
+    t.ok(error, "with an error");
 });
 
 test("running updates (after the tape has started)", async t => {

--- a/tests/score.html
+++ b/tests/score.html
@@ -7,10 +7,11 @@
         <script type="module">
 
 import { test } from "./test.js";
+import { on } from "../lib/events.js";
 import { K } from "../lib/util.js";
 import { Deck } from "../lib/deck.js";
 import { Tape } from "../lib/tape.js";
-import { Score, Instant, Delay, dump } from "../lib/score.js";
+import { Score, Instant, Delay, Event, Seq, dump } from "../lib/score.js";
 
 test("Score()", t => {
     const score = Score();
@@ -69,6 +70,30 @@ test("Score.add(child, at)", t => {
 `* Score-0 [0, ∞[
   * Instant-1 @0 <ok>
   * Delay-2 [17, 40[ <undefined>`, "dump matches");
+});
+
+test("Notification when a child instance ends (with value)", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    const seq = score.add(Seq([Instant(K("ok")), Delay(23)]), 17);
+    let event;
+    on(tape, "end", e => { event = e; });
+    deck.now = 41;
+    t.equal(event.item, seq, "Notification from item");
+    t.equal(event.value, "ok", "Value");
+});
+
+test("Notification when a child instance ends (with failure)", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const score = Score({ tape });
+    const seq = score.add(Seq([Instant(K("ok")), Event(window, "synth").dur(23)]), 17);
+    let event;
+    on(tape, "end", e => { event = e; });
+    deck.now = 41;
+    t.equal(event.item, seq, "Notification from item");
+    t.ok(event.error, "Error (timeout)");
 });
 
         </script>


### PR DESCRIPTION
We only need childInstanceDidEnd, with a value on success, or an error on failure. Added a couple tests for the tape end event.