### PR TITLE
1S0N Optionally include tape occurrences in dump

### DIFF
--- a/lib/timing/util.js
+++ b/lib/timing/util.js
@@ -19,7 +19,13 @@ export function cancelled(instance, t) {
 }
 
 // Dump an instance and its children for debugging and testing.
-export function dump(instance, indent = "* ") {
+export function dump(instance, withOccurrences = false, indent = "* ") {
+    const occurrences = withOccurrences ? instance.tape.occurrences.reduce((is, o, i) => {
+        if (o.id === instance.id) {
+            is.push(`o${i}@${o.t}`);
+        }
+        return is;
+    }, []) : [];
     const selfDump = `${indent}${instance.id} ${
         Object.hasOwn(instance, "begin") ? `[${instance.begin}, ${
             isFinite(instance.end) ? instance.end : "∞"
@@ -31,13 +37,13 @@ export function dump(instance, indent = "* ") {
         instance.error === TimeoutError ? " (timeout)" :
         Object.hasOwn(instance, "error") ? ` error<${instance.error.message ?? instance.error}>` :
         Object.hasOwn(instance, "value") ? ` <${instance.value}>` : ""
-    }`;
+    }${occurrences.length > 0 ? ` {${occurrences}}` : ""}`;
     if (!instance.children) {
         return selfDump;
     }
     return [
         selfDump,
-        ...instance.children.map(child => dump(child, `  ${indent}`))
+        ...instance.children.map(child => dump(child, withOccurrences, `  ${indent}`))
     ].join("\n");
 }
 

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -45,8 +45,7 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
     // Dump the score and tape (for debugging)
     dump() {
         if (this.score) {
-            console.log(dump(this.score.instance));
-            console.log(this.score.tape.show());
+            console.log(dump(this.score.instance, true));
         } else {
             console.warn("No score");
         }

--- a/tests/timing/await.html
+++ b/tests/timing/await.html
@@ -225,13 +225,13 @@ test("Cancel", async t => {
     ).take(1), 17);
     deck.now = 37;
     await notification(deck, "await");
-    t.equal(dump(score.instance),
+    t.equal(dump(score.instance, true),
 `* Score-0 [0, ∞[
   * Par-1 [17, 36[ <19>
     * Seq-2 [17, 36[ <19>
-      * Instant-3 @17 <19>
-      * Par/map-4 [17, 36[ <19>
-        * Delay-6 [17, 36[ <19>
+      * Instant-3 @17 <19> {o0@17}
+      * Par/map-4 [17, 36[ <19> {o1@17}
+        * Delay-6 [17, 36[ <19> {o2@36}
     * Await-5 [17, 36[ (cancelled)`, "dump matches");
 });
 
@@ -245,13 +245,13 @@ test("Cancel Await(f).dur(d)", async t => {
     ).take(1), 17);
     deck.now = 39;
     await notification(deck, "await");
-    t.equal(dump(score.instance),
+    t.equal(dump(score.instance, true),
 `* Score-0 [0, ∞[
   * Par-1 [17, 36[ <19>
     * Seq-2 [17, 36[ <19>
-      * Instant-3 @17 <19>
-      * Par/map-4 [17, 36[ <19>
-        * Delay-6 [17, 36[ <19>
+      * Instant-3 @17 <19> {o0@17}
+      * Par/map-4 [17, 36[ <19> {o1@17}
+        * Delay-6 [17, 36[ <19> {o2@36}
     * Await-5 [17, 36[ (cancelled)`, "dump matches");
 });
 

--- a/tests/timing/delay-until.html
+++ b/tests/timing/delay-until.html
@@ -88,11 +88,10 @@ test("Cancel delay", t => {
         Instant(K("ok")), Delay.until(23)
     ).take(1), 17);
     Deck({ tape }).now = 18;
-    t.equal(dump(choice),
+    t.equal(dump(choice, true),
 `* Par-0 @17 <ok>
-  * Instant-1 @17 <ok>
+  * Instant-1 @17 <ok> {o0@17}
   * Delay/until-2 @17 (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17>", "no occurrence on tape");
 });
 
 test("Prune delay", t => {

--- a/tests/timing/delay.html
+++ b/tests/timing/delay.html
@@ -120,15 +120,14 @@ test("Cancel delay", t => {
         Seq(Delay(23), Instant(K("ko"))),
     ).take(1), 17);
     Deck({ tape }).now = 37;
-    t.equal(dump(choice),
+    t.equal(dump(choice, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-7 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-7 [17, 36[ <19> {o2@36}
   * Seq-4 [17, 36[ (cancelled)
     * Delay-5 [17, 36[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,36>", "occurrences were deleted");
 });
 
 test("Prune delay", t => {

--- a/tests/timing/element.html
+++ b/tests/timing/element.html
@@ -48,15 +48,18 @@ test("Cancel", t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const wait = html("p", "wait");
-    const par = tape.instantiate(Par(
-        Par(Event(window, "synth"), Delay(23)),
+    const instance = tape.instantiate(Par(
+        Delay(23),
         Element(wait).dur(Infinity)
     ).take(1), 17);
     deck.now = 31;
     window.dispatchEvent(new window.Event("synth"));
     deck.now = 41;
-    t.match(dump(par), /^\* Par-0 \[17, 40\[ <\[[^\]]+\],>\n  \* Par-1 \[17, 40\[ <\[[^\]]+\],>\n    \* Event-2 \[17, 31\[ <[^>]+>\n    \* Delay-3 \[17, 40\[ <undefined>\n  \* Element-4 \[17, 40\[ \(cancelled\)$/, "dump matches");
     t.equal(wait.parentElement, null, "element was removed");
+    t.equal(dump(instance, true),
+`* Par-0 [17, 40[ <>
+  * Delay-1 [17, 40[ <undefined> {o0@40}
+  * Element-2 [17, 40[ (cancelled) {o1@40}`, "dump matches");
 });
 
 test("Prune", t => {
@@ -66,15 +69,14 @@ test("Prune", t => {
         Seq(Delay(31), Element(html("p", "ok")).dur(Infinity))
     ).take(1), 17);
     Deck({ tape }).now = 41;
-    t.equal(dump(instance),
+    t.equal(dump(instance, true),
 `* Par-0 [17, 40[ <23>
   * Seq-1 [17, 40[ <23>
-    * Instant-2 @17 <23>
-    * Par/map-3 [17, 40[ <23>
-      * Delay-7 [17, 40[ <23>
+    * Instant-2 @17 <23> {o0@17}
+    * Par/map-3 [17, 40[ <23> {o1@17}
+      * Delay-7 [17, 40[ <23> {o2@40}
   * Seq-4 [17, 40[ (cancelled)
     * Delay-5 [17, 40[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,40>", "occurrences were removed from the tape");
 });
 
         </script>

--- a/tests/timing/event.html
+++ b/tests/timing/event.html
@@ -104,12 +104,12 @@ test("Cancel", t => {
         Event(window, "synth")
     ).take(1), 17);
     deck.now = 37;
-    t.equal(dump(instance),
+    t.equal(dump(instance, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-5 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-5 [17, 36[ <19> {o2@36}
   * Event-4 [17, 36[ (cancelled)`, "dump matches");
 });
 
@@ -126,7 +126,7 @@ test("Cancel with repeat", t => {
     window.dispatchEvent(new window.Event("synth"));
     deck.now = 47;
     window.dispatchEvent(new window.Event("synth"));
-    t.match(dump(par), /^\* Par-0 \[17, 40\[ <>\n  \* Seq\/repeat-1 \[17, 40\[ \(cancelled\)\n    \* Event-2 \[17, 27\[ <[^>]+>\n    \* Event-4 \[27, 37\[ <[^>]+>\n    \* Event-5 \[37, 40\[ \(cancelled\)\n  \* Delay-3 \[17, 40\[ <undefined>$/, "dump matches");
+    t.match(dump(par, true), /^\* Par-0 \[17, 40\[ <>\n  \* Seq\/repeat-1 \[17, 40\[ \(cancelled\)\n    \* Event-2 \[17, 27\[ <[^>]+>\n    \* Event-4 \[27, 37\[ <[^>]+>\n    \* Event-5 \[37, 40\[ \(cancelled\)\n  \* Delay-3 \[17, 40\[ <undefined> {o0@40}$/, "dump matches");
 });
 
 test("Prune", t => {
@@ -137,15 +137,14 @@ test("Prune", t => {
         Seq(Delay(23), Event(window, "synth")),
     ).take(1), 17);
     deck.now = 37;
-    t.equal(dump(choice),
+    t.equal(dump(choice, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-7 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-7 [17, 36[ <19> {o2@36}
   * Seq-4 [17, 36[ (cancelled)
     * Delay-5 [17, 36[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,36>", "occurrences were removed from the tape");
 });
 
 test("Prune with repeat", t => {
@@ -156,15 +155,14 @@ test("Prune with repeat", t => {
         Seq(Delay(23), Event(window, "synth").repeat()),
     ).take(1), 17);
     deck.now = 37;
-    t.equal(dump(choice),
+    t.equal(dump(choice, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-8 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-8 [17, 36[ <19> {o2@36}
   * Seq-4 [17, 36[ (cancelled)
     * Delay-5 [17, 36[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,36>", "occurrences were removed from the tape");
 });
 
         </script>

--- a/tests/timing/par-map.html
+++ b/tests/timing/par-map.html
@@ -282,18 +282,17 @@ test("Cancel Par.map", t => {
         Seq(Instant(K([23, 31])), Par.map(Delay)),
     ).take(1), 17);
     Deck({ tape }).now = 37;
-    t.equal(dump(choice),
+    t.equal(dump(choice, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-7 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-7 [17, 36[ <19> {o4@36}
   * Seq-4 [17, 36[ (cancelled)
-    * Instant-5 @17 <23,31>
-    * Par/map-6 [17, 36[ (cancelled)
+    * Instant-5 @17 <23,31> {o2@17}
+    * Par/map-6 [17, 36[ (cancelled) {o3@17}
       * Delay-8 [17, 36[ (cancelled)
       * Delay-9 [17, 36[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,17,17,36>", "occurrences where removed from the tape");
 });
 
 test("Prune Par.map", t => {
@@ -303,15 +302,14 @@ test("Prune Par.map", t => {
         Seq(Delay(23), Par.map(Delay))
     ).take(1), 17);
     Deck({ tape }).now = 37;
-    t.equal(dump(choice),
+    t.equal(dump(choice, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-7 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-7 [17, 36[ <19> {o2@36}
   * Seq-4 [17, 36[ (cancelled)
     * Delay-5 [17, 36[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,36>", "occurrences where removed from the tape");
 });
 
 test("Input error", t => {

--- a/tests/timing/par.html
+++ b/tests/timing/par.html
@@ -170,16 +170,15 @@ test("Cancel par", t => {
         Par(Delay(23), Delay(31))
     ).take(1), 17);
     Deck({ tape }).now = 37;
-    t.equal(dump(choice),
+    t.equal(dump(choice, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-7 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-7 [17, 36[ <19> {o2@36}
   * Par-4 [17, 36[ (cancelled)
     * Delay-5 [17, 36[ (cancelled)
     * Delay-6 [17, 36[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,36>", "occurrences were removed from the tape");
 });
 
 test("Prune par", t => {
@@ -189,15 +188,14 @@ test("Prune par", t => {
         Seq(Delay(23), Par(), Par(Delay(31)))
     ).take(1), 17);
     Deck({ tape }).now = 37;
-    t.equal(dump(choice),
+    t.equal(dump(choice, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-9 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-9 [17, 36[ <19> {o2@36}
   * Seq-4 [17, 36[ (cancelled)
     * Delay-5 [17, 36[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,36>", "occurrences were removed from the tape");
 });
 
         </script>

--- a/tests/timing/seq-fold.html
+++ b/tests/timing/seq-fold.html
@@ -306,19 +306,18 @@ test("Cancel Seq.fold", t => {
         Seq(Instant(K([1, 2, 3])), Seq.fold(x => Seq(Instant(y => x + y), Delay(23)), 0))
     ).take(1), 17);
     Deck({ tape }).now = 37;
-    t.equal(dump(choice),
+    t.equal(dump(choice, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-7 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-7 [17, 36[ <19> {o5@36}
   * Seq-4 [17, 36[ (cancelled)
-    * Instant-5 @17 <1,2,3>
-    * Seq/fold-6 [17, 36[ (cancelled)
+    * Instant-5 @17 <1,2,3> {o2@17}
+    * Seq/fold-6 [17, 36[ (cancelled) {o3@17}
       * Seq-8 [17, 36[ (cancelled)
-        * Instant-9 @17 <1>
+        * Instant-9 @17 <1> {o4@17}
         * Delay-10 [17, 36[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,17,17,17,36>", "occurrences where removed from the tape");
 });
 
 test("Prune Seq.fold", t => {
@@ -328,15 +327,14 @@ test("Prune Seq.fold", t => {
         Seq(Delay(23), Seq.fold(x => Instant(y => x + y), 0))
     ).take(1), 17);
     Deck({ tape }).now = 37;
-    t.equal(dump(choice),
+    t.equal(dump(choice, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-7 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-7 [17, 36[ <19> {o2@36}
   * Seq-4 [17, 36[ (cancelled)
     * Delay-5 [17, 36[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,36>", "occurrences where removed from the tape");
 });
 
         </script>

--- a/tests/timing/seq-map-function.html
+++ b/tests/timing/seq-map-function.html
@@ -257,17 +257,16 @@ test("Cancel Seq.map", t => {
         Seq(Instant(K([23, 31])), Seq.map(Delay))
     ).take(1), 17);
     Deck({ tape }).now = 37;
-    t.equal(dump(choice),
+    t.equal(dump(choice, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-7 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-7 [17, 36[ <19> {o4@36}
   * Seq-4 [17, 36[ (cancelled)
-    * Instant-5 @17 <23,31>
-    * Seq/map-6 [17, 36[ (cancelled)
+    * Instant-5 @17 <23,31> {o2@17}
+    * Seq/map-6 [17, 36[ (cancelled) {o3@17}
       * Delay-8 [17, 36[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,17,17,36>", "occurrences where removed from the tape");
 });
 
 test("Prune Seq.map", t => {
@@ -277,15 +276,14 @@ test("Prune Seq.map", t => {
         Seq(Delay(23), Seq.map(Delay))
     ).take(1), 17);
     Deck({ tape }).now = 37;
-    t.equal(dump(choice),
+    t.equal(dump(choice, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-7 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-7 [17, 36[ <19> {o2@36}
   * Seq-4 [17, 36[ (cancelled)
     * Delay-5 [17, 36[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,36>", "occurrences where removed from the tape");
 });
 
         </script>

--- a/tests/timing/seq-map-item.html
+++ b/tests/timing/seq-map-item.html
@@ -289,18 +289,17 @@ test("Cancel Seq.map", t => {
         Seq(Instant(K([23, 31])), Seq.map(Instant(x => x * 2).dur(29)))
     ).take(1), 17);
     Deck({ tape }).now = 37;
-    t.equal(dump(choice),
+    t.equal(dump(choice, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-7 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-7 [17, 36[ <19> {o4@36}
   * Seq-4 [17, 36[ (cancelled)
-    * Instant-5 @17 <23,31>
-    * Seq/map-6 [17, 36[ (cancelled)
+    * Instant-5 @17 <23,31> {o2@17}
+    * Seq/map-6 [17, 36[ (cancelled) {o3@17}
       * Seq-8 [17, 36[ (cancelled)
         * Delay-9 [17, 36[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,17,17,36>", "occurrences where removed from the tape");
 });
 
 test("Prune Seq.map", t => {
@@ -310,15 +309,14 @@ test("Prune Seq.map", t => {
         Seq(Delay(23), Seq.map(Seq.map(Instant(x => x * 2).dur(29))))
     ).take(1), 17);
     Deck({ tape }).now = 37;
-    t.equal(dump(choice),
+    t.equal(dump(choice, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-7 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-7 [17, 36[ <19> {o2@36}
   * Seq-4 [17, 36[ (cancelled)
     * Delay-5 [17, 36[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,36>", "occurrences where removed from the tape");
 });
 
         </script>

--- a/tests/timing/seq.html
+++ b/tests/timing/seq.html
@@ -175,16 +175,15 @@ test("Cancel Seq", t => {
         Seq(Instant(K("ok")), Delay(23), Instant(() => { throw Error("should be pruned"); }))
     ).take(1), 17);
     Deck({ tape }).now = 41;
-    t.equal(dump(instance),
+    t.equal(dump(instance, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-8 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-8 [17, 36[ <19> {o3@36}
   * Seq-4 [17, 36[ (cancelled)
-    * Instant-5 @17 <ok>
+    * Instant-5 @17 <ok> {o2@17}
     * Delay-6 [17, 36[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,17,36>", "occurrences were removed from the tape");
 });
 
 test("Prune Seq", t => {
@@ -196,16 +195,15 @@ test("Prune Seq", t => {
         ))
     ).take(1), 17);
     Deck({ tape }).now = 41;
-    t.equal(dump(instance),
+    t.equal(dump(instance, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-10 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-10 [17, 36[ <19> {o3@36}
   * Seq-4 [17, 36[ (cancelled)
-    * Instant-5 @17 <ok>
+    * Instant-5 @17 <ok> {o2@17}
     * Delay-6 [17, 36[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,17,36>", "occurrences were removed from the tape");
 });
 
         </script>

--- a/tests/timing/set.html
+++ b/tests/timing/set.html
@@ -86,16 +86,18 @@ test("Cancel", t => {
     const tape = Tape();
     const deck = Deck({ tape });
     const p = html("p", "ok");
-    const par = tape.instantiate(Par(
-        Par(Event(window, "synth"), Delay(23)),
+    const instance = tape.instantiate(Par(
+        Delay(23),
         Set(p, "textContent", "ko").dur(Infinity)
     ).take(1), 17);
     deck.now = 31;
     t.equal(p.textContent, "ko", "textContent was set");
-    window.dispatchEvent(new window.Event("synth"));
     deck.now = 41;
-    t.match(dump(par), /^\* Par-0 \[17, 40\[ <\[[^\]]+\],>\n  \* Par-1 \[17, 40\[ <\[[^\]]+\],>\n    \* Event-2 \[17, 31\[ <[^>]+>\n    \* Delay-3 \[17, 40\[ <undefined>\n  \* Set-4 \[17, 40\[ \(cancelled\)$/, "dump matches");
     t.equal(p.textContent, "ok", "textContent was reset");
+    t.equal(dump(instance, true),
+`* Par-0 [17, 40[ <>
+  * Delay-1 [17, 40[ <undefined> {o0@40}
+  * Set-2 [17, 40[ (cancelled) {o1@40}`, "dump matches");
 });
 
 test("Prune", t => {
@@ -106,15 +108,14 @@ test("Prune", t => {
         Seq(Delay(31), Set(p, "textContent", "ko").dur(Infinity))
     ).take(1), 17);
     Deck({ tape }).now = 41;
-    t.equal(dump(instance),
+    t.equal(dump(instance, true),
 `* Par-0 [17, 40[ <23>
   * Seq-1 [17, 40[ <23>
-    * Instant-2 @17 <23>
-    * Par/map-3 [17, 40[ <23>
-      * Delay-7 [17, 40[ <23>
+    * Instant-2 @17 <23> {o0@17}
+    * Par/map-3 [17, 40[ <23> {o1@17}
+      * Delay-7 [17, 40[ <23> {o2@40}
   * Seq-4 [17, 40[ (cancelled)
     * Delay-5 [17, 40[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,40>", "occurrences were removed from the tape");
 });
 
         </script>

--- a/tests/timing/try.html
+++ b/tests/timing/try.html
@@ -216,15 +216,14 @@ test("Prune (no error)", t => {
         Seq(Delay(23), Try(Event(window, "synth"), Instant(K("ko")))),
     ).take(1), 17);
     deck.now = 37;
-    t.equal(dump(choice),
+    t.equal(dump(choice, true),
 `* Par-0 [17, 36[ <19>
   * Seq-1 [17, 36[ <19>
-    * Instant-2 @17 <19>
-    * Par/map-3 [17, 36[ <19>
-      * Delay-8 [17, 36[ <19>
+    * Instant-2 @17 <19> {o0@17}
+    * Par/map-3 [17, 36[ <19> {o1@17}
+      * Delay-8 [17, 36[ <19> {o2@36}
   * Seq-4 [17, 36[ (cancelled)
     * Delay-5 [17, 36[ (cancelled)`, "dump matches");
-    t.equal(tape.show(), "Tape<17,17,36>", "occurrences were removed from the tape");
 });
 
         </script>


### PR DESCRIPTION
Add a flag to `dump()` so that tape occurrences corresponding to items can also be shown. This is used for the dump in the patcher, and also for tests like cancel/prune to verify that no stray occurrences are left on the tape. Also useful for testing 1S0H (forthcoming).