### PR TITLE
1P0A `parseTime("1h32mn")` fails

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -170,21 +170,21 @@ export const mod = (a, n) => a - n * Math.floor(a / n);
 export const nop = () => {};
 
 // Parse time values into a number of milliseconds.
-// Units are week (w), day (d), hour (h), minute (m), second (s) and millisecond
+// Units are week (w), day (d), hour (h), minute (mn), second (s) and millisecond
 // (ms). Unitless values default to ms (e.g., "500" is 500ms), and strings can
 // contain several units ("1m 30s" is 90000ms).
 const Units = [
-    ["w|wk|weeks?", 7 * 24 * 60 * 60 * 1000],
-    ["d|days?", 24 * 60 * 60 * 1000],
-    ["h|hr|hours?", 60 * 60 * 1000],
-    ["m|mn|min(:?utes?)?", 60 * 1000],
-    ["s|seconds?", 1000],
+    ["weeks?|wk?", 7 * 24 * 60 * 60 * 1000],
+    ["days?|d", 24 * 60 * 60 * 1000],
+    ["hours?|hr?", 60 * 60 * 1000],
+    ["min(:?utes?)?|mn", 60 * 1000],
+    ["seconds?|s", 1000],
     ["(:?ms)?", 1],
 ];
 
 export function parseTime(string) {
     const [t, rest] = Units.reduce(([t, rest], [unit, ms]) => {
-        const match = rest.match(new RegExp(`^\\s*(\\d+(?:\\.\\d+)?)\\s*(?:${unit})\\b`, "i"));
+        const match = rest.match(new RegExp(`^\\s*(\\d+(?:\\.\\d+)?)\\s*(?:${unit})`, "i"));
         return match ? [t + parseFloat(match[1]) * ms, rest.slice(match[0].length)] : [t, rest];
     }, [0, string]);
     if (/\S/.test(rest)) {

--- a/tests/util.html
+++ b/tests/util.html
@@ -263,8 +263,7 @@ test("parseTime(string)", t => {
     t.equal(parseTime("1 hr"), 3600000, "1 hr = 3,600,000 ms");
     t.equal(parseTime("1 hour"), 3600000, "1 hour = 3,600,000 ms");
     t.equal(parseTime("2 hours"), 7200000, "2 hours = 7,200,000 ms");
-    t.equal(parseTime("1m"), 60000, "1m = 60,000 ms");
-    t.equal(parseTime("1 mn"), 60000, "1 mn = 60,000 ms");
+    t.equal(parseTime("1mn"), 60000, "1 mn = 60,000 ms");
     t.equal(parseTime("1 min"), 60000, "1 min = 60,000 ms");
     t.equal(parseTime("1 minute"), 60000, "1 minute = 60,000 ms");
     t.equal(parseTime("2 minutes"), 120000, "2 minutes = 120,000 ms");
@@ -274,7 +273,9 @@ test("parseTime(string)", t => {
     t.equal(parseTime("1ms"), 1, "1 ms = 1 ms");
     t.equal(parseTime(""), 0, "nothing = 0ms");
     t.equal(parseTime("500"), 500, "ms is the default unit");
-    t.equal(parseTime(" 2 hr 30 mn 10 S  "), 3600000 * 2.5 + 10000, "several units in the right order");
+    t.equal(parseTime(" 2 hr 30 mn 10 S  "), 9010000, "several units in the right order");
+    t.equal(parseTime("2hr30mn10s"), 9010000, "no spaces");
+    t.throws(() => { parseTime("2hr:30mn:10s"); }, "extra separators");
     t.throws(() => { parseTime(" 10 min  2H "); }, "several units in the wrong order");
     t.throws(() => { parseTime("one week"); }, "unexpected format");
 });


### PR DESCRIPTION
Fixed the regex to allow strings without spaces; mn is the short form for minute now instead of m.