### PR TITLE
1Q0S Cancelled Element is not properly removed

### DIFF
--- a/lib/tape.js
+++ b/lib/tape.js
@@ -51,22 +51,26 @@ export const Tape = Object.assign(() => create().call(Tape), {
     // interval.
     *occurrencesInInterval(interval) {
         const { from, to } = interval;
+
+        // Find the index of the first occurrence in the interval (if any).
         let i = this.occurrences.findIndex(o => typeof o.forward === "function" && o.t >= from && o.t < to);
         if (i < 0) {
             return;
         }
 
+        const occurred = new Set();
         while (i < this.occurrences.length) {
-            yield this.occurrences[i++];
+            occurred.add(this.occurrences[i]);
+            yield this.occurrences[i];
             while (i < this.occurrences.length) {
                 const o = this.occurrences[i];
                 if (o.t >= to) {
                     return;
                 }
-                if (typeof o.forward === "function" && o.t >= from && o.t < to) {
+                if (!occurred.has(o) && typeof o.forward === "function" && o.t >= from && o.t < to) {
                     break;
                 }
-                i += 1;
+                i++;
             }
         }
     },

--- a/lib/tape.js
+++ b/lib/tape.js
@@ -70,7 +70,7 @@ export const Tape = Object.assign(() => create().call(Tape), {
                 if (!occurred.has(o) && typeof o.forward === "function" && o.t >= from && o.t < to) {
                     break;
                 }
-                i++;
+                i += 1;
             }
         }
     },

--- a/tests/element.html
+++ b/tests/element.html
@@ -46,17 +46,16 @@ test("Element().dur()", t => {
 test("Cancel", t => {
     const tape = Tape();
     const deck = Deck({ tape });
-    const instance = tape.instantiate(Seq(
-        Par(
-            Element(html("p", "ok")).dur(Infinity),
-            Event(window, "synth")
-        ).take(1),
-        Instant(K("ok"))
-    ), 17);
-    deck.now = 27;
+    const wait = html("p", "wait");
+    const par = tape.instantiate(Par(
+        Par(Event(window, "synth"), Delay(23)),
+        Element(wait).dur(Infinity)
+    ).take(1), 17);
+    deck.now = 31;
     window.dispatchEvent(new window.Event("synth"));
-    deck.now = 28;
-    t.match(dump(instance), /^\* Seq-0 \[17, 27\[ <ok>\n  \* Par-1 \[17, 27\[ <[^>]+>\n    \* Element-2 \[17, 27\[ \(cancelled\)\n    \* Event-3 \[17, 27\[ <[^>]+>\n  \* Instant-4 @27 <ok>$/, "dump matches");
+    deck.now = 41;
+    t.match(dump(par), /^\* Par-0 \[17, 40\[ <\[[^\]]+\],>\n  \* Par-1 \[17, 40\[ <\[[^\]]+\],>\n    \* Event-2 \[17, 31\[ <[^>]+>\n    \* Delay-3 \[17, 40\[ <undefined>\n  \* Element-4 \[17, 40\[ \(cancelled\)$/, "dump matches");
+    t.equal(wait.parentElement, null, "element was removed");
 });
 
 test("Prune", t => {


### PR DESCRIPTION
Because of occurrences being removed and added during the update interval, we could skip over an occurrence (in this case, the one for removing the element when cancelled). We make the update loop safer by increasing the index less eagerly and update a test to verify this.