### PR TITLE
1R0D REGRESSION: elements are not removed when stopped

### DIFF
--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -67,13 +67,13 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
                 }
                 notify(this, "score");
             } catch (error) {
-                this.clearScore();
+                delete this.score;
                 notify(this, "score", { error });
             }
         }
     },
 
-    clearScore() {
+    clearElements() {
         for (const [box, input] of this.elementBoxes.entries()) {
             for (let child = box.foreignObject.firstChild; child;) {
                 const sibling = child.nextSibling;
@@ -83,7 +83,6 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
             box.foreignObject.appendChild(input);
         }
         this.elementBoxes.clear();
-        delete this.score;
     },
 
     // Create an item from a box/node pair, getting the inputs from the inlets

--- a/patcher/patcher.js
+++ b/patcher/patcher.js
@@ -96,6 +96,7 @@ const Patcher = assign(canvas => create({ canvas }).call(Patcher), {
         });
         on(this.transportBar, "stop", () => {
             this.locked = false;
+            this.patch.clearElements();
             this.errorMessage();
             for (const [element, box] of this.resizeObserverTargets) {
                 if (element !== box.input) {


### PR DESCRIPTION
This was broken by 1Q0O and better separates clearing the score from removing the elements created when running.