### PR TITLE
1Q0P Don’t play if score cannot be created properly

### DIFF
--- a/patcher/index.html
+++ b/patcher/index.html
@@ -44,6 +44,8 @@
             <rect width="100%" height="100%" fill="url(#grid)" class="grid"/>
         </svg>
 
+        <p class="error hidden">No error!</p>
+
         <ul class="transport-bar">
             <li>
                 <button type="button" name="stop">

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -1,6 +1,6 @@
 import { Await, Delay, Effect, Element, Event, Instant, Par, Score, Seq, Try, dump } from "../lib/score.js";
 import { create, html, I, K, normalizeWhitespace, parseTime, safe } from "../lib/util.js";
-import { notify } from "../lib/events.js";
+import { notify, notifyAsync } from "../lib/events.js";
 
 export const Patch = Object.assign(properties => create(properties).call(Patch), {
     init() {
@@ -35,7 +35,7 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
                 }
             } catch (error) {
                 this.clearScore();
-                notify(this, "score-error", { error });
+                notify(this, "score", { error });
             }
         }
     },

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -1,6 +1,6 @@
 import { Await, Delay, Effect, Element, Event, Instant, Par, Score, Seq, Try, dump } from "../lib/score.js";
 import { create, html, I, K, normalizeWhitespace, parseTime, safe } from "../lib/util.js";
-import { notify, notifyAsync } from "../lib/events.js";
+import { notify } from "../lib/events.js";
 
 export const Patch = Object.assign(properties => create(properties).call(Patch), {
     init() {

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -288,7 +288,7 @@ const Parse = {
             const n = parseInt(match[0], 10);
             return {
                 label: `take(${n})`,
-                create: item => item.take?.(n),
+                create: ([item]) => item.take?.(n),
                 acceptFrom: node => node.isContainer,
                 inlets: 1,
             }

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -26,11 +26,16 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
         } else {
             // Create a new score.
             tape.erase();
-            this.score = Score({ tape });
-            for (const [box, node] of this.boxes.entries()) {
-                if (!box.outlets[0].enabled) {
-                    this.score.add(this.createItemFor(box, node));
+            try {
+                this.score = Score({ tape });
+                for (const [box, node] of this.boxes.entries()) {
+                    if (!box.outlets[0].enabled) {
+                        this.score.add(this.createItemFor(box, node));
+                    }
                 }
+            } catch (error) {
+                this.clearScore();
+                notify(this, "score-error", { error });
             }
         }
     },

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -276,7 +276,7 @@ const Parse = {
 
     repeat: only(item => item.repeat(), {
         label: "repeat",
-        create: item => item.repeat?.(),
+        create: ([item]) => item.repeat?.(),
         isContainer: true,
         acceptFrom: node => !node.isTry,
         inlets: 1,

--- a/patcher/patcher.js
+++ b/patcher/patcher.js
@@ -74,9 +74,8 @@ const Patcher = assign(canvas => create({ canvas }).call(Patcher), {
         on(this.patch, "element", ({ element, box }) => {
             this.observeElementInBox(element, box);
         });
-        on(this.patch, "score-error", ({ error }) => {
-            console.error("Score error", error);
-            this.transportBar.stop();
+        on(this.patch, "score", ({ error }) => {
+            this.errorMessage(error?.message);
         });
 
         this.transportBar = TransportBar(document.querySelector("ul.transport-bar"));
@@ -87,12 +86,23 @@ const Patcher = assign(canvas => create({ canvas }).call(Patcher), {
         on(this.transportBar, "stop", () => {
             this.locked = false;
             this.patch.clearScore();
+            this.errorMessage();
             for (const [element, box] of this.resizeObserverTargets) {
                 if (element !== box.input) {
                     this.resizeObserver.unobserve(element);
                 }
             }
         });
+    },
+
+    // Show or clear the error message.
+    errorMessage(error) {
+        const p = document.querySelector("p.error");
+        p.classList.toggle("hidden", !error);
+        if (error) {
+            p.textContent = error;
+            this.transportBar.error();
+        }
     },
 
     // Lock the patch when playing (no editing).

--- a/patcher/patcher.js
+++ b/patcher/patcher.js
@@ -74,6 +74,10 @@ const Patcher = assign(canvas => create({ canvas }).call(Patcher), {
         on(this.patch, "element", ({ element, box }) => {
             this.observeElementInBox(element, box);
         });
+        on(this.patch, "score-error", ({ error }) => {
+            console.error("Score error", error);
+            this.transportBar.stop();
+        });
 
         this.transportBar = TransportBar(document.querySelector("ul.transport-bar"));
         on(this.transportBar, "play", ({ tape }) => {

--- a/patcher/style.css
+++ b/patcher/style.css
@@ -31,6 +31,20 @@ button {
     font-size: 1rem;
 }
 
+.hidden {
+    display: none;
+}
+
+p.error {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    background-color: #ffd0d0;
+    padding: 1em;
+    margin: 0;
+}
+
 ul.transport-bar {
     position: absolute;
     bottom: 0;

--- a/patcher/transport-bar.js
+++ b/patcher/transport-bar.js
@@ -36,6 +36,10 @@ const States = {
             this.deck.resume();
         }]
     },
+
+    error: {
+        stop
+    }
 };
 
 // Transport bar controlling a Deck.
@@ -80,6 +84,12 @@ export const TransportBar = Object.assign(element => create({ element }).call(Tr
 
     stop() {
         this.setState(this.state.stop);
+    },
+
+    // Special error state: stop the deck and only allow stopping again to
+    // clear the state.
+    error() {
+        this.setState(["error", () => { this.deck.stop(); }]);
     },
 
     States


### PR DESCRIPTION
Show a (not very helpful at the moment) error message and freeze the transport bar. The error is cleared when stopping (which is the only option).

Also fix a couple oversights for take/repeat creation.