### PR TITLE
1P01 Create score

### DIFF
--- a/patcher/cord.js
+++ b/patcher/cord.js
@@ -26,6 +26,7 @@ export const Cord = Object.assign((port, x2, y2) => {
         this.updateEndpoint(this.outlet.centerX, this.outlet.centerY, "x1", "y1");
         this.updateEndpoint(this.inlet.centerX, this.inlet.centerY);
         this.addTarget();
+        this.patcher.cordWasAdded(this);
     },
 
     // Set the inlet of the cord that was started from an outlet.
@@ -33,6 +34,7 @@ export const Cord = Object.assign((port, x2, y2) => {
         this.inlet = port;
         this.updateEndpoint(this.inlet.centerX, this.inlet.centerY);
         this.addTarget();
+        this.patcher.cordWasAdded(this);
     },
 
     // Update one end point of the lines.
@@ -74,6 +76,7 @@ export const Cord = Object.assign((port, x2, y2) => {
 
     // Remove a cord from both of its ports when deleting it. 
     remove() {
+        this.patcher.cordWillBeRemoved(this);
         this.outlet.disconnect(this.inlet, this);
         this.inlet.disconnect(this.outlet, this);
         this.target.removeEventListener("pointerdown", this);

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -6,10 +6,11 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
         this.boxes = new Map();
     },
 
-    // Dump the score (for debugging)
-    dumpScore() {
+    // Dump the score and tape (for debugging)
+    dump() {
         if (this.score) {
             console.log(dump(this.score.instance));
+            console.log(this.score.tape.show());
         } else {
             console.warn("No score");
         }
@@ -61,6 +62,14 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
     boxWillBeRemoved(box) {
         delete this.score;
         this.boxes.delete(box);
+    },
+
+    cordWasAdded(cord) {
+        delete this.score;
+    },
+
+    cordWillBeRemoved(cord) {
+        delete this.score;
     },
 
     inletAcceptsConnection(inlet, outlet) {

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -10,15 +10,19 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
     dumpScore() {
         if (this.score) {
             console.log(dump(this.score.instance));
+        } else {
+            console.warn("No score");
         }
     },
 
     // Create a new score from the current items; or 
-    getScoreForTape(tape) {
+    updateScoreForTape(tape) {
         if (this.score) {
             // The score has not changed and neither should the tape.
             console.assert(this.score.tape === tape);
         } else {
+            // Create a new score.
+            tape.erase();
             this.score = Score({ tape });
             for (const [box, node] of this.boxes.entries()) {
                 if (box.outlets[0].cords.size === 0) {
@@ -26,7 +30,6 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
                 }
             }
         }
-        return this.score;
     },
 
     // Create an item from a box/node pair, getting the inputs from the inlets

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -33,6 +33,10 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
         }
     },
 
+    clearScore() {
+        delete this.score;
+    },
+
     // Create an item from a box/node pair, getting the inputs from the inlets
     // as necessary.
     createItemFor(box, node) {

--- a/patcher/patcher.js
+++ b/patcher/patcher.js
@@ -10,7 +10,7 @@ import { TransportBar } from "./transport-bar.js";
 const Commands = {
     // Dump the score (for debugging)
     d() {
-        this.patch.dumpScore();
+        this.patch.dump();
     },
 
     // Add a new box.
@@ -79,6 +79,14 @@ const Patcher = Object.assign(canvas => create({ canvas }).call(Patcher), {
 
     boxWillBeRemoved(box) {
         this.patch.boxWillBeRemoved(box);
+    },
+
+    cordWasAdded(cord) {
+        this.patch.cordWasAdded(cord);
+    },
+
+    cordWillBeRemoved(cord) {
+        this.patch.cordWillBeRemoved(cord);
     },
 
     // Decide whether a connection between an inlet and an outlet is valid.

--- a/patcher/patcher.js
+++ b/patcher/patcher.js
@@ -55,7 +55,7 @@ const Patcher = Object.assign(canvas => create({ canvas }).call(Patcher), {
         this.patch = Patch();
         this.transportBar = TransportBar(document.querySelector("ul.transport-bar"));
         on(this.transportBar, "play", ({ tape }) => {
-            const score = this.patch.getScoreForTape(tape);
+            this.patch.updateScoreForTape(tape);
         });
     },
 

--- a/patcher/patcher.js
+++ b/patcher/patcher.js
@@ -8,6 +8,11 @@ import { TransportBar } from "./transport-bar.js";
 // Keyboard commands for different key. `this` is set to the patcher that calls
 // the command.
 const Commands = {
+    // Dump the score (for debugging)
+    d() {
+        this.patch.dumpScore();
+    },
+
     // Add a new box.
     n() {
         const box = Box({

--- a/patcher/patcher.js
+++ b/patcher/patcher.js
@@ -49,8 +49,8 @@ const Patcher = Object.assign(canvas => create({ canvas }).call(Patcher), {
 
         this.patch = Patch();
         this.transportBar = TransportBar(document.querySelector("ul.transport-bar"));
-        on(this.transportBar, "play", () => {
-            // FIXME 1P01 Create items from boxes
+        on(this.transportBar, "play", ({ tape }) => {
+            const score = this.patch.getScoreForTape(tape);
         });
     },
 

--- a/patcher/patcher.js
+++ b/patcher/patcher.js
@@ -57,6 +57,9 @@ const Patcher = Object.assign(canvas => create({ canvas }).call(Patcher), {
         on(this.transportBar, "play", ({ tape }) => {
             this.patch.updateScoreForTape(tape);
         });
+        on(this.transportBar, "stop", () => {
+            this.patch.clearScore();
+        });
     },
 
     // Keep track of the pointer position and listen to keyboard commands.

--- a/patcher/transport-bar.js
+++ b/patcher/transport-bar.js
@@ -6,6 +6,7 @@ import { Deck } from "../lib/deck.js";
 const stop = ["stopped", function() {
     this.deck.stop();
     this.updateDisplay();
+    notify(this, "stop");
 }];
 
 const States = {
@@ -13,6 +14,7 @@ const States = {
         stop: ["stopped", function() {
             this.deck.now = 0;
             this.updateDisplay();
+            notify(this, "stop");
         }],
         play: ["forward", function() {
             this.deck.now = 0;

--- a/patcher/transport-bar.js
+++ b/patcher/transport-bar.js
@@ -1,5 +1,6 @@
 import { notify, on } from "../lib/events.js";
 import { assoc, create, nop } from "../lib/util.js";
+import { Tape } from "../lib/tape.js";
 import { Deck } from "../lib/deck.js";
 
 const stop = ["stopped", function() {
@@ -16,7 +17,7 @@ const States = {
         play: ["forward", function() {
             this.deck.now = 0;
             this.deck.start();
-            notify(this, "play");
+            notify(this, "play", { tape: this.tape });
         }],
     },
 
@@ -46,7 +47,7 @@ export const TransportBar = Object.assign(element => create({ element }).call(Tr
             }
         );
         this.display = this.element.querySelector("span.display");
-        this.deck = Deck();
+        this.deck = Deck({ tape: Tape() });
         on(this.deck, "update", () => {
             this.updateDisplay();
         });

--- a/patcher/transport-bar.js
+++ b/patcher/transport-bar.js
@@ -17,7 +17,7 @@ const States = {
         play: ["forward", function() {
             this.deck.now = 0;
             this.deck.start();
-            notify(this, "play", { tape: this.tape });
+            notify(this, "play", { tape: this.deck.tape });
         }],
     },
 


### PR DESCRIPTION
Create a score from the boxes when playing, starting from any box with no outlet.

The score and tape are cleared when a change is made (a box is edited, added or removed, or a cord is added or removed). The D command (for dump/debug) shows the current score instance and tape in the console.