### PR TITLE
1Q01 Edit vs. playback mode

### DIFF
--- a/patcher/drag-event-listener.js
+++ b/patcher/drag-event-listener.js
@@ -52,6 +52,6 @@ export const DragEventListener = Object.assign(elements => create({ elements }).
         document.removeEventListener("pointermove", this);
         document.removeEventListener("pointerup", this);
         document.removeEventListener("pointercancel", this);
-        document.removeEventListener("keyup", this);
+        document.removeEventListener("keydown", this);
     }
 });

--- a/patcher/index.html
+++ b/patcher/index.html
@@ -41,7 +41,7 @@
                         d="M0,20v60L50,50z M50,20v60L100,50z"/>
                 </symbol>
             </defs>
-            <rect width="100%" height="100%" fill="url(#grid)"/>
+            <rect width="100%" height="100%" fill="url(#grid)" class="grid"/>
         </svg>
 
         <ul class="transport-bar">

--- a/patcher/style.css
+++ b/patcher/style.css
@@ -61,10 +61,6 @@ g.box rect {
     fill: #f8f9f0;
 }
 
-g.box foreignObject {
-    pointer-events: none;
-}
-
 g.box.selected > rect {
     outline: solid 3px #83ebf5;
 }
@@ -101,4 +97,13 @@ g.cord.selected line {
 
 g.cord.reference line:first-child {
     stroke-dasharray: 4, 4;
+}
+
+svg.canvas.locked rect.grid {
+    fill: #f8f9f0;
+}
+
+svg.canvas:not(.locked) g.box foreignObject,
+svg.canvas.locked g.box > rect {
+    pointer-events: none;
 }

--- a/patcher/transport-bar.js
+++ b/patcher/transport-bar.js
@@ -78,6 +78,10 @@ export const TransportBar = Object.assign(element => create({ element }).call(Tr
         this.setState(this.state.play ?? this.state.pause);
     },
 
+    stop() {
+        this.setState(this.state.stop);
+    },
+
     States
 });
 


### PR DESCRIPTION
Lock the patcher during playback; the grid is hidden and elements become clickable. Esc can stop playback and unlock the patcher (also fixes an issue with the drag event listener when no drag was in progress).