### PR TITLE
1Q0D Par end time is not resolved correctly

### DIFF
--- a/lib/score.js
+++ b/lib/score.js
@@ -1,5 +1,5 @@
 import {
-    assign, create, extend, I, isNumber, nop, parseTime, partition, push, remove, safe
+    assign, create, extend, fold1, I, isNumber, nop, parseTime, partition, push, remove, safe
 } from "./util.js";
 import { notify } from "./events.js";
 import { Tape } from "./tape.js";
@@ -596,20 +596,29 @@ export const Par = assign((...children) => create().call(Par, { children }), {
     },
 
     // Once an unresolved end time becomes resolved, the end time of the par
-    // itself may be resolved (if all children have a resolved end time). In
+    // itself may be resolved (if enough children have a resolved end time). In
     // that case, the parent can then be notified in turn.
     childInstanceEndWasResolved(childInstance) {
+        if (Duration.has(this)) {
+            return;
+        }
+
         const childEnd = endOf(childInstance);
         const instance = childInstance.parent;
         console.assert(instance.item === this);
-        const end = instance.children.reduce((end, child) => max(end, endOf(child)), -Infinity);
-        if (isNumber(end) && end >= childEnd) {
-            if (isNumber(instance.end)) {
-                console.assert(instance.end >= childEnd);
-            } else {
-                ended(instance, end);
-                instance.parent?.item.childInstanceEndWasResolved(instance);
+        // Get the list of all resolved child ends.
+        const ends = instance.children.reduce((ends, child) => {
+            const end = endOf(child);
+            if (isNumber(end)) {
+                push(ends, end);
             }
+            return ends;
+        }, []);
+        const n = instance.capacity ?? instance.children.length;
+        if (ends.length >= n) {
+            const end = ends.length > n ? ends.sort((a, b) => a - b)[n - 1] : fold1(ends, max);
+            ended(instance, end);
+            instance.parent?.item.childInstanceEndWasResolved(instance);
         }
     },
 

--- a/tests/par-take.html
+++ b/tests/par-take.html
@@ -79,10 +79,14 @@ test("Instantiation; n < xs.length", t => {
 test("Instantiation; unresolved duration child", t => {
     const tape = Tape();
     const deck = Deck({ tape });
-    const instance = tape.instantiate(Par(Delay(23), Event(window, "synth")).take(1), 17);
+    const instance = tape.instantiate(Seq(
+        Par(Delay(189), Event(window, "synth")).take(1),
+        Instant(K("ok"))
+    ), 17);
     deck.now = 27;
     window.dispatchEvent(new window.Event("synth"));
-    t.match(dump(instance), /^\* Par-0 \[17, 27\[ <[^>]+>\n  \* Delay-1 \[17, 27\[ \(cancelled\)\n  \* Event-2 \[17, 27\[ <[^>]+>$/, "dump matches");
+    deck.now = 28;
+    t.match(dump(instance), /^\* Seq-0 \[17, 27\[ <ok>\n  \* Par-1 \[17, 27\[ <[^>]+>\n    \* Delay-2 \[17, 27\[ \(cancelled\)\n    \* Event-3 \[17, 27\[ <[^>]+>\n  \* Instant-4 @27 <ok>$/, "dump matches");
 });
 
 test("Instantiation; unresolved/indefinite duration child", t => {


### PR DESCRIPTION
When a previously unresolved child of a Par ends, the capacity of the Par must be taken into account to compute the resolved end time of the par, and not just use the max of all children.