### PR TITLE
1O03 Esc to cancel drag

### DIFF
--- a/patcher/patcher.js
+++ b/patcher/patcher.js
@@ -22,20 +22,24 @@ const DragEventListener = {
                 this.target.dragDidProgress?.(x - this.x0, y - this.y0, x, y);
                 break;
             case "pointercancel":
-                this.target.dragWasCancelled?.();
+                this.dragWasCancelled();
                 // Fallthrough
             case "pointerup":
-                this.draggingDidEnd();
+                this.dragDidEnd();
                 break;
             case "keyup":
                 if (event.key === "Escape") {
-                    this.target.dragWasCancelled?.();
-                    this.draggingDidEnd();
+                    this.dragWasCancelled();
+                    this.dragDidEnd();
                 }
         }
     },
 
-    draggingDidEnd() {
+    dragWasCancelled() {
+        this.target.dragWasCancelled?.();
+    },
+
+    dragDidEnd() {
         this.target.dragDidEnd?.();
         delete this.x0;
         delete this.y0;

--- a/patcher/patcher.js
+++ b/patcher/patcher.js
@@ -8,6 +8,7 @@ const DragEventListener = {
                 document.addEventListener("pointermove", this);
                 document.addEventListener("pointerup", this);
                 document.addEventListener("pointercancel", this);
+                document.addEventListener("keyup", this);
                 event.preventDefault();
                 event.stopPropagation();
                 this.x0 = event.clientX;
@@ -24,14 +25,25 @@ const DragEventListener = {
                 this.target.dragWasCancelled?.();
                 // Fallthrough
             case "pointerup":
-                this.target.dragDidEnd?.();
-                delete this.x0;
-                delete this.y0;
-                delete this.target;
-                document.removeEventListener("pointermove", this);
-                document.removeEventListener("pointerup", this);
-                document.removeEventListener("pointercancel", this);
+                this.draggingDidEnd();
+                break;
+            case "keyup":
+                if (event.key === "Escape") {
+                    this.target.dragWasCancelled?.();
+                    this.draggingDidEnd();
+                }
         }
+    },
+
+    draggingDidEnd() {
+        this.target.dragDidEnd?.();
+        delete this.x0;
+        delete this.y0;
+        delete this.target;
+        document.removeEventListener("pointermove", this);
+        document.removeEventListener("pointerup", this);
+        document.removeEventListener("pointercancel", this);
+        document.removeEventListener("keyup", this);
     }
 };
 
@@ -433,7 +445,7 @@ export const App = {
             case "keyup":
                 // Execute the command associated with the key (when not
                 // otherwise editing).
-                if (!this.editItem) {
+                if (!this.editItem && !DragEventListener.target) {
                     this.commands[event.key]?.call(this);
                 }
                 break;


### PR DESCRIPTION
Pressing Escape will cancel a drag gesture—intended to cancel drawing a new cord, but will also cancel a box move. Also disable keyboard commands while a drag gesture is in progress (so no creating a new box while dragging).