### PR TITLE
1O06 EZ container children

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ choice(
         choice(
             Seq(Delay(10000), Send(skip)),
             Event(playButton, "click")
-        )
+        ),
         Video(src)
     )
 );

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ This plays the video when the user clicks on a play button. The Video element is
 (sequence) container, and follows an Event element that waits for a click event from an HTML button.
 
 ```
-Seq([
+Seq(
     Event(playButton, "click"),
     Video(src)
-]);
+);
 ```
 
 A more complex example adds a 10s (or 10,000ms) timeout so that the video is skipped if the user does
@@ -44,16 +44,16 @@ built. This example should then be expressible more succinctly; `choice` itself 
 as will be shown below.
 
 ```
-choice([
+choice(
     Receive(skip),
-    Seq([
-        choice([
-            Seq([Delay(10000), Send(skip)]),
+    Seq(
+        choice(
+            Seq(Delay(10000), Send(skip)),
             Event(playButton, "click")
-        ]),
+        )
         Video(src)
-    ])
-]);
+    )
+);
 ```
 
 Another example is [ABRO](http://www1.cs.columbia.edu/~sedwards/classes/2002/w4995-02/esterel.pdf), the
@@ -65,10 +65,10 @@ Esterel, the solution only grows linearly:
 
 ```
 choice(
-    Seq([
-        Par([Receive(A), Receive(B)]),
+    Seq(
+        Par(Receive(A), Receive(B)),
         Send(O),
-    ]).dur(Infinity),
+    ).dur(Infinity),
     Receive(R)
 ).repeat()
 ```
@@ -79,7 +79,7 @@ ensures that further A and B events are ignored until R is received. And requiri
 sending O is simply a matter of modifying the Par element, so this can turn into ABCRO with:
 
 ```
-Par([Receive(A), Receive(B), Receive(C)])
+Par(Receive(A), Receive(B), Receive(C))
 ```
 
 ## Timing and synchronization model
@@ -102,7 +102,7 @@ finishes, and finishing with the last one.
 These elements can be further modified through the use of the following modifiers:
 
 * `repeat()`: repeats an element indefinitely, producing an inifinite sequence. `x.repeat()` is the same
-as `Seq([x, x, ...])`.
+as `Seq(x, x, ...)`.
 * `take(n)` applies to Par, Seq or repeat and finishes when _n_ ≥ 0 child elements have finished, or all
 elements by default.
     * `Par(xs).take(n)` selects the _n_ elements from _xs_ that finish first and cancels the rest of the
@@ -113,7 +113,7 @@ elements by default.
     * `Seq(xs).take(n)` cuts the sequence short by taking only the first n steps. `Seq(xs).take()` is the
     same as just `Seq(xs)`.
     * It is possible to limit the number of occurrences of `repeat()` with `take(n)`:
-    `x.repeate().take(3)` is the same as `Seq([x, x, x])`.
+    `x.repeate().take(3)` is the same as `Seq(x, x, x)`.
 * `dur(d)` applies to any item (except Delay), and sets the duration to exactly _d_ ≥ 0. If the natural
 duration of the element is less than _d_, then it is padded as if a Delay was added to it. If the natural
 duration of the element is more than _d_, then it is cut off earlier and the children that have not
@@ -145,14 +145,14 @@ can be used to sum all elements of an input list one by one. Given the input `[1
 equivalent to
 
 ```
-Seq([Instant(() => 0), Instant(y => 1 + y), Instant(y => 2 + y), Instant(y => 3 + y)])
+Seq(Instant(() => 0), Instant(y => 1 + y), Instant(y => 2 + y), Instant(y => 3 + y))
 ```
 
 The custom `choice` combinator used in the introduction can be defined as a the following combination
 of elements and modifiers:
 
 ```
-const choice = (x, y) => Seq([Par([x, y]).take(1), Instant(([x]) => x));
+const choice = (x, y) => Seq(Par(x, y).take(1), Instant(([x]) => x));
 ```
 
 Note that because `Par().take(1)` creates a list of a single value, `Instant(([x] => x))` is used to

--- a/lib/score.js
+++ b/lib/score.js
@@ -69,7 +69,7 @@ export const Instant = assign(f => f ? extend(Instant, { valueForInstance: f }) 
 
     // If a valid duration is set, then this is wrapped into a Seq.
     dur(d) {
-        return d > 0 ? Seq([Delay(d), this]) : this;
+        return d > 0 ? Seq(Delay(d), this) : this;
     },
 
     // An instant has no duration.
@@ -429,7 +429,7 @@ export const Event = assign((target, event) => extend(Event, { target, event }, 
 // can be modified with take(), in which case the result values are
 // in the order in which the children finished. Fails if too many children
 // fail. Repeatable (as long as the duration is non zero).
-export const Par = assign(children => create().call(Par, { children: children ?? [] }), {
+export const Par = assign((...children) => create().call(Par, { children }), {
     tag: "Par",
     show,
     repeat,
@@ -737,7 +737,7 @@ export const ParMap = {
 // of every item becomes the input of the next one, the input of the Seq itself
 // begin the input of the first child and the output of the Seq being the output
 // of the last child.
-export const Seq = assign(children => create().call(Seq, { children: children ?? [] }), {
+export const Seq = assign((...children) => create().call(Seq, { children }), {
     tag: "Seq",
     show,
     init,

--- a/tests/await.html
+++ b/tests/await.html
@@ -82,7 +82,7 @@ test("Await in sequence", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const score = Score({ tape });
-    score.add(Seq([Await(ok), Delay(23), Await(ok)]), 17)
+    score.add(Seq(Await(ok), Delay(23), Await(ok)), 17)
     deck.now = 41;
     // Await first timeout
     await notification(deck, "await");
@@ -101,7 +101,7 @@ test("Await in parallel", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const score = Score({ tape });
-    score.add(Par([Await(ok), Delay(23), Await(ok)]), 17)
+    score.add(Par(Await(ok), Delay(23), Await(ok)), 17)
     deck.now = 41;
     // Await two timeouts
     await notification(deck, "await");
@@ -118,7 +118,7 @@ test("Await(f) constrained by parent; call ends early", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const score = Score({ tape });
-    score.add(Par([Await(ok)]).dur(19), 17);
+    score.add(Par(Await(ok)).dur(19), 17);
     deck.now = 18;
     await notification(deck, "await");
     deck.now = 37;
@@ -132,7 +132,7 @@ test("Await(f) constrained by parent; call ends late", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const score = Score({ tape });
-    score.add(Par([Await(ok)]).dur(19), 17);
+    score.add(Par(Await(ok)).dur(19), 17);
     deck.now = 39;
     await notification(deck, "await");
     t.equal(dump(score.instance),
@@ -164,7 +164,7 @@ test("Await(f).dur(d); followed by instant", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const score = Score({ tape });
-    score.add(Seq([Await(ok).dur(23), Instant(x => x + "!")]), 17);
+    score.add(Seq(Await(ok).dur(23), Instant(x => x + "!")), 17);
     deck.now = 18;
     await notification(deck, "await");
     deck.now = 41;
@@ -191,7 +191,7 @@ test("Await(f).dur(d) constrained by parent; call ends early", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const score = Score({ tape });
-    score.add(Par([Await(ok).dur(23)]).dur(19), 17);
+    score.add(Par(Await(ok).dur(23)).dur(19), 17);
     deck.now = 18;
     await notification(deck, "await");
     deck.now = 37;
@@ -205,7 +205,7 @@ test("Await(f).dur(d) constrained by parent; call ends late", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const score = Score({ tape });
-    score.add(Par([Await(ok).dur(23)]).dur(19), 17);
+    score.add(Par(Await(ok).dur(23)).dur(19), 17);
     deck.now = 39;
     await notification(deck, "await");
     t.equal(dump(score.instance),
@@ -218,10 +218,10 @@ test("Cancel", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const score = Score({ tape });
-    score.add(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
+    score.add(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
         Await(() => timeout(100))
-    ]).take(1), 17);
+    ).take(1), 17);
     deck.now = 37;
     await notification(deck, "await");
     t.equal(dump(score.instance),
@@ -238,10 +238,10 @@ test("Cancel Await(f).dur(d)", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const score = Score({ tape });
-    score.add(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
+    score.add(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
         Await(ok).dur(23)
-    ]).take(1), 17);
+    ).take(1), 17);
     deck.now = 39;
     await notification(deck, "await");
     t.equal(dump(score.instance),
@@ -256,10 +256,10 @@ test("Cancel Await(f).dur(d)", async t => {
 
 test("Prune", t => {
     const tape = Tape();
-    const choice = tape.instantiate(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
-        Seq([Delay(23), Await(() => timeout(7777))])
-    ]).take(1), 17);
+    const choice = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Seq(Delay(23), Await(() => timeout(7777)))
+    ).take(1), 17);
     Deck({ tape }).now = 37;
     t.equal(dump(choice),
 `* Par-0 [17, 36[ <19>

--- a/tests/deck.html
+++ b/tests/deck.html
@@ -106,7 +106,7 @@ test("running updates (end with success)", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const score = Score({ tape });
-    const seq = score.add(Seq([Delay(100), Instant(K("ok"))]));
+    const seq = score.add(Seq(Delay(100), Instant(K("ok"))));
     const phi = performance.now();
     deck.start();
     const event = await notification(tape, "end");
@@ -122,7 +122,7 @@ test("running updates (failure)", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const score = Score({ tape });
-    const seq = score.add(Seq([Delay(100), Instant(), Par.map(Delay)]));
+    const seq = score.add(Seq(Delay(100), Instant(), Par.map(Delay)));
     const phi = performance.now();
     deck.start();
     const { item, error } = await notification(tape, "end");
@@ -137,7 +137,7 @@ test("running updates (after the tape has started)", async t => {
     const deck = Deck({ tape });
     const score = Score({ tape });
     const phi = performance.now();
-    const seq = Seq([Delay(100), Instant(K("ok"))]);
+    const seq = Seq(Delay(100), Instant(K("ok")));
     deck.start();
     tape.addOccurrence({
         t: 50,

--- a/tests/delay-until.html
+++ b/tests/delay-until.html
@@ -21,7 +21,7 @@ test("Delay.until(t)", t => {
 
 test("Instantiation (delay applies)", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K("ok")), Delay(23), Delay.until(31), Delay(19)]), 17);
+    const seq = tape.instantiate(Seq(Instant(K("ok")), Delay(23), Delay.until(31), Delay(19)), 17);
     Deck({ tape }).now = 68;
     t.equal(dump(seq),
 `* Seq-0 [17, 67[ <ok>
@@ -34,7 +34,7 @@ test("Instantiation (delay applies)", t => {
 test("Instantiation (delay applies but is cutoff)", t => {
     const tape = Tape();
     const seq = tape.instantiate(
-        Seq([Instant(K("ok")), Delay(23), Delay.until(31), Delay(19)]).dur(29), 17
+        Seq(Instant(K("ok")), Delay(23), Delay.until(31), Delay(19)).dur(29), 17
     );
     Deck({ tape }).now = 47;
     t.equal(dump(seq),
@@ -46,7 +46,7 @@ test("Instantiation (delay applies but is cutoff)", t => {
 
 test("Instantiation (delay does not apply)", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K("ok")), Delay(23), Delay.until(19), Delay(19)]), 17);
+    const seq = tape.instantiate(Seq(Instant(K("ok")), Delay(23), Delay.until(19), Delay(19)), 17);
     Deck({ tape }).now = 60;
     t.equal(dump(seq),
 `* Seq-0 [17, 59[ <ok>
@@ -58,7 +58,7 @@ test("Instantiation (delay does not apply)", t => {
 
 test("Instantiation after an unresolved duration", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([23])), Par.map(Delay), Delay.until(31), Delay(19)]), 17);
+    const seq = tape.instantiate(Seq(Instant(K([23])), Par.map(Delay), Delay.until(31), Delay(19)), 17);
     Deck({ tape }).now = 68;
     t.equal(dump(seq),
 `* Seq-0 [17, 67[ <23>
@@ -71,7 +71,7 @@ test("Instantiation after an unresolved duration", t => {
 
 test("Instantiation inside Par (same as regular delay)", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K("ok")), Par([Delay(23), Delay.until(31)])]), 17);
+    const seq = tape.instantiate(Seq(Instant(K("ok")), Par(Delay(23), Delay.until(31))), 17);
     Deck({ tape }).now = 49;
     t.equal(dump(seq),
 `* Seq-0 [17, 48[ <ok,ok>
@@ -83,9 +83,9 @@ test("Instantiation inside Par (same as regular delay)", t => {
 
 test("Cancel delay", t => {
     const tape = Tape();
-    const choice = tape.instantiate(Par([
+    const choice = tape.instantiate(Par(
         Instant(K("ok")), Delay.until(23)
-    ]).take(1), 17);
+    ).take(1), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(choice),
 `* Par-0 @17 <ok>
@@ -96,10 +96,10 @@ test("Cancel delay", t => {
 
 test("Prune delay", t => {
     const tape = Tape();
-    t.undefined(tape.instantiate(Seq([
+    t.undefined(tape.instantiate(Seq(
         Delay.until(1),
         Par().take(1)
-    ]), 17), "instantiation failed");
+    ), 17), "instantiation failed");
     Deck({ tape }).now = 18;
     t.equal(tape.occurrences, [], "no occurrence on tape");
 });

--- a/tests/delay.html
+++ b/tests/delay.html
@@ -91,7 +91,7 @@ test("Delay(d).repeat().take(n)", t => {
 
 test("Delay value", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K("ok")), Delay(23)]), 17);
+    const seq = tape.instantiate(Seq(Instant(K("ok")), Delay(23)), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(seq),
 `* Seq-0 [17, 40[ <ok>
@@ -101,10 +101,10 @@ test("Delay value", t => {
 
 test("Cancel delay", t => {
     const tape = Tape();
-    const choice = tape.instantiate(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
-        Seq([Delay(23), Instant(K("ko"))]),
-    ]).take(1), 17);
+    const choice = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Seq(Delay(23), Instant(K("ko"))),
+    ).take(1), 17);
     Deck({ tape }).now = 37;
     t.equal(dump(choice),
 `* Par-0 [17, 36[ <19>
@@ -119,10 +119,10 @@ test("Cancel delay", t => {
 
 test("Prune delay", t => {
     const tape = Tape();
-    t.undefined(tape.instantiate(Seq([
+    t.undefined(tape.instantiate(Seq(
         Delay(1),
         Par().take(1)
-    ]), 17), "instantiation failed");
+    ), 17), "instantiation failed");
     Deck({ tape }).now = 18;
     t.equal(tape.occurrences, [], "no occurrence on tape");
 });

--- a/tests/event.html
+++ b/tests/event.html
@@ -33,10 +33,10 @@ test("Instantiation", t => {
 test("Repeat", t => {
     const tape = Tape();
     const deck = Deck({ tape });
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Event(window, "synth").repeat().take(3),
         Instant(K("ok"))
-    ]), 17);
+    ), 17);
     deck.now = 27;
     window.dispatchEvent(new window.Event("synth"));
     deck.now = 37;
@@ -58,7 +58,7 @@ test("Event(target, type).dur(0)", t => {
 test("Event(target, type) constrained by parent; event occurs early", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
-    const par = tape.instantiate(Par([Event(window, "synth")]).dur(23), 17);
+    const par = tape.instantiate(Par(Event(window, "synth")).dur(23), 17);
     deck.now = 18;
     window.dispatchEvent(new window.Event("synth"));
     deck.now = 41;
@@ -68,7 +68,7 @@ test("Event(target, type) constrained by parent; event occurs early", async t =>
 test("Event(target, type) constrained by parent; event occurs late", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
-    const par = tape.instantiate(Par([Event(window, "synth")]).dur(23), 17);
+    const par = tape.instantiate(Par(Event(window, "synth")).dur(23), 17);
     deck.now = 51;
     window.dispatchEvent(new window.Event("synth"));
     t.equal(dump(par),
@@ -98,10 +98,10 @@ test("Event(target, type).dur(d); event occurs late", async t => {
 test("Cancel", t => {
     const tape = Tape();
     const deck = Deck({ tape });
-    const instance = tape.instantiate(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
+    const instance = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
         Event(window, "synth")
-    ]).take(1), 17);
+    ).take(1), 17);
     deck.now = 37;
     t.equal(dump(instance),
 `* Par-0 [17, 36[ <19>
@@ -115,10 +115,10 @@ test("Cancel", t => {
 test("Cancel with repeat", t => {
     const tape = Tape();
     const deck = Deck({ tape });
-    const par = tape.instantiate(Par([
+    const par = tape.instantiate(Par(
         Event(window, "synth").repeat(),
         Delay(23),
-    ]).take(1), 17);
+    ).take(1), 17);
     deck.now = 27;
     window.dispatchEvent(new window.Event("synth"));
     deck.now = 37;
@@ -131,10 +131,10 @@ test("Cancel with repeat", t => {
 test("Prune", t => {
     const tape = Tape();
     const deck = Deck({ tape });
-    const choice = tape.instantiate(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
-        Seq([Delay(23), Event(window, "synth")]),
-    ]).take(1), 17);
+    const choice = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Seq(Delay(23), Event(window, "synth")),
+    ).take(1), 17);
     deck.now = 37;
     t.equal(dump(choice),
 `* Par-0 [17, 36[ <19>
@@ -150,10 +150,10 @@ test("Prune", t => {
 test("Prune with repeat", t => {
     const tape = Tape();
     const deck = Deck({ tape });
-    const choice = tape.instantiate(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
-        Seq([Delay(23), Event(window, "synth").repeat()]),
-    ]).take(1), 17);
+    const choice = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Seq(Delay(23), Event(window, "synth").repeat()),
+    ).take(1), 17);
     deck.now = 37;
     t.equal(dump(choice),
 `* Par-0 [17, 36[ <19>

--- a/tests/instant.html
+++ b/tests/instant.html
@@ -89,19 +89,19 @@ test("Instant(f).repeat().take(n); n finite", t => {
 
 test("Cancel instant", t => {
     const tape = Tape();
-    const choice = tape.instantiate(Par([
+    const choice = tape.instantiate(Par(
         Instant(K("ok")), Instant(() => { throw Error("not cancelled?!"); })
-    ]).take(1), 17);
+    ).take(1), 17);
     Deck({ tape }).now = 18;
     t.equal(choice.value, ["ok"], "expected value");
 });
 
 test("Prune instant", t => {
     const tape = Tape();
-    t.undefined(tape.instantiate(Seq([
+    t.undefined(tape.instantiate(Seq(
         Instant(() => { throw Error("not pruned?!"); }),
         Par().take(1)
-    ]), 17), "instantiation failed");
+    ), 17), "instantiation failed");
     Deck({ tape }).now = 18;
     t.equal(tape.occurrences, [], "no occurrence on tape");
 });

--- a/tests/manual/drag.html
+++ b/tests/manual/drag.html
@@ -29,20 +29,20 @@ const deck = Deck({ tape });
 const score = Score({ tape });
 const box = document.querySelector("div");
 
-score.add(Seq([
+score.add(Seq(
     Event(box, "pointerdown"),
     Effect(event => { console.log(">>> Drag start", event); }),
-    Par([
-        Seq([
+    Par(
+        Seq(
             Event(document, "pointermove"),
             Effect(event => { console.log("... dragging", event); })
-        ]).repeat(),
-        Seq([
+        ).repeat(),
+        Seq(
             Event(document, "pointerup"),
             Effect(event => { console.log("<<< Drag end", event); })
-        ])
-    ]).take(1)
-]).repeat());
+        )
+    ).take(1)
+).repeat());
 
 deck.start();
 

--- a/tests/manual/images.html
+++ b/tests/manual/images.html
@@ -31,11 +31,11 @@ const deck = Deck({ tape });
 const score = Score({ tape });
 const button = document.querySelector("button");
 
-score.add(Seq([
+score.add(Seq(
     Event(button, "click").repeat().take(3),
     Effect(() => { button.disabled = true; }),
     Await(async () => await (await fetch("images.json")).json()),
-    Seq.map(([w, h]) => Seq([
+    Seq.map(([w, h]) => Seq(
         Try(
             Await(async () => await imagePromise(`https://placekitten.com/${w}/${h}`)).dur(500),
             Instant(() => html("div", {
@@ -43,12 +43,12 @@ score.add(Seq([
             }))
         ),
         Effect(element => { document.body.appendChild(element); })
-    ])),
+    )),
     Effect(() => {
         setTimeout(() => { console.log(dump(score.instance)); });
         return "ok";
     })
-]));
+));
 
 deck.start();
 

--- a/tests/par-dur.html
+++ b/tests/par-dur.html
@@ -15,26 +15,26 @@ import { Deck } from "../lib/deck.js";
 test("Par(xs).dur(d) duration", t => {
     t.equal(Par().dur(29).duration, 29, "empty par");
     t.equal(
-        Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).dur(79).duration, 79,
+        Par(Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)).dur(79).duration, 79,
         "dur (more than natural duration)"
     );
     t.equal(
-        Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).dur(29).duration, 29,
+        Par(Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)).dur(29).duration, 29,
         "dur (less than natural duration)"
     );
     t.equal(
-        Par([Delay(51), Delay(23), Delay(31), Par.map(), Par.map()]).dur(29).duration, 29,
+        Par(Delay(51), Delay(23), Delay(31), Par.map(), Par.map()).dur(29).duration, 29,
         "dur (indefinite natural durations)"
     );
     t.equal(
-        Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).dur("79s").duration, 51,
+        Par(Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)).dur("79s").duration, 51,
         "dur (illegal value is not applied)"
     );
 });
 
 test("Extending the duration", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([Instant(), Delay(23), Delay(19)]).dur(31), 17);
+    const par = tape.instantiate(Par(Instant(), Delay(23), Delay(19)).dur(31), 17);
     t.equal(dump(par),
 `* Par-0 [17, 48[
   * Instant-1 @17
@@ -44,7 +44,7 @@ test("Extending the duration", t => {
 
 test("Extending duration (indefinite duration)", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([Instant(), Delay(23), Delay(19)]).dur(Infinity), 17);
+    const par = tape.instantiate(Par(Instant(), Delay(23), Delay(19)).dur(Infinity), 17);
     t.equal(dump(par),
 `* Par-0 [17, ∞[
   * Instant-1 @17
@@ -55,14 +55,14 @@ test("Extending duration (indefinite duration)", t => {
 test("Extending duration (no children)", t => {
     const tape = Tape();
     const noChildren = tape.instantiate(Par().dur(23), 17);
-    const emptyList = tape.instantiate(Par([]).dur(23), 17);
+    const emptyList = tape.instantiate(Par().dur(23), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(noChildren), "* Par-0 [17, 40[ <>", "no children");
     t.equal(dump(emptyList), "* Par-1 [17, 40[ <>", "empty list");
 });
 
 test("Extending duration (but constrained by parent)", t => {
-    const par = Tape().instantiate(Par([Instant(), Delay(23), Delay(19)]).dur(51), 17, 31);
+    const par = Tape().instantiate(Par(Instant(), Delay(23), Delay(19)).dur(51), 17, 31);
     t.equal(dump(par),
 `* Par-0 [17, 48[
   * Instant-1 @17
@@ -72,12 +72,12 @@ test("Extending duration (but constrained by parent)", t => {
 
 test("Par.dur(d), cutting off the duration", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([
-        Seq([Instant(K("A")), Delay(23), Instant(x => x + "*")]),
+    const par = tape.instantiate(Par(
+        Seq(Instant(K("A")), Delay(23), Instant(x => x + "*")),
         Instant(K("B")),
-        Seq([Instant(K("C")), Delay(23), Instant(x => x + "*")]),
-        Seq([Instant(K("D")), Delay(19)]),
-    ]).dur(21), 17);
+        Seq(Instant(K("C")), Delay(23), Instant(x => x + "*")),
+        Seq(Instant(K("D")), Delay(19)),
+    ).dur(21), 17);
     Deck({ tape }).now = 47;
     t.equal(dump(par),
 `* Par-0 [17, 38[ <A,B,C,D>
@@ -95,12 +95,12 @@ test("Par.dur(d), cutting off the duration", t => {
 
 test("Par, cutting off the duration (parent duration)", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([
-        Seq([Instant(K("A")), Delay(23), Instant(x => x + "*")]),
+    const par = tape.instantiate(Par(
+        Seq(Instant(K("A")), Delay(23), Instant(x => x + "*")),
         Instant(K("B")),
-        Seq([Instant(K("C")), Delay(23), Instant(x => x + "*")]),
-        Seq([Instant(K("D")), Delay(19)]),
-    ]), 17, 21);
+        Seq(Instant(K("C")), Delay(23), Instant(x => x + "*")),
+        Seq(Instant(K("D")), Delay(19)),
+    ), 17, 21);
     Deck({ tape }).now = 47;
     t.equal(dump(par),
 `* Par-0 [17, 38[ <A,B,C,D>
@@ -118,7 +118,7 @@ test("Par, cutting off the duration (parent duration)", t => {
 
 test("Cutting off duration (parent duration)", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([Instant(), Delay(31), Delay(19)]), 17, 23);
+    const par = tape.instantiate(Par(Instant(), Delay(31), Delay(19)), 17, 23);
     t.equal(dump(par),
 `* Par-0 [17, 40[
   * Instant-1 @17
@@ -127,7 +127,7 @@ test("Cutting off duration (parent duration)", t => {
 });
 
 test("dur(0)", t => {
-    const par = Tape().instantiate(Par([Instant(), Delay(0), Par(), Delay(23)]).dur(0), 17);
+    const par = Tape().instantiate(Par(Instant(), Delay(0), Par(), Delay(23)).dur(0), 17);
     t.equal(dump(par),
 `* Par-0 @17
   * Instant-1 @17
@@ -137,7 +137,7 @@ test("dur(0)", t => {
 });
 
 test("dur(0) with only zero-duration children", t => {
-    const par = Tape().instantiate(Par([Instant(), Delay(0), Par()]).dur(0), 17);
+    const par = Tape().instantiate(Par(Instant(), Delay(0), Par()).dur(0), 17);
     t.equal(dump(par),
 `* Par-0 @17
   * Instant-1 @17
@@ -147,12 +147,12 @@ test("dur(0) with only zero-duration children", t => {
 
 test("Par.take(n).dur(d), cutting off the duration", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([
-        Seq([Instant(K("A")), Delay(23), Instant(x => x + "*")]),
+    const par = tape.instantiate(Par(
+        Seq(Instant(K("A")), Delay(23), Instant(x => x + "*")),
         Instant(K("B")),
-        Seq([Instant(K("C")), Delay(23), Instant(x => x + "*")]),
-        Seq([Instant(K("D")), Delay(19)]),
-    ]).take(3).dur(20), 17);
+        Seq(Instant(K("C")), Delay(23), Instant(x => x + "*")),
+        Seq(Instant(K("D")), Delay(19)),
+    ).take(3).dur(20), 17);
     Deck({ tape }).now = 38;
     t.equal(dump(par),
 `* Par-0 [17, 37[ <B,D,A>
@@ -167,12 +167,12 @@ test("Par.take(n).dur(d), cutting off the duration", t => {
 
 test("Par.take(n).dur(d), extending the duration", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([
-        Seq([Instant(K("A")), Delay(23)]),
+    const par = tape.instantiate(Par(
+        Seq(Instant(K("A")), Delay(23)),
         Instant(K("B")),
-        Seq([Instant(K("C")), Delay(23), Instant(x => x + "*")]),
-        Seq([Instant(K("D")), Delay(19)]),
-    ]).take(3).dur(31), 17);
+        Seq(Instant(K("C")), Delay(23), Instant(x => x + "*")),
+        Seq(Instant(K("D")), Delay(19)),
+    ).take(3).dur(31), 17);
     Deck({ tape }).now = 49;
     t.equal(dump(par),
 `* Par-0 [17, 48[ <B,D,A>

--- a/tests/par-map.html
+++ b/tests/par-map.html
@@ -33,11 +33,11 @@ test("Par.map(g).repeat()", t => {
 
 test("Instantiation", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K([19, 37, 31])),
         Par.map(Delay),
         Instant(xs => xs.length)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 55;
     t.equal(dump(instance),
 `* Seq-0 [17, 54[ <3>
@@ -51,63 +51,63 @@ test("Instantiation", t => {
 
 test("Instantiation, empty input array", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K([])),
         Par.map(Delay)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 18;
     t.equal(instance.value, [], "empty list");
 });
 
 test("Par.map(g).take(n = ∞)", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K([19, 37, 31, 19, 51])),
-        Par.map((x, i) => Par([Instant(K(i)), Delay(x)])).take(),
+        Par.map((x, i) => Par(Instant(K(i)), Delay(x))).take(),
         Instant(xs => xs.map(([i]) => i))
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 69;
     t.equal(instance.value, [0, 3, 2, 1, 4], "value");
 });
 
 test("Par.map(g).take(n); fails at runtime when n > input length", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K([19, 37, 31, 19, 51])),
-        Par.map((x, i) => Par([Instant(K(i)), Delay(x)])).take(7),
+        Par.map((x, i) => Par(Instant(K(i)), Delay(x))).take(7),
         Instant(xs => xs.map(([i]) => i))
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 18;
     t.equal(instance.error.message, "failed", "failed to instantiate map");
 });
 
 test("Par.map(g).take(n); n < input length", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K([19, 37, 31, 19, 51])),
-        Par.map(x => Par([Instant(K(x)), Delay(x)])).take(3),
+        Par.map(x => Par(Instant(K(x)), Delay(x))).take(3),
         Instant(xs => xs.map(([i]) => i))
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 69;
     t.equal(instance.value, [19, 19, 31], "value");
 });
 
 test("Par.map(g).take(0)", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K([19, 37, 31, 19, 51])),
-        Par.map((x, i) => Par([Instant(K(i)), Delay(x)])).take(0)
-    ]), 17);
+        Par.map((x, i) => Par(Instant(K(i)), Delay(x))).take(0)
+    ), 17);
     Deck({ tape }).now = 18;
     t.equal(instance.value, [], "empty list");
 });
 
 test("Par.map(g).dur(d); extending duration", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K([19, 37, 31, 19, 51])),
         Par.map(Delay).dur(71)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 89;
     t.equal(dump(instance),
 `* Seq-0 [17, 88[ <19,37,31,19,51>
@@ -122,10 +122,10 @@ test("Par.map(g).dur(d); extending duration", t => {
 
 test("Par.map(g).dur(d); extending duration, no children", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K([])),
         Par.map(Delay).dur(71)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 89;
     t.equal(dump(instance),
 `* Seq-0 [17, 88[ <>
@@ -135,10 +135,10 @@ test("Par.map(g).dur(d); extending duration, no children", t => {
 
 test("Par.map(g).dur(d); cutting off duration", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K([19, 37, 31, 19, 51])),
         Par.map(Delay).dur(41)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 59;
     t.equal(dump(instance),
 `* Seq-0 [17, 58[ <19,37,31,19,51>
@@ -153,10 +153,10 @@ test("Par.map(g).dur(d); cutting off duration", t => {
 
 test("Par.map(g).dur(d); cutting off instantiation duration", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K([19, 37, 31, 19, 51])),
         Par.map(Delay)
-    ]), 17, 41);
+    ), 17, 41);
     Deck({ tape }).now = 59;
     t.equal(dump(instance),
 `* Seq-0 [17, 58[ <19,37,31,19,51>
@@ -171,10 +171,10 @@ test("Par.map(g).dur(d); cutting off instantiation duration", t => {
 
 test("Par.map(g).take(n).dur(d); extending duration", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K([19, 37, 31, 19, 51])),
         Par.map(Delay).take(3).dur(71)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 89;
     t.equal(dump(instance),
 `* Seq-0 [17, 88[ <19,19,31>
@@ -187,10 +187,10 @@ test("Par.map(g).take(n).dur(d); extending duration", t => {
 
 test("Par.map(g) failure: input is not an array", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K("oops")),
         Par.map(Delay)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(instance),
 `* Seq-0 @17 (failed)
@@ -200,10 +200,10 @@ test("Par.map(g) failure: input is not an array", t => {
 
 test("Par.map(g) failure: could not instantiate input", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K([1, 2, 3])),
         Par.map(() => { throw window.Error("Augh!"); })
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(instance),
 `* Seq-0 @17 (failed)
@@ -213,10 +213,10 @@ test("Par.map(g) failure: could not instantiate input", t => {
 
 test("Par.map(g).repeat()", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K([19, 23])),
         Par.map(Delay).repeat()
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 69;
     t.equal(dump(instance),
 `* Seq-0 [17, ∞[
@@ -235,10 +235,10 @@ test("Par.map(g).repeat()", t => {
 
 test("Par.map(g).repeat().take(n)", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K([19, 23])),
         Par.map(Delay).repeat().take(3)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 87;
     t.equal(dump(instance),
 `* Seq-0 [17, 86[ <19,23>
@@ -257,13 +257,13 @@ test("Par.map(g).repeat().take(n)", t => {
 
 test("Par may recover from failing child", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K([23, 19])),
-        Par([
+        Par(
             Par().take(1),
             Par.map(Delay)
-        ]).take(1)
-    ]), 17)
+        ).take(1)
+    ), 17)
     Deck({ tape }).now = 41;
     t.equal(dump(instance),
 `* Seq-0 [17, 40[ <23,19>
@@ -276,10 +276,10 @@ test("Par may recover from failing child", t => {
 
 test("Cancel Par.map", t => {
     const tape = Tape();
-    const choice = tape.instantiate(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
-        Seq([Instant(K([23, 31])), Par.map(Delay)]),
-    ]).take(1), 17);
+    const choice = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Seq(Instant(K([23, 31])), Par.map(Delay)),
+    ).take(1), 17);
     Deck({ tape }).now = 37;
     t.equal(dump(choice),
 `* Par-0 [17, 36[ <19>
@@ -297,10 +297,10 @@ test("Cancel Par.map", t => {
 
 test("Prune Par.map", t => {
     const tape = Tape();
-    const choice = tape.instantiate(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
-        Seq([Delay(23), Par.map(Delay)])
-    ]).take(1), 17);
+    const choice = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Seq(Delay(23), Par.map(Delay))
+    ).take(1), 17);
     Deck({ tape }).now = 37;
     t.equal(dump(choice),
 `* Par-0 [17, 36[ <19>

--- a/tests/par-repeat.html
+++ b/tests/par-repeat.html
@@ -13,7 +13,7 @@ import { Tape } from "../lib/tape.js";
 import { Deck } from "../lib/deck.js";
 
 test("Par(xs).repeat()", t => {
-    const par = Par([Delay(23)]);
+    const par = Par(Delay(23));
     const repeat = par.repeat();
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, par, "repeat child");
@@ -24,7 +24,7 @@ test("Par(xs).repeat()", t => {
 
 test("Instantiation", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([Instant(K("A")), Delay(23)]).repeat(), 17);
+    const par = tape.instantiate(Par(Instant(K("A")), Delay(23)).repeat(), 17);
 
     Deck({ tape }).now = 71;
     t.equal(dump(par),
@@ -43,12 +43,12 @@ test("Instantiation", t => {
 test("Instantiation fails for zero duration", t => {
     const tape = Tape();
     t.undefined(tape.instantiate(Par().repeat(), 17), "empty par");
-    t.undefined(tape.instantiate(Par([Instant(), Instant()]).repeat(), 17), "zero duration par");
+    t.undefined(tape.instantiate(Par(Instant(), Instant()).repeat(), 17), "zero duration par");
 });
 
 test("Par(xs).repeat().take(n)", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([Delay(23), Delay(19)]).repeat().take(3), 17);
+    const par = tape.instantiate(Par(Delay(23), Delay(19)).repeat().take(3), 17);
     Deck({ tape }).now = 87;
     t.equal(dump(par),
 `* Seq/repeat-0 [17, 86[ <,>
@@ -76,7 +76,7 @@ test("Par(xs).repeat().take(n); empty par", t => {
 
 test("Par(xs).repeat().take(n); zero-duration par", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([Instant(K("A")), Instant(K(1))]).repeat().take(3), 17);
+    const par = tape.instantiate(Par(Instant(K("A")), Instant(K(1))).repeat().take(3), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(par),
 `* Seq/repeat-0 @17 <A,1>

--- a/tests/par-take.html
+++ b/tests/par-take.html
@@ -14,61 +14,61 @@ import { Deck } from "../lib/deck.js";
 
 test("Par(xs).take(n = ∞) duration", t => {
     t.equal(
-        Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take().duration, 51,
+        Par(Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)).take().duration, 51,
         "dur with n = ∞"
     );
     t.undefined(
-        Par([Delay(51), Delay(23), Delay(31), Par.map(), Par.map()]).take().duration,
+        Par(Delay(51), Delay(23), Delay(31), Par.map(), Par.map()).take().duration,
         "dur with n = ∞ (indefinite durations)"
     );
     t.equal(
-        Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(7).duration, 0,
+        Par(Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)).take(7).duration, 0,
         "zero dur with n > child count (failure)"
     );
     t.equal(
-        Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(3).duration, 23,
+        Par(Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)).take(3).duration, 23,
         "dur with n < child count"
     );
     t.undefined(
-        Par([Delay(51), Delay(23), Delay(31), Par.map(), Delay(19)]).take(3).duration,
+        Par(Delay(51), Delay(23), Delay(31), Par.map(), Delay(19)).take(3).duration,
         "dur with n < child count, but unresolved duration"
     );
     t.equal(
-        Par([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(0).duration, 0,
+        Par(Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)).take(0).duration, 0,
         "dur with n = 0"
     );
 });
 
 test("Instantiation; n = ∞", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([
-        Seq([Instant(K("A")), Delay(23)]),
+    const par = tape.instantiate(Par(
+        Seq(Instant(K("A")), Delay(23)),
         Instant(K("B")),
-        Seq([Instant(K("C")), Delay(23)]),
-        Seq([Instant(K("D")), Delay(19)]),
-    ]).take(), 17);
+        Seq(Instant(K("C")), Delay(23)),
+        Seq(Instant(K("D")), Delay(19)),
+    ).take(), 17);
     Deck({ tape }).now = 49;
     t.equal(par.value, ["B", "D", "A", "C"], "dynamic value");
 });
 
 test("Instantiation fails when n > xs.length", t => {
     const tape = Tape();
-    t.undefined(tape.instantiate(Par([
-        Seq([Instant(K("A")), Delay(23)]),
+    t.undefined(tape.instantiate(Par(
+        Seq(Instant(K("A")), Delay(23)),
         Instant(K("B")),
-        Seq([Instant(K("C")), Delay(23)]),
-        Seq([Instant(K("D")), Delay(19)]),
-    ]).take(7), 17), "not enough children");
+        Seq(Instant(K("C")), Delay(23)),
+        Seq(Instant(K("D")), Delay(19)),
+    ).take(7), 17), "not enough children");
 });
 
 test("Instantiation; n < xs.length", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([
-        Seq([Instant(K("A")), Delay(23), Instant(x => x + "*")]),
+    const par = tape.instantiate(Par(
+        Seq(Instant(K("A")), Delay(23), Instant(x => x + "*")),
         Instant(K("B")),
-        Seq([Instant(K("C")), Delay(23), Instant(x => x + "*")]),
-        Seq([Instant(K("D")), Delay(19), Instant(x => x + "*")]),
-    ]).take(1), 17);
+        Seq(Instant(K("C")), Delay(23), Instant(x => x + "*")),
+        Seq(Instant(K("D")), Delay(19), Instant(x => x + "*")),
+    ).take(1), 17);
     Deck({ tape }).now = 49;
     t.equal(par.value, ["B"], "dynamic value");
     t.equal(dump(par),
@@ -77,13 +77,13 @@ test("Instantiation; n < xs.length", t => {
 });
 
 test("Instantiation; unresolved durations result in more than n children", t => {
-    const par = Tape().instantiate(Par([
+    const par = Tape().instantiate(Par(
         Delay(23),
         Delay(31),
         Par.map(Delay),
         Delay(19),
         Delay(51) // this delay will not be instantiated
-    ]).take(3), 17);
+    ).take(3), 17);
     t.equal(dump(par),
 `* Par-0 [17, ∞[
   * Delay-1 [17, 40[
@@ -94,10 +94,10 @@ test("Instantiation; unresolved durations result in more than n children", t => 
 
 test("Instantiation failure in child after nth", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([
-        Seq([Delay(23), Par().take(1)]),
+    const par = tape.instantiate(Par(
+        Seq(Delay(23), Par().take(1)),
         Instant(K("B")),
-    ]).take(1), 17);
+    ).take(1), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(par),
 `* Par-0 @17 <B>
@@ -106,12 +106,12 @@ test("Instantiation failure in child after nth", t => {
 
 test("Instantiation; n = 0", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([
-        Seq([Instant(K("A")), Delay(23)]),
+    const par = tape.instantiate(Par(
+        Seq(Instant(K("A")), Delay(23)),
         Instant(K("B*")),
-        Seq([Instant(K("C")), Delay(23)]),
-        Seq([Instant(K("D")), Delay(19)]),
-    ]).take(0), 17);
+        Seq(Instant(K("C")), Delay(23)),
+        Seq(Instant(K("D")), Delay(19)),
+    ).take(0), 17);
     Deck({ tape }).now = 18;
     t.equal(par.value, [], "dynamic value");
     t.equal(dump(par), "* Par-0 @17 <>", "dump matches");
@@ -119,13 +119,13 @@ test("Instantiation; n = 0", t => {
 
 test("Allowing failure during instantiation", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([
+    const par = tape.instantiate(Par(
         Delay(23),
         Delay(31),
         Par().take(1), // fails
         Delay(19),
         Instant().repeat(), // fails
-    ]).take(3), 17);
+    ).take(3), 17);
     t.equal(dump(par),
 `* Par-0 [17, 48[
   * Delay-1 [17, 40[
@@ -135,13 +135,13 @@ test("Allowing failure during instantiation", t => {
 
 test("Effects", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([
+    const par = tape.instantiate(Par(
         Instant(K("ok")),
         Effect(() => {
             console.warn("Some effect");
             return "ko";
         })
-    ]).take(1), 17);
+    ).take(1), 17);
     t.warns(() => { Deck({ tape }).now = 18; }, "effect occurred");
     t.equal(dump(par),
 `* Par-0 @17 <ok>

--- a/tests/par.html
+++ b/tests/par.html
@@ -23,7 +23,7 @@ test("Par()", t => {
 test("Par(xs)", t => {
     const delay = Delay(17);
     const instant = Instant(x => x * 2);
-    const par = Par([delay, instant]);
+    const par = Par(delay, instant);
     t.equal(par.show(), "Par/2", "show");
     t.equal(par.children, [delay, instant], "children");
     t.equal(delay.parent, par, "parent (first child)");
@@ -34,15 +34,15 @@ test("Par(xs)", t => {
 
 test("Par duration", t => {
     t.equal(
-        Par([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31).repeat()]).duration, Infinity,
+        Par(Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31).repeat()).duration, Infinity,
         "indefinite duration (repeated child at the end)"
     );
     t.equal(
-        Par([Instant(), Delay(23).repeat(), Seq.fold(), Par.map(), Delay(31)]).duration, Infinity,
+        Par(Instant(), Delay(23).repeat(), Seq.fold(), Par.map(), Delay(31)).duration, Infinity,
         "indefinite duration (repeated child)"
     );
     t.undefined(
-        Par([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31)]).duration,
+        Par(Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31)).duration,
         "unresolved duration"
     );
 });
@@ -52,7 +52,7 @@ test("Instantiation", t => {
     const instant = Instant();
     const delay1 = Delay(23);
     const delay2 = Delay(19);
-    const par = Par([instant, delay1, delay2]);
+    const par = Par(instant, delay1, delay2);
     const instance = tape.instantiate(par, 17);
     t.equal(instance.tape, tape, "instance.tape is set");
     t.equal(instance.item, par, "instance.item is set");
@@ -76,7 +76,7 @@ test("Instantiation", t => {
 
 test("Instantiation; zero duration", t => {
     const tape = Tape();
-    const par = Par([Instant(K(1)), Instant(K(2)), Instant(K(3))]);
+    const par = Par(Instant(K(1)), Instant(K(2)), Instant(K(3)));
     const instance = tape.instantiate(par, 17);
     t.equal(instance.t, 17, "instance.t is set");
     Deck({ tape }).now = 18;
@@ -96,12 +96,12 @@ test("Instantiation; empty par", t => {
 
 test("Instantiation with parent duration (no cutoff)", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([
-        Seq([Instant(K("A")), Delay(23)]),
+    const par = tape.instantiate(Par(
+        Seq(Instant(K("A")), Delay(23)),
         Instant(K("B")),
-        Seq([Instant(K("C")), Delay(23)]),
-        Seq([Instant(K("D")), Delay(19)]),
-    ]), 17, 31);
+        Seq(Instant(K("C")), Delay(23)),
+        Seq(Instant(K("D")), Delay(19)),
+    ), 17, 31);
     Deck({ tape }).now = 41;
     t.equal(dump(par),
 `* Par-0 [17, 40[ <A,B,C,D>
@@ -119,12 +119,12 @@ test("Instantiation with parent duration (no cutoff)", t => {
 
 test("Instantiation with parent duration (cutoff)", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([
-        Seq([Instant(K("A")), Delay(23)]),
+    const par = tape.instantiate(Par(
+        Seq(Instant(K("A")), Delay(23)),
         Instant(K("B")),
-        Seq([Instant(K("C")), Delay(23)]),
-        Seq([Instant(K("D")), Delay(19)]),
-    ]), 17, 21);
+        Seq(Instant(K("C")), Delay(23)),
+        Seq(Instant(K("D")), Delay(19)),
+    ), 17, 21);
     Deck({ tape }).now = 39;
     t.equal(dump(par),
 `* Par-0 [17, 38[ <A,B,C,D>
@@ -142,32 +142,32 @@ test("Instantiation with parent duration (cutoff)", t => {
 
 test("Value", t => {
     const tape = Tape();
-    const par = tape.instantiate(Par([
-        Seq([Instant(K("A")), Delay(23)]),
+    const par = tape.instantiate(Par(
+        Seq(Instant(K("A")), Delay(23)),
         Instant(K("B")),
-        Seq([Instant(K("C")), Delay(23)]),
-        Seq([Instant(K("D")), Delay(19)]),
-    ]), 17);
+        Seq(Instant(K("C")), Delay(23)),
+        Seq(Instant(K("D")), Delay(19)),
+    ), 17);
     Deck({ tape }).now = 49;
     t.equal(par.value, ["A", "B", "C", "D"], "static value");
 });
 
 test("Failure during instantiation", t => {
     const tape = Tape();
-    t.undefined(tape.instantiate(Par([
+    t.undefined(tape.instantiate(Par(
         Instant(() => { throw Error("should be pruned"); }),
         Instant().repeat(),
         Instant(() => { throw Error("should not be intantiated"); })
-    ]), 17), "failed to instantiate par");
+    ), 17), "failed to instantiate par");
     t.equal(tape.occurrences.length, 0, "no occurrences on tape");
 });
 
 test("Cancel par", t => {
     const tape = Tape();
-    const choice = tape.instantiate(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
-        Par([Delay(23), Delay(31)])
-    ]).take(1), 17);
+    const choice = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Par(Delay(23), Delay(31))
+    ).take(1), 17);
     Deck({ tape }).now = 37;
     t.equal(dump(choice),
 `* Par-0 [17, 36[ <19>
@@ -183,10 +183,10 @@ test("Cancel par", t => {
 
 test("Prune par", t => {
     const tape = Tape();
-    const choice = tape.instantiate(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
-        Seq([Delay(23), Par(), Par([Delay(31)])])
-    ]).take(1), 17);
+    const choice = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Seq(Delay(23), Par(), Par(Delay(31)))
+    ).take(1), 17);
     Deck({ tape }).now = 37;
     t.equal(dump(choice),
 `* Par-0 [17, 36[ <19>

--- a/tests/score.html
+++ b/tests/score.html
@@ -76,7 +76,7 @@ test("Notification when a child instance ends (with value)", t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const score = Score({ tape });
-    const seq = score.add(Seq([Instant(K("ok")), Delay(23)]), 17);
+    const seq = score.add(Seq(Instant(K("ok")), Delay(23)), 17);
     let event;
     on(tape, "end", e => { event = e; });
     deck.now = 41;
@@ -88,7 +88,7 @@ test("Notification when a child instance ends (with failure)", t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const score = Score({ tape });
-    const seq = score.add(Seq([Instant(K("ok")), Event(window, "synth").dur(23)]), 17);
+    const seq = score.add(Seq(Instant(K("ok")), Event(window, "synth").dur(23)), 17);
     let event;
     on(tape, "end", e => { event = e; });
     deck.now = 41;

--- a/tests/seq-dur.html
+++ b/tests/seq-dur.html
@@ -15,25 +15,25 @@ import { Deck } from "../lib/deck.js";
 test("Seq(xs).dur(d) duration", t => {
     t.equal(Seq().dur(29).duration, 29, "empty seq");
     t.equal(
-        Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).dur(179).duration, 179,
+        Seq(Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)).dur(179).duration, 179,
         "more than natural duration"
     );
     t.equal(
-        Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).dur(79).duration, 79,
+        Seq(Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)).dur(79).duration, 79,
         "less than natural duration"
     );
     t.equal(
-        Seq([Delay(51), Delay(23).repeat()]).dur(179).duration, 179,
+        Seq(Delay(51), Delay(23).repeat()).dur(179).duration, 179,
         "indefinite natural duration"
     );
     t.equal(
-        Seq([Delay(51), Delay(23), Delay(31), Par.map(), Par.map()]).dur(179).duration, 179,
+        Seq(Delay(51), Delay(23), Delay(31), Par.map(), Par.map()).dur(179).duration, 179,
         "unresolved natural duration"
     );
 });
 
 test("Extending duration", t => {
-    const seq = Tape().instantiate(Seq([Instant(), Delay(23), Delay(19)]).dur(51), 17);
+    const seq = Tape().instantiate(Seq(Instant(), Delay(23), Delay(19)).dur(51), 17);
     t.equal(dump(seq),
 `* Seq-0 [17, 68[
   * Instant-1 @17
@@ -42,7 +42,7 @@ test("Extending duration", t => {
 });
 
 test("Extending duration (indefinite duration)", t => {
-    const seq = Tape().instantiate(Seq([Instant(), Delay(23), Delay(19)]).dur(Infinity), 17);
+    const seq = Tape().instantiate(Seq(Instant(), Delay(23), Delay(19)).dur(Infinity), 17);
     t.equal(dump(seq),
 `* Seq-0 [17, ∞[
   * Instant-1 @17
@@ -53,14 +53,14 @@ test("Extending duration (indefinite duration)", t => {
 test("Extending duration (no children)", t => {
     const tape = Tape();
     const noChildren = tape.instantiate(Seq().dur(23), 17);
-    const emptyList = tape.instantiate(Seq([]).dur(23), 17);
+    const emptyList = tape.instantiate(Seq().dur(23), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(noChildren), "* Seq-0 [17, 40[ <undefined>", "no children");
     t.equal(dump(emptyList), "* Seq-1 [17, 40[ <undefined>", "empty list");
 });
 
 test("Extending duration (but constrained by parent)", t => {
-    const seq = Tape().instantiate(Seq([Instant(), Delay(23), Delay(19)]).dur(71), 17, 51);
+    const seq = Tape().instantiate(Seq(Instant(), Delay(23), Delay(19)).dur(71), 17, 51);
     t.equal(dump(seq),
 `* Seq-0 [17, 68[
   * Instant-1 @17
@@ -69,7 +69,7 @@ test("Extending duration (but constrained by parent)", t => {
 });
 
 test("Cutting off duration (dur)", t => {
-    const seq = Tape().instantiate(Seq([Instant(), Delay(23), Delay(19)]).dur(31), 17);
+    const seq = Tape().instantiate(Seq(Instant(), Delay(23), Delay(19)).dur(31), 17);
     t.equal(dump(seq),
 `* Seq-0 [17, 48[
   * Instant-1 @17
@@ -78,7 +78,7 @@ test("Cutting off duration (dur)", t => {
 });
 
 test("Cutting off duration (parent duration)", t => {
-    const seq = Tape().instantiate(Seq([Instant(), Delay(23), Delay(19)]), 17, 31);
+    const seq = Tape().instantiate(Seq(Instant(), Delay(23), Delay(19)), 17, 31);
     t.equal(dump(seq),
 `* Seq-0 [17, 48[
   * Instant-1 @17
@@ -87,7 +87,7 @@ test("Cutting off duration (parent duration)", t => {
 });
 
 test("dur(0)", t => {
-    const seq = Tape().instantiate(Seq([Instant(), Delay(0), Par(), Delay(23), Instant()]).dur(0), 17);
+    const seq = Tape().instantiate(Seq(Instant(), Delay(0), Par(), Delay(23), Instant()).dur(0), 17);
     t.equal(dump(seq),
 `* Seq-0 @17
   * Instant-1 @17
@@ -97,7 +97,7 @@ test("dur(0)", t => {
 });
 
 test("dur(0) with only zero-duration children", t => {
-    const seq = Tape().instantiate(Seq([Instant(), Delay(0), Par()]).dur(0), 17);
+    const seq = Tape().instantiate(Seq(Instant(), Delay(0), Par()).dur(0), 17);
     t.equal(dump(seq),
 `* Seq-0 @17
   * Instant-1 @17
@@ -107,9 +107,9 @@ test("dur(0) with only zero-duration children", t => {
 
 test("Seq.take(n).dur(d), cutting off the duration", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K("A")), Delay(23), Instant(x => x + "*"), Delay(31), Instant(x => x + "*")
-    ]).take(3).dur(19), 17);
+    ).take(3).dur(19), 17);
     Deck({ tape }).now = 37;
     t.equal(dump(seq),
 `* Seq-0 [17, 36[ <A>
@@ -119,9 +119,9 @@ test("Seq.take(n).dur(d), cutting off the duration", t => {
 
 test("Seq.take(n).dur(d), extending the duration", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K("A")), Delay(23), Instant(x => x + "A"), Delay(31), Instant(x => x + "*")
-    ]).take(3).dur(39), 17);
+    ).take(3).dur(39), 17);
     Deck({ tape }).now = 57;
     t.equal(dump(seq),
 `* Seq-0 [17, 56[ <AA>
@@ -133,7 +133,7 @@ test("Seq.take(n).dur(d), extending the duration", t => {
 test("Cutoff child; resolved duration", t => {
     const tape = Tape();
     const seq = tape.instantiate(
-        Seq([Par([23, 19, 31].map(Delay)), Instant(K("ko"))]).dur(31), 17
+        Seq(Par(...[23, 19, 31].map(Delay)), Instant(K("ko"))).dur(31), 17
     );
     Deck({ tape }).now = 49;
     t.equal(dump(seq),
@@ -147,7 +147,7 @@ test("Cutoff child; resolved duration", t => {
 test("Cutoff child; unresolved duration", t => {
     const tape = Tape();
     const seq = tape.instantiate(
-        Seq([Instant(K([23, 19, 41])), Par.map(Delay), Instant(K("ko"))]).dur(31), 17
+        Seq(Instant(K([23, 19, 41])), Par.map(Delay), Instant(K("ko"))).dur(31), 17
     );
     Deck({ tape }).now = 49;
     t.equal(dump(seq),
@@ -162,7 +162,7 @@ test("Cutoff child; unresolved duration", t => {
 test("Cutoff child; after child with unresolved duration", t => {
     const tape = Tape();
     const seq = tape.instantiate(
-        Seq([Instant(K([23, 19, 41])), Par.map(Delay), Delay(31), (K("ko"))]).dur(51), 17
+        Seq(Instant(K([23, 19, 41])), Par.map(Delay), Delay(31), (K("ko"))).dur(51), 17
     );
     Deck({ tape }).now = 69;
     t.equal(dump(seq),
@@ -178,7 +178,7 @@ test("Cutoff child; after child with unresolved duration", t => {
 test("Extending duration; child with unresolved duration", t => {
     const tape = Tape();
     const seq = tape.instantiate(
-        Seq([Instant(K([23, 19, 41])), Par.map(Delay), Instant(K("ok"))]).dur(71), 17
+        Seq(Instant(K([23, 19, 41])), Par.map(Delay), Instant(K("ok"))).dur(71), 17
     );
     Deck({ tape }).now = 89;
     t.equal(dump(seq),

--- a/tests/seq-fold.html
+++ b/tests/seq-fold.html
@@ -35,7 +35,7 @@ test("Seq.fold(g, z).repeat()", t => {
 
 test("Instantiation; child of Seq", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([1, 2, 3])), Seq.fold(x => Instant(y => x + y), 0)]), 17);
+    const seq = tape.instantiate(Seq(Instant(K([1, 2, 3])), Seq.fold(x => Instant(y => x + y), 0)), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(seq),
 `* Seq-0 @17 <6>
@@ -48,11 +48,11 @@ test("Instantiation; child of Seq", t => {
 
 test("Instantiation; child of Seq, siblings", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K([1, 2, 3])),
         Seq.fold(x => Instant(y => x + y), 0),
         Delay(23)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(seq),
 `* Seq-0 [17, 40[ <6>
@@ -67,7 +67,7 @@ test("Instantiation; child of Seq, siblings", t => {
 test("Instantiation; child of Par", t => {
     const tape = Tape();
     const seq = tape.instantiate(
-        Seq([Instant(K([1, 2, 3])), Par([Delay(23), Seq.fold(x => Instant(y => x + y), 0)])]), 17
+        Seq(Instant(K([1, 2, 3])), Par(Delay(23), Seq.fold(x => Instant(y => x + y), 0))), 17
     );
     Deck({ tape }).now = 41;
     t.equal(dump(seq),
@@ -83,11 +83,11 @@ test("Instantiation; child of Par", t => {
 
 test("Instantiation; empty input array", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K([])),
         Seq.fold(Delay, 31),
         Delay(23)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(seq),
 `* Seq-0 [17, 40[ <31>
@@ -98,11 +98,11 @@ test("Instantiation; empty input array", t => {
 
 test("Instantiation failure; child of Seq", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K("oops")),
         Seq.fold(x => Instant(y => x + y), 0),
         Delay(23)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(seq),
 `* Seq-0 @17 (failed)
@@ -113,7 +113,7 @@ test("Instantiation failure; child of Seq", t => {
 test("Instantiation failure; child of Par", t => {
     const tape = Tape();
     const seq = tape.instantiate(
-        Seq([Instant(K("oops")), Par([Delay(23), Seq.fold(x => Instant(y => x + y), 0)])]), 17
+        Seq(Instant(K("oops")), Par(Delay(23), Seq.fold(x => Instant(y => x + y), 0))), 17
     );
     Deck({ tape }).now = 41;
     t.equal(dump(seq),
@@ -126,11 +126,11 @@ test("Instantiation failure; child of Par", t => {
 
 test("Instantiation failure; could not instantiate input", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K([1, 2, 3])),
         Seq.fold(() => { throw window.Error("Augh!"); }),
         Delay(23)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(seq),
 `* Seq-0 @17 (failed)
@@ -141,7 +141,7 @@ test("Instantiation failure; could not instantiate input", t => {
 test("Seq.fold(g, z).repeat(); instantiation failure", t => {
     const tape = Tape();
     const seq = tape.instantiate(
-        Seq([Instant(K([1, 2, 3])), Seq.fold(x => Instant(y => x + y), 0).repeat()]), 17
+        Seq(Instant(K([1, 2, 3])), Seq.fold(x => Instant(y => x + y), 0).repeat()), 17
     );
     Deck({ tape }).now = 18;
     t.equal(dump(seq),
@@ -157,11 +157,11 @@ test("Seq.fold(g, z).repeat(); instantiation failure", t => {
 
 test("Seq.fold(g, z).take(n = ∞)", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K([1, 2, 3, 4, 5])),
         Seq.fold(x => Instant(y => x + y), 0).take(),
         Delay(23)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(seq),
 `* Seq-0 [17, 40[ <15>
@@ -177,22 +177,22 @@ test("Seq.fold(g, z).take(n = ∞)", t => {
 
 test("Seq.fold(g, z).take(n); fails at runtime when n > input length", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K([1, 2, 3, 4, 5])),
         Seq.fold(x => Instant(y => x + y), 0).take(7),
         Delay(23)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 18;
     t.equal(seq.error.message, "failed", "failed to instantiate map");
 });
 
 test("Seq.fold(g, z).take(n); n < child count", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K([1, 2, 3, 4, 5])),
         Seq.fold(x => Instant(y => x + y), 0).take(3),
         Delay(23)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(seq),
 `* Seq-0 [17, 40[ <6>
@@ -206,11 +206,11 @@ test("Seq.fold(g, z).take(n); n < child count", t => {
 
 test("Seq.fold(g, z).take(0)", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K([1, 2, 3, 4, 5])),
         Seq.fold(x => Instant(y => x + y), 0).take(0),
         Delay(23)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(seq),
 `* Seq-0 [17, 40[ <0>
@@ -221,10 +221,10 @@ test("Seq.fold(g, z).take(0)", t => {
 
 test("Seq.fold(g, z).dur(d), extending duration", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K([23, 19, 31])),
-        Seq.fold(x => Seq([Delay(x), Instant(y => x + y)]), 0).dur(83)
-    ]), 17);
+        Seq.fold(x => Seq(Delay(x), Instant(y => x + y)), 0).dur(83)
+    ), 17);
     Deck({ tape }).now = 101;
     t.equal(dump(seq),
 `* Seq-0 [17, 100[ <73>
@@ -243,10 +243,10 @@ test("Seq.fold(g, z).dur(d), extending duration", t => {
 
 test("Seq.fold(g, z).dur(d), cutting off duration", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K([23, 19, 31])),
-        Seq.fold(x => Seq([Delay(x), Instant(y => x + y)]), 0).dur(43)
-    ]), 17);
+        Seq.fold(x => Seq(Delay(x), Instant(y => x + y)), 0).dur(43)
+    ), 17);
     Deck({ tape }).now = 61;
     t.equal(dump(seq),
 `* Seq-0 [17, 60[ <42>
@@ -264,10 +264,10 @@ test("Seq.fold(g, z).dur(d), cutting off duration", t => {
 
 test("Seq.fold(g, z).dur(d), cutting off parent (i.e. instantiation) duration", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K([23, 19, 31])),
-        Seq.fold(x => Seq([Delay(x), Instant(y => x + y)]), 0)
-    ]).dur(43), 17);
+        Seq.fold(x => Seq(Delay(x), Instant(y => x + y)), 0)
+    ).dur(43), 17);
     Deck({ tape }).now = 61;
     t.equal(dump(seq),
 `* Seq-0 [17, 60[ <42>
@@ -285,10 +285,10 @@ test("Seq.fold(g, z).dur(d), cutting off parent (i.e. instantiation) duration", 
 
 test("Seq.fold(g, z).dur(0), cutting off duration (???)", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K([23, 19, 31])),
-        Seq.fold(x => Seq([Delay(x), Instant(y => x + y)]), 0).dur(0)
-    ]), 17);
+        Seq.fold(x => Seq(Delay(x), Instant(y => x + y)), 0).dur(0)
+    ), 17);
     Deck({ tape }).now = 61;
     t.equal(dump(seq),
 `* Seq-0 @17 <0>
@@ -300,10 +300,10 @@ test("Seq.fold(g, z).dur(0), cutting off duration (???)", t => {
 
 test("Cancel Seq.fold", t => {
     const tape = Tape();
-    const choice = tape.instantiate(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
-        Seq([Instant(K([1, 2, 3])), Seq.fold(x => Seq([Instant(y => x + y), Delay(23)]), 0)])
-    ]).take(1), 17);
+    const choice = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Seq(Instant(K([1, 2, 3])), Seq.fold(x => Seq(Instant(y => x + y), Delay(23)), 0))
+    ).take(1), 17);
     Deck({ tape }).now = 37;
     t.equal(dump(choice),
 `* Par-0 [17, 36[ <19>
@@ -322,10 +322,10 @@ test("Cancel Seq.fold", t => {
 
 test("Prune Seq.fold", t => {
     const tape = Tape();
-    const choice = tape.instantiate(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
-        Seq([Delay(23), Seq.fold(x => Instant(y => x + y), 0)])
-    ]).take(1), 17);
+    const choice = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Seq(Delay(23), Seq.fold(x => Instant(y => x + y), 0))
+    ).take(1), 17);
     Deck({ tape }).now = 37;
     t.equal(dump(choice),
 `* Par-0 [17, 36[ <19>

--- a/tests/seq-map.html
+++ b/tests/seq-map.html
@@ -33,7 +33,7 @@ test("Seq.map(g).repeat()", t => {
 
 test("Instantiation", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([31, 19, 23])), Seq.map(Delay)]), 17);
+    const seq = tape.instantiate(Seq(Instant(K([31, 19, 23])), Seq.map(Delay)), 17);
     Deck({ tape }).now = 91;
     t.equal(dump(seq),
 `* Seq-0 [17, 90[ <31,19,23>
@@ -46,14 +46,14 @@ test("Instantiation", t => {
 
 test("Instantiation; empty input array", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([])), Seq.map(Delay)]), 17);
+    const seq = tape.instantiate(Seq(Instant(K([])), Seq.map(Delay)), 17);
     Deck({ tape }).now = 91;
     t.equal(seq.value, [], "empty list");
 });
 
 test("Seq.map(g).take(n = ∞)", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([31, 19, 23, 41, 37])), Seq.map(Delay).take()]), 17);
+    const seq = tape.instantiate(Seq(Instant(K([31, 19, 23, 41, 37])), Seq.map(Delay).take()), 17);
     Deck({ tape }).now = 169;
     t.equal(dump(seq),
 `* Seq-0 [17, 168[ <31,19,23,41,37>
@@ -68,14 +68,14 @@ test("Seq.map(g).take(n = ∞)", t => {
 
 test("Seq.map(g).take(n); fails at runtime when n > input length", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([31, 19, 23, 41, 37])), Seq.map(Delay).take(7)]), 17);
+    const seq = tape.instantiate(Seq(Instant(K([31, 19, 23, 41, 37])), Seq.map(Delay).take(7)), 17);
     Deck({ tape }).now = 18;
     t.equal(seq.error.message, "failed", "failed to instantiate map");
 });
 
 test("Seq.map(g).take(n); n < input length", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([31, 19, 23, 41, 37])), Seq.map(Delay).take(3)]), 17);
+    const seq = tape.instantiate(Seq(Instant(K([31, 19, 23, 41, 37])), Seq.map(Delay).take(3)), 17);
     Deck({ tape }).now = 91;
     t.equal(dump(seq),
 `* Seq-0 [17, 90[ <31,19,23>
@@ -88,7 +88,7 @@ test("Seq.map(g).take(n); n < input length", t => {
 
 test("Seq.map(g).take(0)", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([31, 19, 23, 41, 37])), Seq.map(Delay).take(0)]), 17);
+    const seq = tape.instantiate(Seq(Instant(K([31, 19, 23, 41, 37])), Seq.map(Delay).take(0)), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(seq),
 `* Seq-0 @17 <>
@@ -99,7 +99,7 @@ test("Seq.map(g).take(0)", t => {
 
 test("Seq.map(g) failure; input is not an array", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K("oops")), Seq.map(Delay)]), 17);
+    const seq = tape.instantiate(Seq(Instant(K("oops")), Seq.map(Delay)), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(seq),
 `* Seq-0 @17 (failed)
@@ -109,10 +109,10 @@ test("Seq.map(g) failure; input is not an array", t => {
 
 test("Seq.map(g) failure; could not instantiate input", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K([1, 2, 3])),
         Seq.map(() => { throw window.Error("Augh!"); })
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(seq),
 `* Seq-0 @17 (failed)
@@ -123,7 +123,7 @@ test("Seq.map(g) failure; could not instantiate input", t => {
 test("Seq.map(g) failure; could not instantiate input (after an unresolved duration)", t => {
     const tape = Tape();
     const deck = Deck({ tape });
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K([1, 2, 3])),
         Seq.map((_, i) => {
             if (i > 0) {
@@ -131,7 +131,7 @@ test("Seq.map(g) failure; could not instantiate input (after an unresolved durat
             }
             return Event(window, "synth");
         })
-    ]), 17);
+    ), 17);
     deck.now = 51;
     window.dispatchEvent(new window.Event("synth"));
     deck.now = 52;
@@ -140,7 +140,7 @@ test("Seq.map(g) failure; could not instantiate input (after an unresolved durat
 
 test("Seq.map(g).repeat(); instantiation", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([19, 23])), Seq.map(Delay).repeat()]), 17);
+    const seq = tape.instantiate(Seq(Instant(K([19, 23])), Seq.map(Delay).repeat()), 17);
     Deck({ tape }).now = 111;
     t.equal(dump(seq),
 `* Seq-0 [17, ∞[
@@ -159,7 +159,7 @@ test("Seq.map(g).repeat(); instantiation", t => {
 
 test("Seq.map(g).repeat().take(n)", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([19, 23])), Seq.map(Delay).repeat().take(3)]), 17);
+    const seq = tape.instantiate(Seq(Instant(K([19, 23])), Seq.map(Delay).repeat().take(3)), 17);
     Deck({ tape }).now = 144;
     t.equal(dump(seq),
 `* Seq-0 [17, 143[ <19,23>
@@ -178,7 +178,7 @@ test("Seq.map(g).repeat().take(n)", t => {
 
 test("Seq.map(g).dur(d), extending duration", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([31, 19, 23])), Seq.map(Delay).dur(83)]), 17);
+    const seq = tape.instantiate(Seq(Instant(K([31, 19, 23])), Seq.map(Delay).dur(83)), 17);
     Deck({ tape }).now = 101;
     t.equal(dump(seq),
 `* Seq-0 [17, 100[ <31,19,23>
@@ -191,7 +191,7 @@ test("Seq.map(g).dur(d), extending duration", t => {
 
 test("Seq.map(g).dur(d), cutting off duration", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([31, 19, 23])), Seq.map(Delay).dur(43)]), 17);
+    const seq = tape.instantiate(Seq(Instant(K([31, 19, 23])), Seq.map(Delay).dur(43)), 17);
     Deck({ tape }).now = 61;
     t.equal(dump(seq),
 `* Seq-0 [17, 60[ <31,19>
@@ -203,7 +203,7 @@ test("Seq.map(g).dur(d), cutting off duration", t => {
 
 test("Seq.map(g).dur(0), cutting off duration (???)", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([31, 19, 23])), Seq.map(Delay).dur(0)]), 17);
+    const seq = tape.instantiate(Seq(Instant(K([31, 19, 23])), Seq.map(Delay).dur(0)), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(seq),
 `* Seq-0 @17 <31>
@@ -214,7 +214,7 @@ test("Seq.map(g).dur(0), cutting off duration (???)", t => {
 
 test("Seq.map(g).dur(d), cutting off duration during instantiation", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([31, 19, 23])), Seq.map(Delay)]), 17, 43);
+    const seq = tape.instantiate(Seq(Instant(K([31, 19, 23])), Seq.map(Delay)), 17, 43);
     Deck({ tape }).now = 61;
     t.equal(dump(seq),
 `* Seq-0 [17, 60[ <31,19>
@@ -226,10 +226,10 @@ test("Seq.map(g).dur(d), cutting off duration during instantiation", t => {
 
 test("Children with unresolved duration", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Instant(K([23, 19, 31])),
-        Seq.fold(x => Seq([Instant(K([x])), Par.map(Delay)]))
-    ]), 17);
+        Seq.fold(x => Seq(Instant(K([x])), Par.map(Delay)))
+    ), 17);
     Deck({ tape }).now = 91;
     t.equal(dump(instance),
 `* Seq-0 [17, 90[ <31>
@@ -251,10 +251,10 @@ test("Children with unresolved duration", t => {
 
 test("Cancel Seq.map", t => {
     const tape = Tape();
-    const choice = tape.instantiate(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
-        Seq([Instant(K([23, 31])), Seq.map(Delay)]),
-    ]).take(1), 17);
+    const choice = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Seq(Instant(K([23, 31])), Seq.map(Delay)),
+    ).take(1), 17);
     Deck({ tape }).now = 37;
     t.equal(dump(choice),
 `* Par-0 [17, 36[ <19>
@@ -271,10 +271,10 @@ test("Cancel Seq.map", t => {
 
 test("Prune Seq.map", t => {
     const tape = Tape();
-    const choice = tape.instantiate(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
-        Seq([Delay(23), Seq.map(Delay)])
-    ]).take(1), 17);
+    const choice = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Seq(Delay(23), Seq.map(Delay))
+    ).take(1), 17);
     Deck({ tape }).now = 37;
     t.equal(dump(choice),
 `* Par-0 [17, 36[ <19>

--- a/tests/seq-repeat.html
+++ b/tests/seq-repeat.html
@@ -13,7 +13,7 @@ import { Tape } from "../lib/tape.js";
 import { Deck } from "../lib/deck.js";
 
 test("Seq(xs).repeat()", t => {
-    const seq = Seq([Delay(23)]);
+    const seq = Seq(Delay(23));
     const repeat = seq.repeat();
     t.equal(repeat.show(), "Seq/repeat", "show");
     t.equal(repeat.child, seq, "repeat child");
@@ -25,10 +25,10 @@ test("Seq(xs).repeat()", t => {
 
 test("Instantiation", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K(1)),
-        Seq([Instant(x => x * 2), Delay(23)]).repeat()
-    ]), 17);
+        Seq(Instant(x => x * 2), Delay(23)).repeat()
+    ), 17);
     Deck({ tape }).now = 110;
     t.equal(dump(seq),
 `* Seq-0 [17, ∞[
@@ -54,16 +54,16 @@ test("Instantiation", t => {
 test("Instantiation fails for zero duration", t => {
     const tape = Tape();
     t.undefined(tape.instantiate(Seq().repeat(), 17), "empty seq");
-    t.undefined(tape.instantiate(Seq([Instant(), Instant()]).repeat(), 17), "zero duration seq");
+    t.undefined(tape.instantiate(Seq(Instant(), Instant()).repeat(), 17), "zero duration seq");
     t.undefined(tape.instantiate(Seq().repeat().dur(23), 17), "also fails with dur()");
 });
 
 test("Seq(xs).repeat().take(n)", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K(1)),
-        Seq([Instant(x => x * 2), Delay(23)]).repeat().take(4)
-    ]), 17);
+        Seq(Instant(x => x * 2), Delay(23)).repeat().take(4)
+    ), 17);
     Deck({ tape }).now = 110;
     t.equal(seq.value, 16, "return value");
 });
@@ -81,7 +81,7 @@ test("Seq(xs).repeat().take(n); empty seq", t => {
 
 test("Seq(xs).repeat().take(n); zero-duration seq", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K("A")), Instant(x => x + "*")]).repeat().take(3), 17);
+    const seq = tape.instantiate(Seq(Instant(K("A")), Instant(x => x + "*")).repeat().take(3), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(seq),
 `* Seq/repeat-0 @17 <A*>
@@ -98,7 +98,7 @@ test("Seq(xs).repeat().take(n); zero-duration seq", t => {
 
 test("Repeat with unresolved duration", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([19, 23])), Seq.map(Delay)]).repeat(), 17);
+    const seq = tape.instantiate(Seq(Instant(K([19, 23])), Seq.map(Delay)).repeat(), 17);
     Deck({ tape }).now = 111;
     t.equal(dump(seq),
 `* Seq/repeat-0 [17, ∞[
@@ -121,10 +121,10 @@ test("Repeat with unresolved duration", t => {
 
 test("Repeat with dur", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K("A")),
-        Seq([Delay(7), Instant(x => x + "+")]).repeat().dur(23)
-    ]), 17);
+        Seq(Delay(7), Instant(x => x + "+")).repeat().dur(23)
+    ), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(seq),
 `* Seq-0 [17, 40[ <A+++>
@@ -145,10 +145,10 @@ test("Repeat with dur", t => {
 
 test("Repeat with dur and take (extend duration)", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K("A")),
-        Seq([Delay(7), Instant(x => x + "+")]).repeat().take(3).dur(23)
-    ]), 17);
+        Seq(Delay(7), Instant(x => x + "+")).repeat().take(3).dur(23)
+    ), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(seq),
 `* Seq-0 [17, 40[ <A+++>
@@ -167,10 +167,10 @@ test("Repeat with dur and take (extend duration)", t => {
 
 test("Repeat with dur and take (not enough iterations)", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K("A")),
-        Seq([Delay(7), Instant(x => x + "+")]).repeat().take(4).dur(23)
-    ]), 17);
+        Seq(Delay(7), Instant(x => x + "+")).repeat().take(4).dur(23)
+    ), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(seq),
 `* Seq-0 [17, 40[ (failed)

--- a/tests/seq-take.html
+++ b/tests/seq-take.html
@@ -14,34 +14,34 @@ import { Deck } from "../lib/deck.js";
 
 test("Seq(xs).take(n = ∞) duration", t => {
     t.equal(
-        Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take().duration, 141,
+        Seq(Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)).take().duration, 141,
         "dur with n = ∞"
     );
     t.undefined(
-        Seq([Delay(51), Delay(23), Delay(31), Par.map(), Par.map()]).take().duration,
+        Seq(Delay(51), Delay(23), Delay(31), Par.map(), Par.map()).take().duration,
         "dur with n = ∞ (indefinite durations)"
     );
     t.equal(
-        Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(7).duration, 0,
+        Seq(Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)).take(7).duration, 0,
         "zero dur with n > child count (failure)"
     );
     t.equal(
-        Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(3).duration, 105,
+        Seq(Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)).take(3).duration, 105,
         "dur with n < child count"
     );
     t.undefined(
-        Seq([Delay(51), Delay(23), Par.map(), Delay(19)]).take(3).duration,
+        Seq(Delay(51), Delay(23), Par.map(), Delay(19)).take(3).duration,
         "dur with n < child count, but unresolved duration"
     );
     t.equal(
-        Seq([Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)]).take(0).duration, 0,
+        Seq(Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)).take(0).duration, 0,
         "dur with n = 0"
     );
 });
 
 test("Instantiation, n = ∞", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K("ok")), Delay(23), Delay(19)]).take(), 17);
+    const seq = tape.instantiate(Seq(Instant(K("ok")), Delay(23), Delay(19)).take(), 17);
     Deck({ tape }).now = 60;
     t.equal(dump(seq),
 `* Seq-0 [17, 59[ <ok>
@@ -53,14 +53,14 @@ test("Instantiation, n = ∞", t => {
 test("Instantiation fails when n > xs.length", t => {
     const tape = Tape();
     t.undefined(
-        tape.instantiate(Seq([Instant(K("ok")), Delay(23), Delay(19)]).take(7), 17),
+        tape.instantiate(Seq(Instant(K("ok")), Delay(23), Delay(19)).take(7), 17),
         "not enough children"
     );
 });
 
 test("Instantiation; n < xs.length", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K("ok")), Delay(23), Instant(K("nope"))]).take(2), 17);
+    const seq = tape.instantiate(Seq(Instant(K("ok")), Delay(23), Instant(K("nope"))).take(2), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(seq),
 `* Seq-0 [17, 40[ <ok>
@@ -70,20 +70,20 @@ test("Instantiation; n < xs.length", t => {
 
 test("Instantiation failure in child after nth", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K("ok")),
         Instant(),
         Instant(),
         Instant().repeat(),
         Instant(() => { throw Error("should not be intantiated"); })
-    ]).take(3), 17);
+    ).take(3), 17);
     Deck({ tape }).now = 18;
     t.equal(seq.value, "ok", "correct value");
 });
 
 test("Instantiation; n = 0", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K("nope")), Delay(23), Delay(19)]).take(0), 17);
+    const seq = tape.instantiate(Seq(Instant(K("nope")), Delay(23), Delay(19)).take(0), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(seq), "* Seq-0 @17 <undefined>", "dump matches");
 });

--- a/tests/seq.html
+++ b/tests/seq.html
@@ -24,7 +24,7 @@ test("Seq()", t => {
 test("Seq(xs)", t => {
     const delay = Delay(17);
     const instant = Instant(x => x * 2);
-    const seq = Seq([delay, instant]);
+    const seq = Seq(delay, instant);
     t.equal(seq.show(), "Seq/2", "show");
     t.equal(seq.children, [delay, instant], "children");
     t.equal(delay.parent, seq, "parent (1)");
@@ -34,24 +34,24 @@ test("Seq(xs)", t => {
 });
 
 test("Seq duration", t => {
-    t.equal(Seq([Instant(), Instant(), Par(), Seq()]).duration, 0, "non-empty but zero duration");
+    t.equal(Seq(Instant(), Instant(), Par(), Seq()).duration, 0, "non-empty but zero duration");
     t.equal(
-        Seq([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31).repeat()]).duration, Infinity,
+        Seq(Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31).repeat()).duration, Infinity,
         "indefinite duration (1)"
     );
     t.equal(
-        Seq([Instant(), Delay(23).repeat(), Seq.fold(), Par.map(), Delay(31)]).duration, Infinity,
+        Seq(Instant(), Delay(23).repeat(), Seq.fold(), Par.map(), Delay(31)).duration, Infinity,
         "indefinite duration (2)"
     );
     t.undefined(
-        Seq([Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31)]).duration,
+        Seq(Instant(), Delay(23), Seq.fold(), Par.map(), Delay(31)).duration,
         "unresolved duration"
     );
 });
 
 test("Seq value", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K("ok")), Delay(23)]), 17);
+    const seq = tape.instantiate(Seq(Instant(K("ok")), Delay(23)), 17);
     Deck({ tape }).now = 41;
     t.equal(seq.value, "ok", "Seq value");
 });
@@ -61,7 +61,7 @@ test("Instantiation", t => {
     const instant = Instant();
     const delay1 = Delay(23);
     const delay2 = Delay(19);
-    const seq = Seq([instant, delay1, delay2]);
+    const seq = Seq(instant, delay1, delay2);
     const instance = tape.instantiate(seq, 17);
     t.equal(instance.tape, tape, "instance.tape is set");
     t.equal(instance.item, seq, "instance.item is set");
@@ -96,7 +96,7 @@ test("Instantiation; empty", t => {
 
 test("Instantiation; zero duration", t => {
     const tape = Tape();
-    const seq = Seq([Instant(), Instant(), Instant()]);
+    const seq = Seq(Instant(), Instant(), Instant());
     const instance = tape.instantiate(seq, 17);
     t.equal(instance.t, 17, "instance.t is set");
     Deck({ tape }).now = 18;
@@ -105,7 +105,7 @@ test("Instantiation; zero duration", t => {
 
 test("Instantiation; child with infinite duration", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(), Instant(), Delay(23).repeat(), Par().take(1)]), 17);
+    const seq = tape.instantiate(Seq(Instant(), Instant(), Delay(23).repeat(), Par().take(1)), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(seq),
 `* Seq-0 [17, ∞[
@@ -117,7 +117,7 @@ test("Instantiation; child with infinite duration", t => {
 
 test("Instantiation; child with unresolved duration", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([Instant(K([23])), Par.map(Delay), Instant()]), 17);
+    const seq = tape.instantiate(Seq(Instant(K([23])), Par.map(Delay), Instant()), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(seq),
 `* Seq-0 [17, 40[ <23>
@@ -129,10 +129,10 @@ test("Instantiation; child with unresolved duration", t => {
 
 test("Instantiation; child with unresolved duration; failure once the end is resolved", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Instant(K([23])), Par.map(Delay),
         Instant(K("ko")), Par.map(Delay)
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(seq),
 `* Seq-0 [17, 40[ (failed)
@@ -145,21 +145,21 @@ test("Instantiation; child with unresolved duration; failure once the end is res
 
 test("Instantiation failure", t => {
     const tape = Tape();
-    t.undefined(tape.instantiate(Seq([
+    t.undefined(tape.instantiate(Seq(
         Instant(() => { throw Error("should be pruned"); }),
         Instant().repeat(),
         Instant(() => { throw Error("should not be intantiated"); })
-    ]), 17), "failed to instantiate seq");
+    ), 17), "failed to instantiate seq");
     t.equal(tape.occurrences.length, 0, "no occurrences on tape");
 });
 
 test("Child failure (not the last child)", async t => {
     const tape = Tape();
     const deck = Deck({ tape });
-    const seq = tape.instantiate(Seq([
+    const seq = tape.instantiate(Seq(
         Await(async () => await timeout(10)).dur(19),
         Instant(K("ok"))
-    ]), 17);
+    ), 17);
     deck.now = 51;
     await notification(deck, "await");
     t.equal(dump(seq),
@@ -169,10 +169,10 @@ test("Child failure (not the last child)", async t => {
 
 test("Cancel Seq", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
-        Seq([Instant(K("ok")), Delay(23), Instant(() => { throw Error("should be pruned"); })])
-    ]).take(1), 17);
+    const instance = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Seq(Instant(K("ok")), Delay(23), Instant(() => { throw Error("should be pruned"); }))
+    ).take(1), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(instance),
 `* Par-0 [17, 36[ <19>
@@ -188,12 +188,12 @@ test("Cancel Seq", t => {
 
 test("Prune Seq", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
-        Seq([Instant(K("ok")), Delay(23), Seq([
+    const instance = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Seq(Instant(K("ok")), Delay(23), Seq(
             Seq(), Instant(() => { throw Error("should be pruned"); })
-        ])])
-    ]).take(1), 17);
+        ))
+    ).take(1), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(instance),
 `* Par-0 [17, 36[ <19>

--- a/tests/try.html
+++ b/tests/try.html
@@ -39,7 +39,7 @@ test("Instantiation (no error, zero duration)", t => {
 test("Instantiation (no error, unresolved duration)", t => {
     const tape = Tape();
     const instance = tape.instantiate(Try(
-        Seq([Instant(K([23])), Par.map(Delay)]),
+        Seq(Instant(K([23])), Par.map(Delay)),
         Instant(K("ko"))
     ), 17);
     Deck({ tape }).now = 41;
@@ -122,10 +122,10 @@ test("Instantiation (async error)", async t => {
 
 test("Recovery in Seq", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Seq([
+    const instance = tape.instantiate(Seq(
         Try(Instant(() => { throw window.Error("Augh!"); }), Instant(K("ok"))),
         Instant(x => x + "!")
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(instance),
 `* Seq-0 @17 <ok!>
@@ -137,10 +137,10 @@ test("Recovery in Seq", t => {
 
 test("Recovery in Par", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Par([
+    const instance = tape.instantiate(Par(
         Try(Instant(() => { throw window.Error("Augh!"); }), Instant(K("ok"))),
         Instant(K("yeah"))
-    ]), 17);
+    ), 17);
     Deck({ tape }).now = 18;
     t.equal(dump(instance),
 `* Par-0 @17 <ok,yeah>
@@ -153,9 +153,9 @@ test("Recovery in Par", t => {
 test("Instantiation (not enough time to recover)", t => {
     const tape = Tape();
     const deck = Deck({ tape });
-    const instance = tape.instantiate(Par([
+    const instance = tape.instantiate(Par(
         Try(Event(window, "synth").dur(23), Event(window, "synth"))
-    ]).dur(23), 17);
+    ).dur(23), 17);
     deck.now = 41;
     t.equal(dump(instance),
 `* Par-0 [17, 40[ (failed)
@@ -165,9 +165,9 @@ test("Instantiation (not enough time to recover)", t => {
 
 test("Catch duration", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Par([
+    const instance = tape.instantiate(Par(
         Try(Instant(() => { throw window.Error("Augh!"); }), Instant(K("ok")).dur(29))
-    ]).dur(23), 17);
+    ).dur(23), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(instance),
 `* Par-0 [17, 40[ <Error: Augh!>
@@ -180,10 +180,10 @@ test("Catch duration", t => {
 test("Cancel (no error)", t => {
     const tape = Tape();
     const deck = Deck({ tape });
-    const instance = tape.instantiate(Par([
+    const instance = tape.instantiate(Par(
         Delay(23),
         Try(Event(window, "synth"), Instant(() => { throw window.Error("not cancelled?!"); }))
-    ]).take(1), 17);
+    ).take(1), 17);
     deck.now = 41;
     t.equal(dump(instance),
 `* Par-0 [17, 40[ <>
@@ -194,10 +194,10 @@ test("Cancel (no error)", t => {
 
 test("Cancel (error)", t => {
     const tape = Tape();
-    const instance = tape.instantiate(Par([
+    const instance = tape.instantiate(Par(
         Delay(23),
         Try(Instant(() => { throw window.Error("Augh!"); }), Delay(37))
-    ]).take(1), 17);
+    ).take(1), 17);
     Deck({ tape }).now = 41;
     t.equal(dump(instance),
 `* Par-0 [17, 40[ <>
@@ -210,10 +210,10 @@ test("Cancel (error)", t => {
 test("Prune (no error)", t => {
     const tape = Tape();
     const deck = Deck({ tape });
-    const choice = tape.instantiate(Par([
-        Seq([Instant(K([19])), Par.map(Delay)]),
-        Seq([Delay(23), Try(Event(window, "synth"), Instant(K("ko")))]),
-    ]).take(1), 17);
+    const choice = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Seq(Delay(23), Try(Event(window, "synth"), Instant(K("ko")))),
+    ).take(1), 17);
     deck.now = 37;
     t.equal(dump(choice),
 `* Par-0 [17, 36[ <19>


### PR DESCRIPTION
Par and Seq behave like Try where parameters of the constructors are the children instead of a list.