### PR TITLE
1S0F Par(set, set).take(1) has the wrong duration

### DIFF
--- a/lib/timing/par.js
+++ b/lib/timing/par.js
@@ -111,7 +111,7 @@ export const Par = assign((...children) => create().call(Par, { children }), {
         const end = isNumber(itemDur) ?
             t + dur :
             instance.capacity < instance.children.length ?
-                endOf(instance.children.toSorted((a, b) => endOf(a) - endOf(b))[instance.capacity - 1]) :
+                endOfNth(instance.children, instance.capacity - 1) :
                 instance.children.reduce((end, child) => max(end, endOf(child)), t);
         if (end === t) {
             instance.t = t;
@@ -325,6 +325,20 @@ export const ParMap = {
         return input;
     },
 };
+
+// Return the nth end of a list of instances, or unresolved if any instance has
+// an unresolved end.
+function endOfNth(instances, n) {
+    const ends = [];
+    for (const instance of instances) {
+        const end = endOf(instance);
+        if (!isNumber(end)) {
+            return;
+        }
+        ends.push(end);
+    }
+    return ends.toSorted((a, b) => a - b)[n];
+}
 
 // Select at least n items from the list according to their duration, keeping
 // them in their original order, and return [duration, item] pairs. Fallible

--- a/lib/timing/par.js
+++ b/lib/timing/par.js
@@ -110,7 +110,9 @@ export const Par = assign((...children) => create().call(Par, { children }), {
         // the end if there are no children.
         const end = isNumber(itemDur) ?
             t + dur :
-            instance.children.reduce((end, child) => max(end, endOf(child)), t);
+            instance.capacity < instance.children.length ?
+                endOf(instance.children.toSorted((a, b) => endOf(a) - endOf(b))[instance.capacity - 1]) :
+                instance.children.reduce((end, child) => max(end, endOf(child)), t);
         if (end === t) {
             instance.t = t;
             if (instance.children.length === 0) {

--- a/tests/timing/par-take.html
+++ b/tests/timing/par-take.html
@@ -10,7 +10,7 @@ import { test } from "../test.js";
 import { K } from "../../lib/util.js";
 import { Tape } from "../../lib/tape.js";
 import { Deck } from "../../lib/deck.js";
-import { Delay, Effect, Event, Instant, Par, Seq } from "../../lib/timing.js";
+import { Delay, Effect, Event, Instant, Par, Seq, Set } from "../../lib/timing.js";
 import { dump } from "../../lib/timing/util.js";
 
 test("Par(xs).take(n = ∞) duration", t => {
@@ -195,6 +195,25 @@ test("Effects", t => {
   * Instant-1 @17 <ok>
   * Effect-2 @17 <ko>`, "dump matches");
 });
+
+test("More effects", t => {
+    const object = { foo: 1, bar: 2 };
+    const tape = Tape();
+    const instance = tape.instantiate(Seq(
+        Par(
+            Set(object, "foo", "ko").dur(31),
+            Set(object, "bar", "ok").dur(23)
+        ).take(1),
+        Instant()
+    ), 17);
+    Deck({ tape }).now = 41;
+    t.equal(dump(instance),
+`* Seq-0 [17, 40[ <ok>
+  * Par-1 [17, 40[ <ok>
+    * Set-2 [17, 40[ (cancelled)
+    * Set-3 [17, 40[ <ok>
+  * Instant-4 @40 <ok>`, "dump matches");
+})
 
         </script>
     </head>


### PR DESCRIPTION
Make sure that when take(n) is in effect the end of the nth item is used and not the end of the last items, except if one of the durations is unresolved in which case the end is unresolved.