### PR TITLE
1P0H Review ended

### DIFF
--- a/lib/score.js
+++ b/lib/score.js
@@ -275,7 +275,7 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
                     } else {
                         instance.error = TimeoutError;
                     }
-                    instance.parent?.item.childInstanceDidEnd(instance, t);
+                    instance.parent?.item.childInstanceDidEnd(instance);
                 } })
             ];
         }
@@ -378,7 +378,7 @@ export const Event = assign((target, event) => extend(Event, { target, event }, 
                 } else {
                     instance.error = TimeoutError;
                 }
-                instance.parent?.item.childInstanceDidEnd(instance, t);
+                instance.parent?.item.childInstanceDidEnd(instance);
             } });
         }
 
@@ -556,7 +556,8 @@ export const Par = assign((...children) => create().call(Par, { children }), {
     // the values are in the same order as the children, otherwise they are
     // in the order in which the children finished (using the child order for
     // children finishing at the exact same time).
-    childInstanceDidEnd(childInstance, t) {
+    childInstanceDidEnd(childInstance) {
+        const end = endOf(childInstance);
         const instance = childInstance.parent;
         console.assert(instance.item === this);
         if (!instance.finished) {
@@ -575,21 +576,21 @@ export const Par = assign((...children) => create().call(Par, { children }), {
                 // Cancel all the other children and fail
                 for (const child of instance.children) {
                     if (child !== childInstance && !Object.hasOwn(child, "value")) {
-                        child.item.cancelInstance(child, t);
+                        child.item.cancelInstance(child, end);
                     }
                 }
                 delete instance.finished;
-                failed(instance, t);
+                failed(instance, end);
             }
         } else {
             instance.finished.push(childInstance);
             if (instance.finished.length === instance.capacity) {
                 for (const child of instance.children) {
                     if (instance.finished.indexOf(child) < 0) {
-                        child.item.cancelInstance(child, t);
+                        child.item.cancelInstance(child, end);
                     }
                 }
-                ended(instance, t, this.valueForInstance.call(instance));
+                ended(instance, end, this.valueForInstance.call(instance));
             }
         }
     },
@@ -597,16 +598,17 @@ export const Par = assign((...children) => create().call(Par, { children }), {
     // Once an unresolved end time becomes resolved, the end time of the par
     // itself may be resolved (if all children have a resolved end time). In
     // that case, the parent can then be notified in turn.
-    childInstanceEndWasResolved(childInstance, t) {
+    childInstanceEndWasResolved(childInstance) {
+        const childEnd = endOf(childInstance);
         const instance = childInstance.parent;
         console.assert(instance.item === this);
         const end = instance.children.reduce((end, child) => max(end, endOf(child)), -Infinity);
-        if (isNumber(end) && end >= t) {
+        if (isNumber(end) && end >= childEnd) {
             if (isNumber(instance.end)) {
-                console.assert(instance.end >= t);
+                console.assert(instance.end >= childEnd);
             } else {
                 ended(instance, end);
-                instance.parent?.item.childInstanceEndWasResolved(instance, end);
+                instance.parent?.item.childInstanceEndWasResolved(instance);
             }
         }
     },
@@ -709,10 +711,10 @@ export const ParMap = {
             });
             if (isNumber(end)) {
                 ended(instance, end);
-                instance.parent?.item.childInstanceEndWasResolved(instance, end);
+                instance.parent?.item.childInstanceEndWasResolved(instance);
                 if (instance.children.length === 0) {
                     instance.value = this.valueForInstance.call(instance);
-                    instance.parent?.item.childInstanceDidEnd(instance, end);
+                    instance.parent?.item.childInstanceDidEnd(instance);
                 }
             }
             return occurrence;
@@ -890,7 +892,8 @@ export const Seq = assign((...children) => create().call(Seq, { children }), {
     // A child with an unresolved duration becomes solved, so the following
     // siblings can now be instantiated (this happens after a Par.map or
     // Seq.fold gets evaluated and the children are created).
-    childInstanceEndWasResolved(childInstance, t) {
+    childInstanceEndWasResolved(childInstance) {
+        let end = endOf(childInstance);
         const instance = childInstance.parent;
         console.assert(instance.item === this);
         const n = min(this.children.length, Capacity.get(this));
@@ -903,19 +906,19 @@ export const Seq = assign((...children) => create().call(Seq, { children }), {
         } else {
             // Continue instantiation starting from the next child.
             const m = instance.children.length;
-            for (let i = m; i < n && t <= instance.maxEnd; ++i) {
+            for (let i = m; i < n && end <= instance.maxEnd; ++i) {
                 const childInstance = instance.tape.instantiate(
-                    this.children[i], t, instance.maxEnd - t, instance
+                    this.children[i], end, instance.maxEnd - end, instance
                 );
                 if (!childInstance) {
                     for (let j = m; j < i; ++j) {
                         instance.children[j].item.pruneInstance(instance.children[j]);
                     }
                     instance.children.length = m;
-                    failed(instance, t);
+                    failed(instance, end);
                     return;
                 }
-                t = endOf(push(instance.children, childInstance));
+                end = endOf(push(instance.children, childInstance));
 
                 // If a child instance is cut off then we cannot go any further.
                 if (childInstance.cutoff) {
@@ -932,9 +935,9 @@ export const Seq = assign((...children) => create().call(Seq, { children }), {
             return;
         }
 
-        if (isNumber(t)) {
-            ended(instance, t);
-            instance.parent?.item.childInstanceEndWasResolved(instance, t);
+        if (isNumber(end)) {
+            ended(instance, end);
+            instance.parent?.item.childInstanceEndWasResolved(instance);
         }
     },
 
@@ -952,7 +955,8 @@ export const Seq = assign((...children) => create().call(Seq, { children }), {
     // Move to the next child when a child finishes by keeping track of the
     // index of the current child in the list of children. Done if the last
     // child of the list ended.
-    childInstanceDidEnd(childInstance, t) {
+    childInstanceDidEnd(childInstance) {
+        const end = endOf(childInstance);
         const instance = childInstance.parent;
         console.assert(instance.item === this);
 
@@ -961,18 +965,18 @@ export const Seq = assign((...children) => create().call(Seq, { children }), {
             const n = instance.currentChildIndex + 1;
             for (let i = n; i < instance.children.length; ++i) {
                 const child = instance.children[i];
-                child.item.pruneInstance(child, t);
+                child.item.pruneInstance(child, end);
                 delete child.parent;
             }
             instance.children.length = n;
-            failed(instance, t);
+            failed(instance, end);
             delete instance.currentChildIndex;
         } else {
             console.assert(instance.children[instance.currentChildIndex] === childInstance);
             instance.currentChildIndex += 1;
             if (instance.currentChildIndex === instance.capacity) {
                 instance.value = this.valueForInstance.call(instance);
-                instance.parent?.item.childInstanceDidEnd(instance, endOf(instance));
+                instance.parent?.item.childInstanceDidEnd(instance);
                 delete instance.currentChildIndex;
             }
         }
@@ -1092,22 +1096,23 @@ const Repeat = assign(child => extend(Repeat, { child }), {
     // unless the total number of iterations has been reached. If the end of
     // the duration is reached, the instance may fail if it did not reach the
     // required number of iterations as specified by take().
-    childInstanceDidEnd(childInstance, t) {
+    childInstanceDidEnd(childInstance) {
+        const end = endOf(childInstance);
         const instance = childInstance.parent;
         console.assert(instance.item === this);
 
         // Fail if the child fails.
         if (childInstance.error) {
             console.assert(childInstance === instance.children.at(-1));
-            failed(instance, t);
+            failed(instance, end);
         } else {
             if (childInstance.cutoff) {
                 delete childInstance.cutoff;
                 if (isFinite(instance.capacity)) {
-                    return failed(instance, t);
+                    return failed(instance, end);
                 }
                 instance.cutoff = true;
-                return ended(instance, t, childInstance.value);
+                return ended(instance, end, childInstance.value);
             }
 
             if (instance.children.length > RepeatMax) {
@@ -1115,10 +1120,10 @@ const Repeat = assign(child => extend(Repeat, { child }), {
                 throw window.Error("Too many repeats");
             }
             if (instance.children.length === instance.capacity) {
-                ended(instance, t, childInstance.value, !Duration.has(this));
+                ended(instance, end, childInstance.value, !Duration.has(this));
             } else {
                 instance.children.push(
-                    instance.tape.instantiate(this.child, t, instance.maxEnd - t, instance)
+                    instance.tape.instantiate(this.child, end, instance.maxEnd - end, instance)
                 );
             }
         }
@@ -1239,10 +1244,10 @@ const SeqFold = {
 
         if (isNumber(t)) {
             ended(instance, t);
-            instance.parent?.item.childInstanceEndWasResolved(instance, t);
+            instance.parent?.item.childInstanceEndWasResolved(instance);
             if (instance.children.length === 0) {
                 instance.value = this.valueForInstance.call(instance);
-                instance.parent?.item.childInstanceDidEnd(instance, t);
+                instance.parent?.item.childInstanceDidEnd(instance);
                 return;
             }
         }
@@ -1265,7 +1270,8 @@ const SeqFold = {
     },
 
     // Resume instantiation of children.
-    childInstanceEndWasResolved(childInstance, t) {
+    childInstanceEndWasResolved(childInstance) {
+        let end = endOf(childInstance);
         const instance = childInstance.parent;
         console.assert(instance.item === this);
         console.assert(instance.children.at(-1) === childInstance);
@@ -1278,25 +1284,25 @@ const SeqFold = {
         } else {
             // Constinue instantiation starting from the next child.
             const m = instance.children.length;
-            for (let i = m; i < instance.capacity && t <= instance.maxEnd; ++i) {
+            for (let i = m; i < instance.capacity && end <= instance.maxEnd; ++i) {
                 let childItem;
                 try {
                     childItem = this.g(instance.input[i], i);
                 } catch {
-                    return failed(instance, t, InputError);
+                    return failed(instance, end, InputError);
                 }
                 const childInstance = instance.tape.instantiate(
-                    childItem, t, instance.maxEnd - t, instance
+                    childItem, end, instance.maxEnd - end, instance
                 );
                 if (!childInstance) {
                     for (let j = m; j < i; ++j) {
                         instance.children[j].item.pruneInstance(instance.children[j]);
                     }
                     instance.children.length = m;
-                    failed(instance, t);
+                    failed(instance, end);
                     return;
                 }
-                t = endOf(push(instance.children, childInstance));
+                end = endOf(push(instance.children, childInstance));
 
                 // If a child instance is cut off then we cannot go any further
                 if (childInstance.cutoff) {
@@ -1312,9 +1318,9 @@ const SeqFold = {
             return;
         }
 
-        if (isNumber(t)) {
-            ended(instance, t);
-            instance.parent?.item.childInstanceEndWasResolved(instance, t);
+        if (isNumber(end)) {
+            ended(instance, end);
+            instance.parent?.item.childInstanceEndWasResolved(instance);
         }
     },
 
@@ -1399,40 +1405,43 @@ export const Try = assign((child, _catch) => create().call(Try, { child, catch: 
         if (isNumber(instance.begin)) {
             ended(instance, t);
             if (!cancelled) {
-                instance.parent?.item.childInstanceEndWasResolved(instance, t);
+                instance.parent?.item.childInstanceEndWasResolved(instance);
             }
         }
         if (!cancelled) {
-            instance.parent?.item.childInstanceDidEnd(instance, t);
+            instance.parent?.item.childInstanceDidEnd(instance);
         }
     },
 
     // End when either child ends normally. If the regular child ends in error,
     // then instantiate catch and wait for it to end. If it still ends in error,
     // then end in error as well.
-    childInstanceDidEnd(childInstance, t) {
+    childInstanceDidEnd(childInstance) {
+        const end = endOf(childInstance);
         const instance = childInstance.parent;
         console.assert(instance.item === this);
 
         if (childInstance.error) {
             if (childInstance.item === this.child) {
                 // There was an error, so try to recover.
-                const catchChild = instance.tape.instantiate(this.catch, t, instance.maxEnd - t, instance);
+                const catchChild = instance.tape.instantiate(
+                    this.catch, end, instance.maxEnd - end, instance
+                );
                 if (catchChild) {
                     instance.caughtError = childInstance.error;
                     instance.children.push(catchChild);
                 } else {
-                    failed(instance, t, FailureError);
+                    failed(instance, end, FailureError);
                 }
             } else {
                 // There was an error that could not be recovered.
                 instance.error = childInstance.error;
-                this.instanceDidEnd(instance, t);
+                this.instanceDidEnd(instance, end);
             }
         } else {
             // No error, or we could recover.
             instance.value = childInstance.value;
-            this.instanceDidEnd(instance, t);
+            this.instanceDidEnd(instance, end);
         }
     },
 
@@ -1543,7 +1552,7 @@ function forward(t, interval) {
     } catch (error) {
         instance.error = error;
     }
-    instance.parent?.item.childInstanceDidEnd(instance, endOf(instance));
+    instance.parent?.item.childInstanceDidEnd(instance);
 }
 
 // When an instance is pruned, it erases its occurrence from the tape.
@@ -1565,7 +1574,7 @@ function cancelled(instance, t) {
 function failed(instance, t, error = FailureError) {
     ended(instance, t);
     instance.error = error;
-    instance.parent?.item.childInstanceDidEnd(instance, t);
+    instance.parent?.item.childInstanceDidEnd(instance);
 }
 
 // When an instance has ended, its end or t property gets updated and its value
@@ -1590,9 +1599,9 @@ function ended(...args) {
     if (endsWithValue) {
         instance.value = value;
         if (resolved) {
-            instance.parent?.item.childInstanceEndWasResolved(instance, endOf(instance));
+            instance.parent?.item.childInstanceEndWasResolved(instance);
         }
-        instance.parent?.item.childInstanceDidEnd(instance, endOf(instance));
+        instance.parent?.item.childInstanceDidEnd(instance);
     }
 }
 

--- a/lib/score.js
+++ b/lib/score.js
@@ -300,11 +300,7 @@ export const Await = assign(f => extend(Await, { instanceDidBegin: f }), {
                     if (hasDuration) {
                         instance.tape.removeOccurrenceForInstance(instance);
                     }
-                    instance.value = value;
-                    instance.end = deck.instantAtTime(performance.now());
-                    console.assert(instance.end > instance.begin);
-                    instance.parent?.item.childInstanceEndWasResolved(instance, instance.end);
-                    instance.parent?.item.childInstanceDidEnd(instance, instance.end);
+                    ended(instance, deck.instantAtTime(performance.now()), value, true);
                 }
                 notify(deck, "await", { instance });
             }).catch(error => {
@@ -410,18 +406,14 @@ export const Event = assign((target, event) => extend(Event, { target, event }, 
             if (t <= instance.end) {
                 instance.tape.removeOccurrenceForInstance(instance);
             }
-            instance.value = event;
-            instance.end = t;
-            instance.parent?.item.childInstanceEndWasResolved(instance, t);
-            instance.parent?.item.childInstanceDidEnd(instance, t);
+            ended(instance, t, event, true);
         }
     },
 
     // When cancelling, there is no occurrence to remove, but we may need to
     // remove the event listener.
     cancelInstance(instance, t) {
-        ended(instance, t);
-        instance.error = CancelError;
+        cancelled(instance, t);
         instance.tape.deck.removeEventTarget(instance);
     },
 
@@ -613,12 +605,7 @@ export const Par = assign((...children) => create().call(Par, { children }), {
             if (isNumber(instance.end)) {
                 console.assert(instance.end >= t);
             } else {
-                if (instance.begin === end) {
-                    delete instance.begin;
-                    instance.t = end;
-                } else {
-                    instance.end = end;
-                }
+                ended(instance, end);
                 instance.parent?.item.childInstanceEndWasResolved(instance, end);
             }
         }
@@ -721,11 +708,12 @@ export const ParMap = {
                 child.input = xs[children.indexOf(child.item)];
             });
             if (isNumber(end)) {
+                ended(instance, end);
+                instance.parent?.item.childInstanceEndWasResolved(instance, end);
                 if (instance.children.length === 0) {
                     instance.value = this.valueForInstance.call(instance);
-                    instance.parent?.item.childInstanceDidEnd(instance, t);
+                    instance.parent?.item.childInstanceDidEnd(instance, end);
                 }
-                instance.parent?.item.childInstanceEndWasResolved(instance, end);
             }
             return occurrence;
         } catch {
@@ -944,16 +932,9 @@ export const Seq = assign((...children) => create().call(Seq, { children }), {
             return;
         }
 
-        if (instance.children.length === n && isNumber(t)) {
-            if (instance.begin === t) {
-                delete instance.begin;
-                instance.t = t;
-            } else {
-                instance.end = t;
-            }
+        if (isNumber(t)) {
+            ended(instance, t);
             instance.parent?.item.childInstanceEndWasResolved(instance, t);
-        } else if (t === Infinity) {
-            instance.end = t;
         }
     },
 
@@ -991,10 +972,7 @@ export const Seq = assign((...children) => create().call(Seq, { children }), {
             instance.currentChildIndex += 1;
             if (instance.currentChildIndex === instance.capacity) {
                 instance.value = this.valueForInstance.call(instance);
-                if (!Duration.has(instance.item)) {
-                    instance.end = t;
-                }
-                instance.parent?.item.childInstanceDidEnd(instance, instance.end);
+                instance.parent?.item.childInstanceDidEnd(instance, endOf(instance));
                 delete instance.currentChildIndex;
             }
         }
@@ -1137,8 +1115,7 @@ const Repeat = assign(child => extend(Repeat, { child }), {
                 throw window.Error("Too many repeats");
             }
             if (instance.children.length === instance.capacity) {
-                instance.parent?.item.childInstanceEndWasResolved(instance, t);
-                ended(instance, t, childInstance.value);
+                ended(instance, t, childInstance.value, !Duration.has(this));
             } else {
                 instance.children.push(
                     instance.tape.instantiate(this.child, t, instance.maxEnd - t, instance)
@@ -1260,26 +1237,16 @@ const SeqFold = {
             t = end;
         }
 
-        if (instance.begin === t) {
-            delete instance.begin;
-            instance.t = t;
-            instance.value = this.valueForInstance.call(instance);
+        if (isNumber(t)) {
+            ended(instance, t);
+            instance.parent?.item.childInstanceEndWasResolved(instance, t);
             if (instance.children.length === 0) {
+                instance.value = this.valueForInstance.call(instance);
                 instance.parent?.item.childInstanceDidEnd(instance, t);
-            }
-        } else {
-            if (isNumber(t)) {
-                instance.end = t;
-            }
-            if (instance.children.length === 0) {
-                console.assert(isNumber(t));
-                instance.parent?.item.childInstanceDidEnd(instance, t);
+                return;
             }
         }
 
-        if (isNumber(t)) {
-            instance.parent?.item.childInstanceEndWasResolved(instance, t);
-        }
         instance.currentChildIndex = 0;
         if (instance.children.length < instance.input.length) {
             instance.maxEnd = end;
@@ -1345,16 +1312,9 @@ const SeqFold = {
             return;
         }
 
-        if (instance.children.length === instance.input.length && isNumber(t)) {
-            if (instance.begin === t) {
-                delete instance.begin;
-                instance.t = t;
-            } else {
-                instance.end = t;
-            }
+        if (isNumber(t)) {
+            ended(instance, t);
             instance.parent?.item.childInstanceEndWasResolved(instance, t);
-        } else if (t === Infinity) {
-            instance.end = t;
         }
     },
 
@@ -1436,13 +1396,8 @@ export const Try = assign((child, _catch) => create().call(Try, { child, catch: 
         delete instance.caughtError;
         delete instance.maxEnd;
         const cancelled = instance.error === CancelError;
-        if (instance.begin >= 0) {
-            if (t === instance.begin) {
-                delete instance.begin;
-                instance.t = t;
-            } else {
-                instance.end = t;
-            }
+        if (isNumber(instance.begin)) {
+            ended(instance, t);
             if (!cancelled) {
                 instance.parent?.item.childInstanceEndWasResolved(instance, t);
             }
@@ -1617,7 +1572,7 @@ function failed(instance, t, error = FailureError) {
 // is optionally stored (note that it may be undefined), in which case the
 // parent instance is notified.
 function ended(...args) {
-    const [instance, t, value] = args;
+    const [instance, t, value, resolved] = args;
     const endsWithValue = args.length > 2;
     if (Object.hasOwn(instance, "begin")) {
         if (endsWithValue && Duration.has(instance.item)) {
@@ -1634,6 +1589,9 @@ function ended(...args) {
     }
     if (endsWithValue) {
         instance.value = value;
+        if (resolved) {
+            instance.parent?.item.childInstanceEndWasResolved(instance, endOf(instance));
+        }
         instance.parent?.item.childInstanceDidEnd(instance, endOf(instance));
     }
 }


### PR DESCRIPTION
Generalize the use of `ended()` which can also call `childInstanceEndWasResolved()` with the end correctly set. Also remove the unnecessary `t` parameter from `childInstanceDidEnd()` and `childInstanceEndWasResolved()` to avoid any ambiguity.