### PR TITLE
1Q09 Text and Element boxes

### DIFF
--- a/patcher/box.js
+++ b/patcher/box.js
@@ -60,12 +60,18 @@ export const Box = assign(properties => create(properties).call(Box), {
 
     // Update the size of the box based on the size of the input control. Do
     // not go under the base width for boxes.
-    updateSize(width) {
+    updateSize(width, height) {
         const w = this.rect.width.baseVal.value;
         if ((width > w) || (width >= Box.width && width < w)) {
             this.rect.setAttribute("width", width);
-            this.input.parentElement.setAttribute("width", width);
+            this.foreignObject.setAttribute("width", width);
             this.inlets[1].updateX(width - Port.width);
+        }
+        const h = this.rect.height.baseVal.value;
+        if ((height > h) || (height >= Box.height && height < h)) {
+            this.rect.setAttribute("height", height);
+            this.foreignObject.setAttribute("height", height);
+            this.outlets[0].updateY(height - Port.height);
         }
     },
 

--- a/patcher/box.js
+++ b/patcher/box.js
@@ -58,8 +58,8 @@ export const Box = assign(properties => create(properties).call(Box), {
         }
     },
 
-    // Update the size of the box based on the size of the input control. Do
-    // not go under the base width for boxes.
+    // Update the size of the box based on the size of the content of the
+    // foreign object.Do not go under the base size.
     updateSize(width, height) {
         const w = this.rect.width.baseVal.value;
         if ((width > w) || (width >= Box.width && width < w)) {
@@ -67,12 +67,10 @@ export const Box = assign(properties => create(properties).call(Box), {
             this.foreignObject.setAttribute("width", width);
             this.inlets[1].updateX(width - Port.width);
         }
-        const h = this.rect.height.baseVal.value;
-        if ((height > h) || (height >= Box.height && height < h)) {
-            this.rect.setAttribute("height", height);
-            this.foreignObject.setAttribute("height", height);
-            this.outlets[0].updateY(height - Port.height);
-        }
+        const h = Math.max(Box.height, height);
+        this.rect.setAttribute("height", h);
+        this.foreignObject.setAttribute("height", h - 2 * Port.height);
+        this.outlets[0].updateY(h - Port.height);
     },
 
     toggleSelected(selected) {

--- a/patcher/box.js
+++ b/patcher/box.js
@@ -15,13 +15,14 @@ export const Box = assign(properties => create(properties).call(Box), {
         this.outlets = [Port({ box: this, y: this.height - Port.height, isOutlet: true })];
         this.rect = svg("rect", { width: this.width, height: this.height });
         this.input = html("span", { class: "input", spellcheck: false });
+        this.foreignObject = svg("foreignObject", {
+            y: Port.height,
+            width: this.width,
+            height: this.height - 2 * Port.height
+        }, this.input);
         this.element = svg("g", { class: "box" },
             this.rect,
-            svg("foreignObject", {
-                y: Port.height,
-                width: this.width,
-                height: this.height - 2 * Port.height
-            }, this.input),
+            this.foreignObject,
             [...this.ports()].map(port => port.element)
         );
         this.rect.addEventListener("pointerdown", this.patcher.dragEventListener);

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -1,5 +1,6 @@
 import { Await, Delay, Effect, Element, Event, Instant, Par, Score, Seq, Try, dump } from "../lib/score.js";
 import { create, html, I, K, normalizeWhitespace, parseTime, safe } from "../lib/util.js";
+import { notify } from "../lib/events.js";
 
 export const Patch = Object.assign(properties => create(properties).call(Patch), {
     init() {
@@ -188,7 +189,11 @@ const Parse = {
             return {
                 label: `Element ${tagName} ${normalizeWhitespace(input)}`,
                 isElement: true,
-                create: (_, box) => Element(html(tagName, attrs), box.foreignObject)
+                create: function(_, box) {
+                    const element = html(tagName, attrs);
+                    notify(this, "element", { element, box });
+                    return Element(element, box.foreignObject);
+                }
             };
         }
     },

--- a/patcher/port.js
+++ b/patcher/port.js
@@ -53,7 +53,7 @@ export const Port = assign(properties => create(properties).call(Port), {
 
     updateY(y) {
         this.y = y;
-        this.rect.setAttribute("y", x);
+        this.rect.setAttribute("y", y);
         this.target.setAttribute("cy", y + this.height / 2);
         this.updateCords();
     },

--- a/patcher/port.js
+++ b/patcher/port.js
@@ -51,6 +51,13 @@ export const Port = assign(properties => create(properties).call(Port), {
         this.updateCords();
     },
 
+    updateY(y) {
+        this.y = y;
+        this.rect.setAttribute("y", x);
+        this.target.setAttribute("cy", y + this.height / 2);
+        this.updateCords();
+    },
+
     // When the box moves, one end of every cord for this box must move as well.
     updateCords() {
         for (const cord of this.cords.values()) {

--- a/patcher/style.css
+++ b/patcher/style.css
@@ -21,7 +21,6 @@ span.input {
     pointer-events: none;
     padding: 2px 4px;
     display: inline-block;
-    height: 100%;
 }
 
 span.input:focus {


### PR DESCRIPTION
Very rudimentary text and element boxes to display DOM nodes when active. Text simply shows the text given as argument (anything after “Text”), while Element creates an (empty) DOM element with the tag name and attributes passed as argument (_e.g._, “Element img src="https://placekitten.com/400/300"”). When running, the input for the element is removed and replaced with the content when active.