### PR TITLE
1Q0Y Failing assertion when adding an occurrence with no time

### DIFF
--- a/lib/score.js
+++ b/lib/score.js
@@ -640,7 +640,7 @@ export const Par = assign((...children) => create().call(Par, { children }), {
                         child.item.cancelInstance(child, end);
                     }
                 }
-                ended(instance, end, this.valueForInstance.call(instance));
+                ended(instance, end, this.valueForInstance.call(instance), !isNumber(endOf(instance)));
             }
         }
     },
@@ -1034,8 +1034,7 @@ export const Seq = assign((...children) => create().call(Seq, { children }), {
             console.assert(instance.children[instance.currentChildIndex] === childInstance);
             instance.currentChildIndex += 1;
             if (instance.currentChildIndex === instance.capacity) {
-                instance.value = this.valueForInstance.call(instance);
-                instance.parent?.item.childInstanceDidEnd(instance);
+                ended(instance, end, this.valueForInstance.call(instance), !isNumber(endOf(instance)));
                 delete instance.currentChildIndex;
             }
         }

--- a/tests/par-take.html
+++ b/tests/par-take.html
@@ -84,7 +84,7 @@ test("Instantiation; n < xs.length", t => {
   * Instant-1 @17 <B>`, "dump matches");
 });
 
-test("Instantiation; unresolved duration child", t => {
+test("Instantiation; unresolved duration child (unresolved child finishes)", t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const instance = tape.instantiate(Seq(
@@ -95,6 +95,22 @@ test("Instantiation; unresolved duration child", t => {
     window.dispatchEvent(new window.Event("synth"));
     deck.now = 28;
     t.match(dump(instance), /^\* Seq-0 \[17, 27\[ <ok>\n  \* Par-1 \[17, 27\[ <[^>]+>\n    \* Delay-2 \[17, 27\[ \(cancelled\)\n    \* Event-3 \[17, 27\[ <[^>]+>\n  \* Instant-4 @27 <ok>$/, "dump matches");
+});
+
+test("Instantiation; unresolved duration child (resolved child finishes)", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const instance = tape.instantiate(Seq(
+        Par(Delay(23), Event(window, "synth")).take(1),
+        Instant(K("ok"))
+    ), 17);
+    deck.now = 41;
+    t.equal(dump(instance),
+`* Seq-0 [17, 40[ <ok>
+  * Par-1 [17, 40[ <>
+    * Delay-2 [17, 40[ <undefined>
+    * Event-3 [17, 40[ (cancelled)
+  * Instant-4 @40 <ok>`, "dump matches");
 });
 
 test("Instantiation; unresolved/indefinite duration child", t => {


### PR DESCRIPTION
The issue is that a Par or Seq could finish with the end still being unresolved (e.g., when a Par().take(1) has an unresolved child that gets cancelled), so we make sure to resolve the end when finishing if necessary.