### PR TITLE
1O0B More flexible time units

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -173,16 +173,19 @@ export const nop = () => {};
 // Units are week (w), day (d), hour (h), minute (m), second (s) and millisecond
 // (ms). Unitless values default to ms (e.g., "500" is 500ms), and strings can
 // contain several units ("1m 30s" is 90000ms).
-const Units = { s: 1000, ms: 1, "": 1 };
-Units.m = 60 * Units.s;
-Units.h = 60 * Units.m;
-Units.d = 24 * Units.h;
-Units.w = 7 * Units.d;
+const Units = [
+    ["w|wk|weeks?", 7 * 24 * 60 * 60 * 1000],
+    ["d|days?", 24 * 60 * 60 * 1000],
+    ["h|hr|hours?", 60 * 60 * 1000],
+    ["m|mn|min(:?utes?)?", 60 * 1000],
+    ["s|seconds?", 1000],
+    ["(:?ms)?", 1],
+];
 
 export function parseTime(string) {
-    const [t, rest] = ["w", "d", "h", "m", "s", "ms", ""].reduce(([t, rest], unit) => {
-        const match = rest.match(new RegExp(`^\\s*(\\d+(?:\\.\\d+)?)\\s*${unit}\\b`, "i"));
-        return match ? [t + parseFloat(match[1]) * Units[unit], rest.slice(match[0].length)] : [t, rest];
+    const [t, rest] = Units.reduce(([t, rest], [unit, ms]) => {
+        const match = rest.match(new RegExp(`^\\s*(\\d+(?:\\.\\d+)?)\\s*(?:${unit})\\b`, "i"));
+        return match ? [t + parseFloat(match[1]) * ms, rest.slice(match[0].length)] : [t, rest];
     }, [0, string]);
     if (/\S/.test(rest)) {
         throw Error(`unable to parse "${string}"; went as far as "${rest}".`);

--- a/tests/util.html
+++ b/tests/util.html
@@ -252,17 +252,30 @@ test("nop()", t => {
 });
 
 test("parseTime(string)", t => {
-    t.equal(parseTime("365.25d"), 31557600000, "1 average year = 31,557,600,000 ms");
-    t.equal(parseTime("1w"), 604800000, "1 week = 604,800,000 ms");
-    t.equal(parseTime("1d"), 86400000, "1 day = 86,400,000 ms");
-    t.equal(parseTime("1h"), 3600000, "1 hour = 3,600,000 ms");
-    t.equal(parseTime("1m"), 60000, "1 minute = 60,000 ms");
-    t.equal(parseTime("1s"), 1000, "1 second = 1,000 ms");
+    t.equal(parseTime("365 days 6hr"), 31557600000, "1 average year = 31,557,600,000 ms");
+    t.equal(parseTime("1w"), 604800000, "1w = 604,800,000 ms");
+    t.equal(parseTime("1 week"), 604800000, "1 week = 604,800,000 ms");
+    t.equal(parseTime("2 weeks"), 1209600000, "2 weeks = 1,209,600,000 ms");
+    t.equal(parseTime("1d"), 86400000, "1d = 86,400,000 ms");
+    t.equal(parseTime("1 day"), 86400000, "1 day = 86,400,000 ms");
+    t.equal(parseTime("2 days"), 172800000, "2 days = 172,800,000 ms");
+    t.equal(parseTime("1h"), 3600000, "1h = 3,600,000 ms");
+    t.equal(parseTime("1 hr"), 3600000, "1 hr = 3,600,000 ms");
+    t.equal(parseTime("1 hour"), 3600000, "1 hour = 3,600,000 ms");
+    t.equal(parseTime("2 hours"), 7200000, "2 hours = 7,200,000 ms");
+    t.equal(parseTime("1m"), 60000, "1m = 60,000 ms");
+    t.equal(parseTime("1 mn"), 60000, "1 mn = 60,000 ms");
+    t.equal(parseTime("1 min"), 60000, "1 min = 60,000 ms");
+    t.equal(parseTime("1 minute"), 60000, "1 minute = 60,000 ms");
+    t.equal(parseTime("2 minutes"), 120000, "2 minutes = 120,000 ms");
+    t.equal(parseTime("1s"), 1000, "1s = 1,000 ms");
+    t.equal(parseTime("1 second"), 1000, "1 second = 1,000 ms");
+    t.equal(parseTime("2 seconds"), 2000, "2 seconds = 2,000 ms");
     t.equal(parseTime("1ms"), 1, "1 ms = 1 ms");
     t.equal(parseTime(""), 0, "nothing = 0ms");
     t.equal(parseTime("500"), 500, "ms is the default unit");
-    t.equal(parseTime(" 2.5 H 10s  "), 3600000 * 2.5 + 10000, "several units in the right order");
-    t.throws(() => { parseTime(" 10s  2H "); }, "several units in the wrong order");
+    t.equal(parseTime(" 2 hr 30 mn 10 S  "), 3600000 * 2.5 + 10000, "several units in the right order");
+    t.throws(() => { parseTime(" 10 min  2H "); }, "several units in the wrong order");
     t.throws(() => { parseTime("one week"); }, "unexpected format");
 });
 


### PR DESCRIPTION
Allow longer form for time units such as mn, min, minutes, &c.