### PR TITLE
1O09 Keep label as single line

### DIFF
--- a/patcher/box.js
+++ b/patcher/box.js
@@ -90,7 +90,7 @@ export const Box = assign(properties => create(properties).call(Box), {
                 // Firefox (for instance) does not support "plaintext-only"
                 this.input.contentEditable = true;
             }
-            this.input.addEventListener("keyup", this);
+            this.input.addEventListener("keydown", this);
             window.setTimeout(() => {
                 this.input.focus();
                 const selection = deselectText();
@@ -100,7 +100,7 @@ export const Box = assign(properties => create(properties).call(Box), {
             });
         } else {
             this.input.contentEditable = false;
-            this.input.removeEventListener("keyup", this);
+            this.input.removeEventListener("keydown", this);
             this.label = this.input.textContent;
         }
     },
@@ -114,6 +114,7 @@ export const Box = assign(properties => create(properties).call(Box), {
             case "Escape":
                 this.input.textContent = this.label;
             case "Enter":
+                event.preventDefault();
                 this.patcher.didEdit(this);
         }
     },

--- a/patcher/drag-event-listener.js
+++ b/patcher/drag-event-listener.js
@@ -14,7 +14,7 @@ export const DragEventListener = Object.assign(elements => create({ elements }).
                 document.addEventListener("pointermove", this);
                 document.addEventListener("pointerup", this);
                 document.addEventListener("pointercancel", this);
-                document.addEventListener("keyup", this);
+                document.addEventListener("keydown", this);
                 event.preventDefault();
                 event.stopPropagation();
                 this.x0 = event.clientX;
@@ -32,7 +32,7 @@ export const DragEventListener = Object.assign(elements => create({ elements }).
             case "pointerup":
                 this.dragDidEnd();
                 break;
-            case "keyup":
+            case "keydown":
                 if (event.key === "Escape") {
                     this.dragWasCancelled();
                     this.dragDidEnd();


### PR DESCRIPTION
Use keydown instead of keyup to cancel the effect of the Enter key; this also prevents arrow down from going down. Use keydown for the drag listener as well so that Esc cancels immediately.