### PR TITLE
1S0A Seq/map with item

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ finished yet are pruned.
 the time `t` from the beginning of the parent container (usually a `Seq`, since it behaves like a regular
 delay inside a `Par`). If the delay begins _after_ the time _t_, then it has no effect. This is *not*
 repeatable since the delay can occur at most once.
-* `Par.map(g)` and `Seq.map(g)` map the function _g_ to an input list in parallel or in sequence.
+* `Par.map(x)` and `Seq.map(x)` map _x_ to an input list in parallel or in sequence. `x` can either be an
+item, which will be instantiated for each input value, or a function that gets called for each input value
+and is expected to return an item.
 * `Seq.fold(g, z)` folds over an input list with the function _g_ and an initial value _z_ in sequence.
 
 In SMIL, presentations are static in that their content is always the same (the user may influence the

--- a/lib/timing/seq.js
+++ b/lib/timing/seq.js
@@ -77,17 +77,17 @@ export const Seq = assign((...children) => create().call(Seq, { children }), {
         return this.children?.at(-1)?.value;
     },
 
-    // Create a new SeqMap object with the given generator function.
-    map(g) {
+    // Create a new Map object with the given generator function.
+    map(x) {
         console.assert(this === Seq);
-        return extend(SeqMap, { g });
+        return typeof x === "function" ? extend(FunctionMap, { g: x }) : extend(Map, { child: x });
     },
 
-    // Create a new SeqFold object with the given generator function and initial
+    // Create a new Fold object with the given generator function and initial
     // accumulator value.
     fold(g, z) {
         console.assert(this === Seq);
-        return extend(SeqFold, { g, z });
+        return extend(Fold, { g, z });
     },
 
     // A Seq instance is an interval, unless all of its children have zero
@@ -284,11 +284,122 @@ export const Seq = assign((...children) => create().call(Seq, { children }), {
     },
 });
 
+// Seq/map with a child that gets instantiated for every input value in turn.
+const Map = {
+    tag: "Seq/map",
+    show,
+    take,
+    dur,
+    repeat,
+
+    // Duration is unresolved, unless it is specified by dur() or modified by
+    // take(0).
+    get duration() {
+        if (hasModifier(this, "dur")) {
+            return this.modifiers.dur;
+        }
+        if (this.modifiers?.take === 0) {
+            return 0;
+        }
+    },
+
+    // Schedule instantiation of the contents.
+    instantiate(instance, t, dur) {
+        if (this.modifiers?.take === 0) {
+            return Object.assign(instance, { t, forward });
+        }
+
+        instance.begin = t;
+        return extend(instance, { t, forward(t) {
+            instance.item.instantiateChildren(
+                instance, instance.parent?.item.inputForChildInstance(instance), t, dur
+            );
+        } });
+    },
+
+    // Collect the values of the children as the value of the map itself.
+    valueForInstance() {
+        return this.children?.map(child => child.value) ?? [];
+    },
+
+    // Actually instantiate the children from the input.
+    instantiateChildren(instance, xs, t, dur) {
+        console.assert(t === instance.begin);
+        if (!Array.isArray(xs)) {
+            return failed(instance, t, InputError);
+        }
+
+        const end = t + min(dur, this.modifiers?.dur);
+
+        // Check that we have the right number of input values.
+        const n = this.modifiers?.take;
+        if (isFinite(n)) {
+            if (xs.length < n) {
+                return failed(instance, t);
+            }
+            instance.input = xs.slice(0, n);
+        } else {
+            instance.input = xs;
+        }
+
+        instance.children = [];
+        instance.capacity = instance.input.length;
+        for (let i = 0; i < instance.capacity && t <= end; ++i) {
+            const childInstance = instance.tape.instantiate(this.child, t, end - t, instance);
+            if (!childInstance) {
+                for (const childInstance of instance.children) {
+                    childInstance.item.pruneInstance(childInstance, t);
+                }
+                return failed(instance, t);
+            }
+            t = endOf(push(instance.children, childInstance));
+
+            // If a child instance is cut off then we cannot go any further
+            if (childInstance.cutoff) {
+                delete childInstance.cutoff;
+                instance.cutoff = true;
+                instance.capacity = min(instance.children.length, n);
+                break;
+            }
+        }
+
+        if (hasModifier(this, "dur")) {
+            t = end;
+        }
+
+        if (isNumber(t)) {
+            ended(instance, t);
+            instance.parent?.item.childInstanceEndWasResolved(instance);
+            if (instance.children.length === 0) {
+                instance.value = this.valueForInstance.call(instance);
+                instance.parent?.item.childInstanceDidEnd(instance);
+                return;
+            }
+        }
+
+        instance.currentChildIndex = 0;
+        if (instance.children.length < instance.input.length) {
+            instance.maxEnd = end;
+        }
+    },
+
+    // Each successive child gets the next input from the Seq/map parent.
+    inputForChildInstance(childInstance) {
+        const instance = childInstance.parent;
+        console.assert(instance.item === this);
+        return instance.input[instance.currentChildIndex];
+    },
+
+    childInstanceDidEnd: Seq.childInstanceDidEnd,
+    cancelInstance: Seq.cancelInstance,
+    pruneInstance: Seq.pruneInstance,
+};
+
 // Seq/fold is similar to Seq but its children are produced by mapping its
 // input through the g function, and the initial value of the fold is given by
 // z. The initial instantiation is an interval with an unresolved end time and
 // an occurrence to instantiate the contents.
-const SeqFold = {
+const Fold = {
     tag: "Seq/fold",
     show,
     take,
@@ -467,7 +578,7 @@ const SeqFold = {
 
 // Seq/map is just like Seq/fold but taking its initial input from its parent,
 // like a normal Seq, and returns a list of its outputs in order.
-export const SeqMap = extend(SeqFold, {
+const FunctionMap = extend(Fold, {
     tag: "Seq/map",
 
     // Collect the values of the children as the value of the map itself.

--- a/lib/timing/seq.js
+++ b/lib/timing/seq.js
@@ -80,7 +80,7 @@ export const Seq = assign((...children) => create().call(Seq, { children }), {
     // Create a new Map object with the given generator function.
     map(x) {
         console.assert(this === Seq);
-        return typeof x === "function" ? extend(FunctionMap, { g: x }) : extend(Map, { child: x });
+        return typeof x === "function" ? extend(FunctionMap, { g: x }) : create().call(Map, { child: x });
     },
 
     // Create a new Fold object with the given generator function and initial
@@ -288,6 +288,7 @@ export const Seq = assign((...children) => create().call(Seq, { children }), {
 const Map = {
     tag: "Seq/map",
     show,
+    init,
     take,
     dur,
     repeat,

--- a/lib/timing/seq.js
+++ b/lib/timing/seq.js
@@ -384,6 +384,55 @@ const Map = {
         }
     },
 
+    // Resume instantiation of children.
+    childInstanceEndWasResolved(childInstance) {
+        let end = endOf(childInstance);
+        const instance = childInstance.parent;
+        console.assert(instance.item === this);
+        console.assert(instance.children.at(-1) === childInstance);
+
+        if (childInstance.cutoff) {
+            // Stop instantiation here.
+            delete childInstance.cutoff;
+            instance.capacity = min(instance.input.length, n);
+            instance.cutoff = true;
+        } else {
+            // Constinue instantiation starting from the next child.
+            const m = instance.children.length;
+            for (let i = m; i < instance.capacity && end <= instance.maxEnd; ++i) {
+                const childInstance = instance.tape.instantiate(
+                    this.child, end, instance.maxEnd - end, instance
+                );
+                if (!childInstance) {
+                    for (let j = m; j < i; ++j) {
+                        instance.children[j].item.pruneInstance(instance.children[j]);
+                    }
+                    instance.children.length = m;
+                    failed(instance, end);
+                    return;
+                }
+                end = endOf(push(instance.children, childInstance));
+
+                // If a child instance is cut off then we cannot go any further
+                if (childInstance.cutoff) {
+                    delete childInstance.cutoff;
+                    instance.capacity = min(instance.children.length, this.modifiers?.take);
+                    instance.cutoff = true;
+                }
+            }
+        }
+
+        if (hasModifier(this, "dur")) {
+            // The end was already set.
+            return;
+        }
+
+        if (isNumber(end)) {
+            ended(instance, end);
+            instance.parent?.item.childInstanceEndWasResolved(instance);
+        }
+    },
+
     // Each successive child gets the next input from the Seq/map parent.
     inputForChildInstance(childInstance) {
         const instance = childInstance.parent;

--- a/lib/timing/util.js
+++ b/lib/timing/util.js
@@ -88,7 +88,7 @@ export const max = (x, y) => isNumber(y) ? Math.max(x, y) : x === Infinity ? x :
 // Generic init function for containers, setting themselves as parent of their
 // children.
 export function init() {
-    for (const child of this.children) {
+    for (const child of this.children ?? [this.child]) {
         if (Object.hasOwn(child, "parent")) {
             throw window.Error("Cannot share item between containers");
         }

--- a/tests/index.html
+++ b/tests/index.html
@@ -32,7 +32,7 @@
             <li>timing/seq-dur.html</li>
             <li>timing/seq-repeat.html</li>
             <li>timing/seq-map-item.html</li>
-            <li>timing/seq-map.html</li>
+            <li>timing/seq-map-function.html</li>
             <li>timing/seq-fold.html</li>
             <li>timing/try.html</li>
         </ul>

--- a/tests/index.html
+++ b/tests/index.html
@@ -31,6 +31,7 @@
             <li>timing/seq-take.html</li>
             <li>timing/seq-dur.html</li>
             <li>timing/seq-repeat.html</li>
+            <li>timing/seq-map-item.html</li>
             <li>timing/seq-map.html</li>
             <li>timing/seq-fold.html</li>
             <li>timing/try.html</li>

--- a/tests/manual/tomato.html
+++ b/tests/manual/tomato.html
@@ -34,7 +34,7 @@ score.add(Par(
             ),
             Set(frame, "textContent").dur(dur)
         ))
-    )
+    ).repeat()
 ));
 
 deck.start();

--- a/tests/manual/tomato.html
+++ b/tests/manual/tomato.html
@@ -13,22 +13,28 @@ import { Element, Instant, Par, Score, Seq, Set } from "../../lib/timing.js";
 import { dump } from "../../lib/timing/util.js";
 
 const FPS = 9;
+const dur = 1000 / FPS;
 
 const tape = Tape();
 const deck = Deck({ tape });
 const score = Score({ tape });
 
 const image = html("img");
+const frame = html("p");
 
 score.add(Par(
     Element(image).dur(Infinity),
+    Element(frame).dur(Infinity),
     Seq(
         Instant(K([...range(1, 18)])),
-        Seq.map(Seq(
-            Instant(i => `tomato${i.toString().padStart(2, "0")}.png`),
-            Set(image, "src").dur(1000 / FPS)
+        Seq.map(Par(
+            Seq(
+                Instant(i => `tomato${i.toString().padStart(2, "0")}.png`),
+                Set(image, "src").dur(dur)
+            ),
+            Set(frame, "textContent").dur(dur)
         ))
-    ).repeat()
+    )
 ));
 
 deck.start();

--- a/tests/manual/tomato.html
+++ b/tests/manual/tomato.html
@@ -18,14 +18,17 @@ const tape = Tape();
 const deck = Deck({ tape });
 const score = Score({ tape });
 
-const image = html("img", { src: "tomato01.png" });
-const frames = [...range(1, 18)].map(i => Set(
-    image, "src", `tomato${i.toString().padStart(2, "0")}.png`).dur(1000 / FPS)
-);
+const image = html("img");
 
 score.add(Par(
     Element(image).dur(Infinity),
-    Seq(...frames).repeat()
+    Seq(
+        Instant(K([...range(1, 18)])),
+        Seq.map(Seq(
+            Instant(i => `tomato${i.toString().padStart(2, "0")}.png`),
+            Set(image, "src").dur(1000 / FPS)
+        ))
+    ).repeat()
 ));
 
 deck.start();

--- a/tests/timing/seq-map-function.html
+++ b/tests/timing/seq-map-function.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>Seq.map</title>
+        <title>Seq.map (function)</title>
         <meta charset="utf8">
         <link rel="stylesheet" href="../test.css">
         <script type="module">
@@ -213,7 +213,7 @@ test("Seq.map(g).dur(0), cutting off duration (???)", t => {
     * Delay-3 @17 <31>`, "dump matches");
 });
 
-test("Seq.map(g).dur(d), cutting off duration during instantiation", t => {
+test("Seq.map(g).dur(d), cutting off duration at instantiation", t => {
     const tape = Tape();
     const seq = tape.instantiate(Seq(Instant(K([31, 19, 23])), Seq.map(Delay)), 17, 43);
     Deck({ tape }).now = 61;
@@ -229,13 +229,13 @@ test("Children with unresolved duration", t => {
     const tape = Tape();
     const instance = tape.instantiate(Seq(
         Instant(K([23, 19, 31])),
-        Seq.fold(x => Seq(Instant(K([x])), Par.map(Delay)))
+        Seq.map(x => Seq(Instant(K([x])), Par.map(Delay)))
     ), 17);
     Deck({ tape }).now = 91;
     t.equal(dump(instance),
-`* Seq-0 [17, 90[ <31>
+`* Seq-0 [17, 90[ <23,19,31>
   * Instant-1 @17 <23,19,31>
-  * Seq/fold-2 [17, 90[ <31>
+  * Seq/map-2 [17, 90[ <23,19,31>
     * Seq-3 [17, 40[ <23>
       * Instant-4 @17 <23>
       * Par/map-5 [17, 40[ <23>
@@ -254,7 +254,7 @@ test("Cancel Seq.map", t => {
     const tape = Tape();
     const choice = tape.instantiate(Par(
         Seq(Instant(K([19])), Par.map(Delay)),
-        Seq(Instant(K([23, 31])), Seq.map(Delay)),
+        Seq(Instant(K([23, 31])), Seq.map(Delay))
     ).take(1), 17);
     Deck({ tape }).now = 37;
     t.equal(dump(choice),

--- a/tests/timing/seq-map-item.html
+++ b/tests/timing/seq-map-item.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Seq.map (item)</title>
+        <meta charset="utf8">
+        <link rel="stylesheet" href="../test.css">
+        <script type="module">
+
+import { test } from "../test.js";
+import { K } from "../../lib/util.js";
+import { Tape } from "../../lib/tape.js";
+import { Deck } from "../../lib/deck.js";
+import { Delay, Event, Instant, Par, Seq } from "../../lib/timing.js";
+import { dump } from "../../lib/timing/util.js";
+
+test("Seq.map(child)", t => {
+    const child = Instant();
+    const map = Seq.map(child);
+    t.equal(map.show(), "Seq/map", "show");
+    t.equal(map.child, child, "child item");
+    t.undefined(map.duration, "unresolved duration");
+    t.equal(map.take(0).duration, 0, "down to zero with take(0)");
+    t.equal(!map.fallible, true, "not fallible");
+});
+
+test("Seq.map(child).repeat()", t => {
+    const seq = Seq.map(Instant());
+    const repeat = seq.repeat();
+    t.equal(repeat.show(), "Seq/repeat", "show");
+    t.equal(repeat.child, seq, "repeat child");
+    t.equal(repeat.duration, Infinity, "indefinite duration");
+    t.equal(!repeat.fallible, true, "not fallible");
+    t.undefined(repeat.take(3).duration, "repeat dur (limited)");
+});
+
+test("Instantiation", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq(
+        Instant(K([31, 19, 23])),
+        Seq.map(Instant(x => x * 2).dur(41))
+    ), 17);
+    Deck({ tape }).now = 141;
+    t.equal(dump(seq),
+`* Seq-0 [17, 140[ <62,38,46>
+  * Instant-1 @17 <31,19,23>
+  * Seq/map-2 [17, 140[ <62,38,46>
+    * Seq-3 [17, 58[ <62>
+      * Delay-4 [17, 58[ <31>
+      * Instant-5 @58 <62>
+    * Seq-6 [58, 99[ <38>
+      * Delay-7 [58, 99[ <19>
+      * Instant-8 @99 <38>
+    * Seq-9 [99, 140[ <46>
+      * Delay-10 [99, 140[ <23>
+      * Instant-11 @140 <46>`, "dump matches");
+});
+
+test("Instantiation; empty input array", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq(Instant(K([])), Seq.map(Instant())), 17);
+    Deck({ tape }).now = 91;
+    t.equal(seq.value, [], "empty list");
+});
+
+        </script>
+    </head>
+    <body>
+        <p><a href="../index.html">Back</a></p>
+    </body>
+</html>

--- a/tests/timing/seq-map-item.html
+++ b/tests/timing/seq-map-item.html
@@ -38,29 +38,287 @@ test("Instantiation", t => {
     const tape = Tape();
     const seq = tape.instantiate(Seq(
         Instant(K([31, 19, 23])),
-        Seq.map(Instant(x => x * 2).dur(41))
+        Seq.map(Instant(x => x * 2).dur(29))
     ), 17);
-    Deck({ tape }).now = 141;
+    Deck({ tape }).now = 105;
     t.equal(dump(seq),
-`* Seq-0 [17, 140[ <62,38,46>
+`* Seq-0 [17, 104[ <62,38,46>
   * Instant-1 @17 <31,19,23>
-  * Seq/map-2 [17, 140[ <62,38,46>
-    * Seq-3 [17, 58[ <62>
-      * Delay-4 [17, 58[ <31>
-      * Instant-5 @58 <62>
-    * Seq-6 [58, 99[ <38>
-      * Delay-7 [58, 99[ <19>
-      * Instant-8 @99 <38>
-    * Seq-9 [99, 140[ <46>
-      * Delay-10 [99, 140[ <23>
-      * Instant-11 @140 <46>`, "dump matches");
+  * Seq/map-2 [17, 104[ <62,38,46>
+    * Seq-3 [17, 46[ <62>
+      * Delay-4 [17, 46[ <31>
+      * Instant-5 @46 <62>
+    * Seq-6 [46, 75[ <38>
+      * Delay-7 [46, 75[ <19>
+      * Instant-8 @75 <38>
+    * Seq-9 [75, 104[ <46>
+      * Delay-10 [75, 104[ <23>
+      * Instant-11 @104 <46>`, "dump matches");
 });
 
 test("Instantiation; empty input array", t => {
     const tape = Tape();
-    const seq = tape.instantiate(Seq(Instant(K([])), Seq.map(Instant())), 17);
+    const seq = tape.instantiate(Seq(Instant(K([])), Seq.map(Instant(x => x * 2))), 17);
     Deck({ tape }).now = 91;
     t.equal(seq.value, [], "empty list");
+});
+
+test("Seq.map(child).take(n = ∞)", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq(
+        Instant(K([31, 19, 23, 41, 37])), Seq.map(Instant(x => x * 2).dur(29)).take()
+    ), 17);
+    Deck({ tape }).now = 163;
+    t.equal(dump(seq),
+`* Seq-0 [17, 162[ <62,38,46,82,74>
+  * Instant-1 @17 <31,19,23,41,37>
+  * Seq/map-2 [17, 162[ <62,38,46,82,74>
+    * Seq-3 [17, 46[ <62>
+      * Delay-4 [17, 46[ <31>
+      * Instant-5 @46 <62>
+    * Seq-6 [46, 75[ <38>
+      * Delay-7 [46, 75[ <19>
+      * Instant-8 @75 <38>
+    * Seq-9 [75, 104[ <46>
+      * Delay-10 [75, 104[ <23>
+      * Instant-11 @104 <46>
+    * Seq-12 [104, 133[ <82>
+      * Delay-13 [104, 133[ <41>
+      * Instant-14 @133 <82>
+    * Seq-15 [133, 162[ <74>
+      * Delay-16 [133, 162[ <37>
+      * Instant-17 @162 <74>`, "dump matches");
+});
+
+test("Seq.map(child).take(n); fails at runtime when n > input length", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq(
+        Instant(K([31, 19, 23, 41, 37])), Seq.map(Instant(x => x * 2).dur(29)).take(7)
+    ), 17);
+    Deck({ tape }).now = 18;
+    t.equal(seq.error.message, "failed", "failed to instantiate map");
+});
+
+test("Seq.map(child).take(n); n < input length", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq(
+        Instant(K([31, 19, 23, 41, 37])), Seq.map(Instant(x => x * 2).dur(29)).take(3)
+    ), 17);
+    Deck({ tape }).now = 105;
+    t.equal(dump(seq),
+`* Seq-0 [17, 104[ <62,38,46>
+  * Instant-1 @17 <31,19,23,41,37>
+  * Seq/map-2 [17, 104[ <62,38,46>
+    * Seq-3 [17, 46[ <62>
+      * Delay-4 [17, 46[ <31>
+      * Instant-5 @46 <62>
+    * Seq-6 [46, 75[ <38>
+      * Delay-7 [46, 75[ <19>
+      * Instant-8 @75 <38>
+    * Seq-9 [75, 104[ <46>
+      * Delay-10 [75, 104[ <23>
+      * Instant-11 @104 <46>`, "dump matches");
+});
+
+test("Seq.map(child).take(0)", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq(
+        Instant(K([31, 19, 23, 41, 37])), Seq.map(Instant(x => x * 2).dur(29)).take(0)
+    ), 17);
+    Deck({ tape }).now = 18;
+    t.equal(dump(seq),
+`* Seq-0 @17 <>
+  * Instant-1 @17 <31,19,23,41,37>
+  * Seq/map-2 @17 <>`, "dump matches");
+    t.equal(seq.value, [], "empty list");
+});
+
+test("Seq.map(child) failure; input is not an array", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq(Instant(K("oops")), Seq.map(Instant(x => x * 2).dur(29))), 17);
+    Deck({ tape }).now = 18;
+    t.equal(dump(seq),
+`* Seq-0 @17 (failed)
+  * Instant-1 @17 <oops>
+  * Seq/map-2 @17 (input error)`, "dump matches");
+});
+
+test("Seq.map(child).repeat(); instantiation", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq(
+        Instant(K([19, 23])), Seq.map(Instant(x => x * 2).dur(29)).repeat()
+    ), 17);
+    Deck({ tape }).now = 111;
+    t.equal(dump(seq),
+`* Seq-0 [17, ∞[
+  * Instant-1 @17 <19,23>
+  * Seq/repeat-2 [17, ∞[
+    * Seq/map-3 [17, 75[ <38,46>
+      * Seq-4 [17, 46[ <38>
+        * Delay-5 [17, 46[ <19>
+        * Instant-6 @46 <38>
+      * Seq-7 [46, 75[ <46>
+        * Delay-8 [46, 75[ <23>
+        * Instant-9 @75 <46>
+    * Seq/map-10 [75, 133[
+      * Seq-11 [75, 104[ <76>
+        * Delay-12 [75, 104[ <38>
+        * Instant-13 @104 <76>
+      * Seq-14 [104, 133[
+        * Delay-15 [104, 133[
+        * Instant-16 @133`, "dump matches");
+});
+
+test("Seq.map(child).repeat().take(n)", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(Seq(
+        Instant(K([19, 23])), Seq.map(Instant(x => x * 2).dur(29)).repeat().take(3)
+    ), 17);
+    Deck({ tape }).now = 192;
+    t.equal(dump(seq),
+`* Seq-0 [17, 191[ <152,184>
+  * Instant-1 @17 <19,23>
+  * Seq/repeat-2 [17, 191[ <152,184>
+    * Seq/map-3 [17, 75[ <38,46>
+      * Seq-4 [17, 46[ <38>
+        * Delay-5 [17, 46[ <19>
+        * Instant-6 @46 <38>
+      * Seq-7 [46, 75[ <46>
+        * Delay-8 [46, 75[ <23>
+        * Instant-9 @75 <46>
+    * Seq/map-10 [75, 133[ <76,92>
+      * Seq-11 [75, 104[ <76>
+        * Delay-12 [75, 104[ <38>
+        * Instant-13 @104 <76>
+      * Seq-14 [104, 133[ <92>
+        * Delay-15 [104, 133[ <46>
+        * Instant-16 @133 <92>
+    * Seq/map-17 [133, 191[ <152,184>
+      * Seq-18 [133, 162[ <152>
+        * Delay-19 [133, 162[ <76>
+        * Instant-20 @162 <152>
+      * Seq-21 [162, 191[ <184>
+        * Delay-22 [162, 191[ <92>
+        * Instant-23 @191 <184>`, "dump matches");
+});
+
+test("Seq.map(child).dur(d), extending duration", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(
+        Seq(Instant(K([31, 19, 23])), Seq.map(Instant(x => x * 2).dur(29)).dur(103)
+    ), 17);
+    Deck({ tape }).now = 121;
+    t.equal(dump(seq),
+`* Seq-0 [17, 120[ <62,38,46>
+  * Instant-1 @17 <31,19,23>
+  * Seq/map-2 [17, 120[ <62,38,46>
+    * Seq-3 [17, 46[ <62>
+      * Delay-4 [17, 46[ <31>
+      * Instant-5 @46 <62>
+    * Seq-6 [46, 75[ <38>
+      * Delay-7 [46, 75[ <19>
+      * Instant-8 @75 <38>
+    * Seq-9 [75, 104[ <46>
+      * Delay-10 [75, 104[ <23>
+      * Instant-11 @104 <46>`, "dump matches");
+});
+
+test("Seq.map(child).dur(d), cutting off duration", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(
+        Seq(Instant(K([31, 19, 23])), Seq.map(Instant(x => x * 2).dur(29)).dur(43)
+    ), 17);
+    Deck({ tape }).now = 61;
+    t.equal(dump(seq),
+`* Seq-0 [17, 60[ <62,19>
+  * Instant-1 @17 <31,19,23>
+  * Seq/map-2 [17, 60[ <62,19>
+    * Seq-3 [17, 46[ <62>
+      * Delay-4 [17, 46[ <31>
+      * Instant-5 @46 <62>
+    * Seq-6 [46, 60[ <19>
+      * Delay-7 [46, 60[ <19>`, "dump matches");
+});
+
+test("Seq.map(child).dur(d), cutting off duration at instantiation", t => {
+    const tape = Tape();
+    const seq = tape.instantiate(
+        Seq(Instant(K([31, 19, 23])), Seq.map(Instant(x => x * 2).dur(29))
+    ), 17, 43);
+    Deck({ tape }).now = 61;
+    t.equal(dump(seq),
+`* Seq-0 [17, 60[ <62,19>
+  * Instant-1 @17 <31,19,23>
+  * Seq/map-2 [17, 60[ <62,19>
+    * Seq-3 [17, 46[ <62>
+      * Delay-4 [17, 46[ <31>
+      * Instant-5 @46 <62>
+    * Seq-6 [46, 60[ <19>
+      * Delay-7 [46, 60[ <19>`, "dump matches");
+});
+
+test("Children with unresolved duration", t => {
+    const tape = Tape();
+    const instance = tape.instantiate(Seq(
+        Instant(K([23, 19, 31])),
+        Seq.map(Seq(Instant(x => ([x])), Par.map(Delay)))
+    ), 17);
+    Deck({ tape }).now = 91;
+    t.equal(dump(instance),
+`* Seq-0 [17, 90[ <23,19,31>
+  * Instant-1 @17 <23,19,31>
+  * Seq/map-2 [17, 90[ <23,19,31>
+    * Seq-3 [17, 40[ <23>
+      * Instant-4 @17 <23>
+      * Par/map-5 [17, 40[ <23>
+        * Delay-6 [17, 40[ <23>
+    * Seq-7 [40, 59[ <19>
+      * Instant-8 @40 <19>
+      * Par/map-9 [40, 59[ <19>
+        * Delay-10 [40, 59[ <19>
+    * Seq-11 [59, 90[ <31>
+      * Instant-12 @59 <31>
+      * Par/map-13 [59, 90[ <31>
+        * Delay-14 [59, 90[ <31>`, "dump matches")
+});
+
+test("Cancel Seq.map", t => {
+    const tape = Tape();
+    const choice = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Seq(Instant(K([23, 31])), Seq.map(Instant(x => x * 2).dur(29)))
+    ).take(1), 17);
+    Deck({ tape }).now = 37;
+    t.equal(dump(choice),
+`* Par-0 [17, 36[ <19>
+  * Seq-1 [17, 36[ <19>
+    * Instant-2 @17 <19>
+    * Par/map-3 [17, 36[ <19>
+      * Delay-7 [17, 36[ <19>
+  * Seq-4 [17, 36[ (cancelled)
+    * Instant-5 @17 <23,31>
+    * Seq/map-6 [17, 36[ (cancelled)
+      * Seq-8 [17, 36[ (cancelled)
+        * Delay-9 [17, 36[ (cancelled)`, "dump matches");
+    t.equal(tape.show(), "Tape<17,17,17,17,36>", "occurrences where removed from the tape");
+});
+
+test("Prune Seq.map", t => {
+    const tape = Tape();
+    const choice = tape.instantiate(Par(
+        Seq(Instant(K([19])), Par.map(Delay)),
+        Seq(Delay(23), Seq.map(Seq.map(Instant(x => x * 2).dur(29))))
+    ).take(1), 17);
+    Deck({ tape }).now = 37;
+    t.equal(dump(choice),
+`* Par-0 [17, 36[ <19>
+  * Seq-1 [17, 36[ <19>
+    * Instant-2 @17 <19>
+    * Par/map-3 [17, 36[ <19>
+      * Delay-7 [17, 36[ <19>
+  * Seq-4 [17, 36[ (cancelled)
+    * Delay-5 [17, 36[ (cancelled)`, "dump matches");
+    t.equal(tape.show(), "Tape<17,17,36>", "occurrences where removed from the tape");
 });
 
         </script>

--- a/tests/timing/seq-map-item.html
+++ b/tests/timing/seq-map-item.html
@@ -18,6 +18,7 @@ test("Seq.map(child)", t => {
     const map = Seq.map(child);
     t.equal(map.show(), "Seq/map", "show");
     t.equal(map.child, child, "child item");
+    t.equal(map.child.parent, map, "child item parent");
     t.undefined(map.duration, "unresolved duration");
     t.equal(map.take(0).duration, 0, "down to zero with take(0)");
     t.equal(!map.fallible, true, "not fallible");


### PR DESCRIPTION
Seq/map accepts a child item that gets instantiated for every value of the input array. This avoids the issue of not being able to generate an item properly, and is the form that can be used in the patcher.