### PR TITLE
1Q0B Delay(Infinity) should not create an occurrence

### DIFF
--- a/lib/score.js
+++ b/lib/score.js
@@ -155,7 +155,9 @@ export const Delay = Object.assign(createDelay, {
             instance.end = t + dur;
             instance.cutoff = true;
         }
-        return Object.assign(instance, { t: instance.end, forward });
+        if (isFinite(instance.end)) {
+            return Object.assign(instance, { t: instance.end, forward });
+        }
     },
 
     // Delay just returns its input value after the delay has passed.

--- a/lib/tape.js
+++ b/lib/tape.js
@@ -82,8 +82,9 @@ export const Tape = Object.assign(() => create().call(Tape), {
     // Remove an occurrence from the tape (this is used when cancelling).
     removeOccurrence(occurrence) {
         const index = this.occurrences.indexOf(occurrence);
-        console.assert(index >= 0);
-        return this.occurrences.splice(index, 1)[0];
+        if (index >= 0) {
+            return this.occurrences.splice(index, 1)[0];
+        }
     },
 
     // Remove the occurrence for an instance by looking it up in the

--- a/tests/delay.html
+++ b/tests/delay.html
@@ -58,6 +58,12 @@ test("Instantiation (zero duration)", t => {
     t.equal(dump(delay), "* Instant-0 @17 <undefined>", "dump matches");
 });
 
+test("Instantiation (indefinite duration)", t => {
+    const tape = Tape();
+    const delay = tape.instantiate(Delay(Infinity), 17);
+    t.equal(dump(delay), "* Delay-0 [17, ∞[", "dump matches");
+});
+
 test("Instantiation (illegal duration)", t => {
     const tape = Tape();
     t.equal(dump(tape.instantiate(Delay(-23), 17)), "* Instant-0 @17", "negative duration");

--- a/tests/par-take.html
+++ b/tests/par-take.html
@@ -8,9 +8,18 @@
 
 import { test } from "./test.js";
 import { K } from "../lib/util.js";
-import { Instant, Effect, Delay, Par, Seq, dump } from "../lib/score.js";
+import { Delay, Effect, Event, Instant, Par, Seq, dump } from "../lib/score.js";
 import { Tape } from "../lib/tape.js";
 import { Deck } from "../lib/deck.js";
+
+test("Instantiation; indefinite duration child", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const instance = tape.instantiate(Par(Delay(Infinity), Event(window, "synth")).take(1), 17);
+    deck.now = 27;
+    window.dispatchEvent(new window.Event("synth"));
+    t.match(dump(instance), /^\* Par-0 \[17, 27\[ <[^>]+>\n  \* Delay-1 \[17, 27\[ \(cancelled\)\n  \* Event-2 \[17, 27\[ <[^>]+>$/, "dump matches");
+});
 
 test("Par(xs).take(n = ∞) duration", t => {
     t.equal(

--- a/tests/par-take.html
+++ b/tests/par-take.html
@@ -76,7 +76,16 @@ test("Instantiation; n < xs.length", t => {
   * Instant-1 @17 <B>`, "dump matches");
 });
 
-test("Instantiation; indefinite duration child", t => {
+test("Instantiation; unresolved duration child", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const instance = tape.instantiate(Par(Delay(23), Event(window, "synth")).take(1), 17);
+    deck.now = 27;
+    window.dispatchEvent(new window.Event("synth"));
+    t.match(dump(instance), /^\* Par-0 \[17, 27\[ <[^>]+>\n  \* Delay-1 \[17, 27\[ \(cancelled\)\n  \* Event-2 \[17, 27\[ <[^>]+>$/, "dump matches");
+});
+
+test("Instantiation; unresolved/indefinite duration child", t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const instance = tape.instantiate(Par(Delay(Infinity), Event(window, "synth")).take(1), 17);

--- a/tests/par-take.html
+++ b/tests/par-take.html
@@ -12,15 +12,6 @@ import { Delay, Effect, Event, Instant, Par, Seq, dump } from "../lib/score.js";
 import { Tape } from "../lib/tape.js";
 import { Deck } from "../lib/deck.js";
 
-test("Instantiation; indefinite duration child", t => {
-    const tape = Tape();
-    const deck = Deck({ tape });
-    const instance = tape.instantiate(Par(Delay(Infinity), Event(window, "synth")).take(1), 17);
-    deck.now = 27;
-    window.dispatchEvent(new window.Event("synth"));
-    t.match(dump(instance), /^\* Par-0 \[17, 27\[ <[^>]+>\n  \* Delay-1 \[17, 27\[ \(cancelled\)\n  \* Event-2 \[17, 27\[ <[^>]+>$/, "dump matches");
-});
-
 test("Par(xs).take(n = ∞) duration", t => {
     t.equal(
         Par(Delay(51), Delay(23), Delay(31), Delay(17), Delay(19)).take().duration, 51,
@@ -83,6 +74,15 @@ test("Instantiation; n < xs.length", t => {
     t.equal(dump(par),
 `* Par-0 @17 <B>
   * Instant-1 @17 <B>`, "dump matches");
+});
+
+test("Instantiation; indefinite duration child", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const instance = tape.instantiate(Par(Delay(Infinity), Event(window, "synth")).take(1), 17);
+    deck.now = 27;
+    window.dispatchEvent(new window.Event("synth"));
+    t.match(dump(instance), /^\* Par-0 \[17, 27\[ <[^>]+>\n  \* Delay-1 \[17, 27\[ \(cancelled\)\n  \* Event-2 \[17, 27\[ <[^>]+>$/, "dump matches");
 });
 
 test("Instantiation; unresolved durations result in more than n children", t => {


### PR DESCRIPTION
This would cause issue with the tape. Also, removing occurrence should be more chill and not fail when there is no occurrence to remove.