### PR TITLE
1O07 "plaintext-only" not supported in Firefox

### DIFF
--- a/patcher/box.js
+++ b/patcher/box.js
@@ -84,7 +84,12 @@ export const Box = assign(properties => create(properties).call(Box), {
 
     toggleEditing(editing) {
         if (editing) {
-            this.input.contentEditable = "plaintext-only";
+            try {
+                this.input.contentEditable = "plaintext-only";
+            } catch (_) {
+                // Firefox (for instance) does not support "plaintext-only"
+                this.input.contentEditable = true;
+            }
             this.input.addEventListener("keyup", this);
             window.setTimeout(() => {
                 this.input.focus();

--- a/patcher/style.css
+++ b/patcher/style.css
@@ -11,7 +11,7 @@ svg.canvas {
 }
 
 body, text {
-    font-family: ui-sans-serif;
+    font-family: ui-sans-serif, sans-serif;
     font-size: 16px;
 }
 


### PR DESCRIPTION
Use `true` instead, parsing should do the rest of the cleanup.