### PR TITLE
1P0C Event box

### DIFF
--- a/patcher/cord.js
+++ b/patcher/cord.js
@@ -19,6 +19,7 @@ export const Cord = assign((port, x2, y2) => {
         this.patcher = (this.inlet ?? this.outlet).box.patcher;
     },
 
+    // The cord may be a reference cord rather than a value cord.
     get isReference() {
         return this.element.classList.contains("reference");
     },

--- a/patcher/cord.js
+++ b/patcher/cord.js
@@ -1,8 +1,8 @@
-import { create, svg } from "../lib/util.js";
+import { assign, create, svg } from "../lib/util.js";
 import { bringElementFrontward } from "./util.js";
 
 // A patch cord between an outlet and an inlet.
-export const Cord = Object.assign((port, x2, y2) => {
+export const Cord = assign((port, x2, y2) => {
     const properties = {
         element: svg("g", { class: "cord" },
             svg("line", { x1: port.centerX, y1: port.centerY, x2, y2 }),
@@ -17,6 +17,14 @@ export const Cord = Object.assign((port, x2, y2) => {
 }, {
     init() {
         this.patcher = (this.inlet ?? this.outlet).box.patcher;
+    },
+
+    get isReference() {
+        return this.element.classList.contains("reference");
+    },
+
+    set isReference(value) {
+        this.element.classList.toggle("reference", !!value);
     },
 
     // Set the outlet of the cord that was started from an inlet. Switch the

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -172,6 +172,19 @@ const Parse = {
         }
     },
 
+    Event: input => {
+        const match = input.match(/^\s+(\w+)\s*$/);
+        if (match) {
+            const event = match[1];
+            return {
+                label: `Event ${event}`,
+                inlets: 1,
+                acceptFrom: box => box.isElement,
+                create: ([target]) => Event(target.element, event)
+            };
+        }
+    },
+
     Element: input => {
         let params = input;
         let match = params.match(/^\s+(\w+)/);

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -84,6 +84,8 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
     },
 
     cordWasAdded(cord) {
+        const source = this.boxes.get(cord.outlet.box);
+        cord.isReference = (source.isElement || source.isWindow) && this.boxes.get(cord.inlet.box).isEvent;
         delete this.score;
     },
 
@@ -179,6 +181,7 @@ const Parse = {
             return {
                 label: `Event ${event}`,
                 inlets: 1,
+                isEvent: true,
                 acceptFrom: box => box.isElement || box.isWindow,
                 create: ([target]) => Event(target.element, event)
             };

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -179,7 +179,7 @@ const Parse = {
             return {
                 label: `Event ${event}`,
                 inlets: 1,
-                acceptFrom: box => box.isElement,
+                acceptFrom: box => box.isElement || box.isWindow,
                 create: ([target]) => Event(target.element, event)
             };
         }
@@ -218,6 +218,16 @@ const Parse = {
                 isElement: true,
                 create: (_, box) => Element(document.createTextNode(input), box.foreignObject)
             };
+        }
+    },
+
+    Window: input => {
+        if (!/\S/.test(input)) {
+            return {
+                label: "Window",
+                create: K({ element: window }),
+                isWindow: true
+            }
         }
     },
 

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -50,20 +50,24 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
 
     // Create an item from a box/node pair, getting the inputs from the inlets
     // as necessary.
-    createItemFor(box, node) {
+    createItemFor(box, node, cord) {
         if (node.isElement) {
             this.elementBoxes.set(box, box.input);
             box.input.remove();
         }
         const inputs = box.inlets.flatMap(
-            inlet => [...inlet.cords.keys()].map(outlet => outlet.box)
-        ).map(box => {
+            inlet => [...inlet.cords.entries()].map(([outlet, cord]) => [outlet.box, cord])
+        ).map(([box, cord]) => {
             if (box) {
                 const node = this.boxes.get(box);
-                return this.createItemFor(box, node);
+                return this.createItemFor(box, node, cord);
             }
         });
-        return node.create.call(this, inputs, box);
+        const item = node.create.call(this, inputs, box);
+        if (cord?.isReference && node.isElement) {
+            box.foreignObject.appendChild(item.element);
+        }
+        return item;
     },
 
     boxWasEdited(box) {

--- a/patcher/style.css
+++ b/patcher/style.css
@@ -98,3 +98,7 @@ g.cord.selected line {
     stroke-width: 4;
     stroke-linecap: round;
 }
+
+g.cord.reference line:first-child {
+    stroke-dasharray: 3, 3;
+}

--- a/patcher/style.css
+++ b/patcher/style.css
@@ -100,5 +100,5 @@ g.cord.selected line {
 }
 
 g.cord.reference line:first-child {
-    stroke-dasharray: 3, 3;
+    stroke-dasharray: 4, 4;
 }


### PR DESCRIPTION
Add an Event box that takes a *reference* to an element as its input and an event name as its parameter. Connecting  the outlet of an Element to the inlet of an Event creates a reference cord, rendered as a dashed instead of a solid line, which indicates that the element is not part of the score—it stays on the page forever.

Also add a Window object that represents the window (so that its events can be listened to).