### PR TITLE
1Q11 Bigger targets for cords

### DIFF
--- a/patcher/port.js
+++ b/patcher/port.js
@@ -8,7 +8,7 @@ export const Port = assign(properties => create(properties).call(Port), {
     y: 0,
     width: 12,
     height: 3,
-    r: 16
+    r: 16,
 
     init() {
         this.patcher = this.box.patcher;

--- a/patcher/port.js
+++ b/patcher/port.js
@@ -8,7 +8,7 @@ export const Port = assign(properties => create(properties).call(Port), {
     y: 0,
     width: 12,
     height: 3,
-    r: 10,
+    r: 16
 
     init() {
         this.patcher = this.box.patcher;

--- a/patcher/port.js
+++ b/patcher/port.js
@@ -8,13 +8,13 @@ export const Port = assign(properties => create(properties).call(Port), {
     y: 0,
     width: 12,
     height: 3,
-    r: 16,
+    r: 12,
 
     init() {
         this.patcher = this.box.patcher;
         this.rect = svg("rect", { width: this.width, height: this.height, x: this.x, y: this.y });
         this.target = svg("circle", {
-            cx: this.x + this.width / 2, cy: this.y + this.height / 2, r: this.r
+            class: "target", cx: this.x + this.width / 2, cy: this.y + this.height / 2, r: this.r
         });
         this.element = svg("g", { class: "port" }, this.rect, this.target);
         this.target.addEventListener("pointerdown", this.patcher.dragEventListener);
@@ -67,11 +67,11 @@ export const Port = assign(properties => create(properties).call(Port), {
 
     // Highlight when a current target for a coord.
     get isTargetForCord() {
-        return this.element.classList.contains("target");
+        return this.element.classList.contains("potential-target");
     },
 
     set isTargetForCord(value) {
-        this.element.classList.toggle("target", value);
+        this.element.classList.toggle("potential-target", value);
     },
 
     // Enable or disable the port.
@@ -115,7 +115,7 @@ export const Port = assign(properties => create(properties).call(Port), {
 
     // Update the cord and decide whether it can be connected to a target.
     dragDidProgress(_, __, x, y) {
-        const element = document.elementsFromPoint(x, y)[1];
+        const element = document.elementsFromPoint(x, y).find(e => e.classList.contains("target"));
         const target = this.patcher.elements.get(element)?.possibleTargetForCord?.(this);
         if (target) {
             if (this.dragTarget !== target) {

--- a/patcher/style.css
+++ b/patcher/style.css
@@ -77,7 +77,7 @@ g.port circle {
     fill: transparent;
 }
 
-g.port.target circle {
+g.port.potential-target circle {
     fill: rgba(64, 255, 64, 0.25);
 }
 


### PR DESCRIPTION
Actually we don’t really need bigger targets (though a small increase in size does not hurt), the problem is that sometimes the line element for the cord is on top and sometimes not so we need to check for the target in a more robust fashion.