### PR TITLE
Util: parseTime

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -173,14 +173,14 @@ export const nop = () => {};
 // Units are week (w), day (d), hour (h), minute (m), second (s) and millisecond
 // (ms). Unitless values default to ms (e.g., "500" is 500ms), and strings can
 // contain several units ("1m 30s" is 90000ms).
-const Units = { s: 1000, ms: 1 };
+const Units = { s: 1000, ms: 1, "": 1 };
 Units.m = 60 * Units.s;
 Units.h = 60 * Units.m;
 Units.d = 24 * Units.h;
 Units.w = 7 * Units.d;
 
 export function parseTime(string) {
-    const [t, rest] = ["w", "d", "h", "m", "s", "ms"].reduce(([t, rest], unit) => {
+    const [t, rest] = ["w", "d", "h", "m", "s", "ms", ""].reduce(([t, rest], unit) => {
         const match = rest.match(new RegExp(`^\\s*(\\d+(?:\\.\\d+)?)\\s*${unit}\\b`, "i"));
         return match ? [t + parseFloat(match[1]) * Units[unit], rest.slice(match[0].length)] : [t, rest];
     }, [0, string]);

--- a/lib/util.js
+++ b/lib/util.js
@@ -169,6 +169,27 @@ export const mod = (a, n) => a - n * Math.floor(a / n);
 // Do nothing.
 export const nop = () => {};
 
+// Parse time values into a number of milliseconds.
+// Units are week (w), day (d), hour (h), minute (m), second (s) and millisecond
+// (ms). Unitless values default to ms (e.g., "500" is 500ms), and strings can
+// contain several units ("1m 30s" is 90000ms).
+const Units = { s: 1000, ms: 1 };
+Units.m = 60 * Units.s;
+Units.h = 60 * Units.m;
+Units.d = 24 * Units.h;
+Units.w = 7 * Units.d;
+
+export function parseTime(string) {
+    const [t, rest] = ["w", "d", "h", "m", "s", "ms"].reduce(([t, rest], unit) => {
+        const match = rest.match(new RegExp(`^\\s*(\\d+(?:\\.\\d+)?)\\s*${unit}\\b`, "i"));
+        return match ? [t + parseFloat(match[1]) * Units[unit], rest.slice(match[0].length)] : [t, rest];
+    }, [0, string]);
+    if (/\S/.test(rest)) {
+        throw Error(`unable to parse "${string}"; went as far as "${rest}".`);
+    }
+    return t;
+}
+
 // Partition an array into two arrays according to a predicate. The first
 // array of the pair contains all items from the source array for which the
 // predicate is true, and the second array the items for which it is false.

--- a/tests/util.html
+++ b/tests/util.html
@@ -10,8 +10,8 @@ import { test } from "./test.js";
 import {
     add, addBy, assign, assoc, clamp, create, cycle, escapeMarkup, extend, flip,
     fold1, get, I, imagePromise, isAsync, isEmpty, isIterable, isNumber,
-    isObject, K, mod, nop, partition, push, range, remove, shuffle, sign,
-    single, snd, timeout, todo, typeOf
+    isObject, K, mod, nop, parseTime, partition, push, range, remove, shuffle,
+    sign, single, snd, timeout, todo, typeOf
 } from "../lib/util.js";
 
 test("add(collection, item/key, value?)", t => {
@@ -249,6 +249,20 @@ test("mod(x, m)", t => {
 
 test("nop()", t => {
     t.undefined(nop());
+});
+
+test("parseTime(string)", t => {
+    t.equal(parseTime("365.25d"), 31557600000, "1 average year = 31,557,600,000 ms");
+    t.equal(parseTime("1w"), 604800000, "1 week = 604,800,000 ms");
+    t.equal(parseTime("1d"), 86400000, "1 day = 86,400,000 ms");
+    t.equal(parseTime("1h"), 3600000, "1 hour = 3,600,000 ms");
+    t.equal(parseTime("1m"), 60000, "1 minute = 60,000 ms");
+    t.equal(parseTime("1s"), 1000, "1 second = 1,000 ms");
+    t.equal(parseTime("1ms"), 1, "1 ms = 1 ms");
+    t.equal(parseTime(""), 0, "nothing = 0ms");
+    t.equal(parseTime(" 2.5 H 10s  "), 3600000 * 2.5 + 10000, "several units in the right order");
+    t.throws(() => { parseTime(" 10s  2H "); }, "several units in the wrong order");
+    t.throws(() => { parseTime("one week"); }, "unexpected format");
 });
 
 test("partition(xs, p)", t => {

--- a/tests/util.html
+++ b/tests/util.html
@@ -260,6 +260,7 @@ test("parseTime(string)", t => {
     t.equal(parseTime("1s"), 1000, "1 second = 1,000 ms");
     t.equal(parseTime("1ms"), 1, "1 ms = 1 ms");
     t.equal(parseTime(""), 0, "nothing = 0ms");
+    t.equal(parseTime("500"), 500, "ms is the default unit");
     t.equal(parseTime(" 2.5 H 10s  "), 3600000 * 2.5 + 10000, "several units in the right order");
     t.throws(() => { parseTime(" 10s  2H "); }, "several units in the wrong order");
     t.throws(() => { parseTime("one week"); }, "unexpected format");


### PR DESCRIPTION
Parse a string into a time in millisecond for more user friendly time input.