### PR TITLE
1R0T Multiple cords from outlet

### DIFF
--- a/lib/score.js
+++ b/lib/score.js
@@ -1550,7 +1550,9 @@ export function dump(instance, indent = "* ") {
 // children.
 function init() {
     for (const child of this.children) {
-        console.assert(!Object.hasOwn(child, "parent"));
+        if (Object.hasOwn(child, "parent")) {
+            throw window.Error("Cannot share item between containers");
+        }
         child.parent = this;
     }
 }

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -61,9 +61,10 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
             tape.erase();
             try {
                 this.score = Score({ tape });
+                const items = new Map();
                 for (const [box, node] of this.boxes.entries()) {
                     if (!node.isComment && !box.outlets[0].enabled) {
-                        this.score.add(this.createItemFor(box, node));
+                        this.score.add(this.createItemFor(items, box, node));
                     }
                 }
                 notify(this, "score");
@@ -89,7 +90,10 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
 
     // Create an item from a box/node pair, getting the inputs from the inlets
     // as necessary.
-    createItemFor(box, node, cord) {
+    createItemFor(items, box, node, cord) {
+        if (items.has(box)) {
+            return items.get(box);
+        }
         if (node.isElement) {
             this.elementBoxes.set(box, box.input);
             box.input.remove();
@@ -99,7 +103,9 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
         ).map(([box, cord]) => {
             if (box) {
                 const node = this.boxes.get(box);
-                return this.createItemFor(box, node, cord);
+                const item = this.createItemFor(items, box, node, cord);
+                items.set(box, item);
+                return item;
             }
         });
         const item = node.create.call(this, inputs, box);

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -61,10 +61,9 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
             tape.erase();
             try {
                 this.score = Score({ tape });
-                const items = new Map();
                 for (const [box, node] of this.boxes.entries()) {
                     if (!node.isComment && !box.outlets[0].enabled) {
-                        this.score.add(this.createItemFor(items, box, node));
+                        this.score.add(this.createItemFor(new Map(), box, node));
                     }
                 }
                 notify(this, "score");

--- a/patcher/port.js
+++ b/patcher/port.js
@@ -107,7 +107,10 @@ export const Port = assign(properties => create(properties).call(Port), {
         if (port.possibleTargets.has(this)) {
             return port.possibleTargets.get(this);
         }
-        if (port.isOutlet !== this.isOutlet && this.cords.size === 0) {
+        // Ports must be of opposite polarity (inlet vs. outlet) and inlets
+        // can have only one incoming cord (but outlets can have many outgoing
+        // cords).
+        if (port.isOutlet !== this.isOutlet && (this.isOutlet || this.cords.size === 0)) {
             const inlet = this.isOutlet ? port : this;
             const outlet = this.isOutlet ? this : port;
             if (this.patcher.inletAcceptsConnection(inlet, outlet)) {
@@ -134,10 +137,10 @@ export const Port = assign(properties => create(properties).call(Port), {
         port.possibleTargets.set(this);
     },
 
-    // Create a cord from this port. Currently, only a single outgoing or
-    // incoming cord is allowed (to maintain a tree structure).
+    // Create a cord from this port. Prevent creating new incoming cords for
+    // inlets that already have one.
     dragDidBegin(x, y) {
-        if (this.cords.size > 0) {
+        if (!this.isOutlet && this.cords.size > 0) {
             return false;
         }
         this.cord = Cord(this, x, y);


### PR DESCRIPTION
Allow multiple cords to originate from an outlet (but still maintain a single incoming cord per inlet). Currently this allows an element to be referenced as well as be part of the timeline; sharing is not yet possible and will generate an error when trying to play.