### PR TITLE
1S0H Review effect of Set.cancel

### DIFF
--- a/lib/tape.js
+++ b/lib/tape.js
@@ -117,14 +117,22 @@ export const Tape = Object.assign(() => create().call(Tape), {
 // True if occurrence a is after occurrence b. When both have the same time,
 // check the instance tree to find which comes first.
 function after(a, b) {
+    // Occurrences are derived from instances, so find the actual instance
+    // object from an occurrence to go up the tree.
     const unwrap = o => Object.hasOwn(o, "id") ? o : unwrap(Object.getPrototypeOf(o));
     if (a.t === b.t) {
+        // Find the lowest common ancestor (if any) between a and b. Do so by
+        // going up the tree from a, recording the position of each ancestor
+        // node in its parent’s list of children.
         const path = new Map();
         let p = unwrap(a);
         while (p.parent) {
             path.set(p.parent, p.parent.children.indexOf(p));
             p = p.parent;
         }
+        // Then go up from b until a node in the path from a is found, which is
+        // the common ancestor. The positions in the child list of this ancestor
+        // can then be compared to find out whether a comes after b.
         let q = unwrap(b);
         while (q.parent) {
             let i = q.parent.children.indexOf(q);

--- a/lib/tape.js
+++ b/lib/tape.js
@@ -79,7 +79,7 @@ export const Tape = Object.assign(() => create().call(Tape), {
     // their time t.
     addOccurrence(occurrence) {
         console.assert(isFinite(occurrence.t));
-        addBy(this.occurrences, occurrence, o => o.t > occurrence.t);
+        addBy(this.occurrences, occurrence, o => after(o, occurrence));
         return occurrence;
     },
 
@@ -113,3 +113,27 @@ export const Tape = Object.assign(() => create().call(Tape), {
         this.occurrences = [];
     },
 });
+
+// True if occurrence a is after occurrence b. When both have the same time,
+// check the instance tree to find which comes first.
+function after(a, b) {
+    const unwrap = o => Object.hasOwn(o, "id") ? o : unwrap(Object.getPrototypeOf(o));
+    if (a.t === b.t) {
+        const path = new Map();
+        let p = unwrap(a);
+        while (p.parent) {
+            path.set(p.parent, p.parent.children.indexOf(p));
+            p = p.parent;
+        }
+        let q = unwrap(b);
+        while (q.parent) {
+            let i = q.parent.children.indexOf(q);
+            q = q.parent;
+            if (path.has(q)) {
+                return path.get(q) > i;
+            }
+        }
+        return false;
+    }
+    return a.t > b.t;
+}

--- a/lib/timing/par.js
+++ b/lib/timing/par.js
@@ -96,14 +96,15 @@ export const Par = assign((...children) => create().call(Par, { children }), {
         if (!isFinite(instance.capacity)) {
             instance.capacity = children.length;
         }
-        instance.children = children.map(child => {
+        instance.children = [];
+        for (const child of children) {
             const childInstance = instance.tape.instantiate(child, t, dur, instance);
             if (childInstance.cutoff) {
                 instance.cutoff = true;
                 delete childInstance.cutoff;
             }
-            return childInstance;
-        });
+            instance.children.push(childInstance);
+        }
         instance.finished = [];
 
         // Set t or begin/end for the par instance and create an occurrence at

--- a/tests/manual/tomato.html
+++ b/tests/manual/tomato.html
@@ -13,7 +13,6 @@ import { Element, Instant, Par, Score, Seq, Set } from "../../lib/timing.js";
 import { dump } from "../../lib/timing/util.js";
 
 const FPS = 9;
-const dur = 1000 / FPS;
 
 const tape = Tape();
 const deck = Deck({ tape });
@@ -30,10 +29,10 @@ score.add(Par(
         Seq.map(Par(
             Seq(
                 Instant(i => `tomato${i.toString().padStart(2, "0")}.png`),
-                Set(image, "src").dur(dur)
+                Set(image, "src").dur(1000 / FPS)
             ),
-            Set(frame, "textContent").dur(dur)
-        ))
+            Set(frame, "textContent").dur(Infinity)
+        ).take(1))
     ).repeat()
 ));
 

--- a/tests/manual/tomato.html
+++ b/tests/manual/tomato.html
@@ -19,22 +19,19 @@ const deck = Deck({ tape });
 const score = Score({ tape });
 
 const image = html("img");
-const frame = html("p");
+const frame = document.querySelector("span");
 
-score.add(Par(
-    Element(image).dur(Infinity),
-    Element(frame).dur(Infinity),
-    Seq(
-        Instant(K([...range(1, 18)])),
-        Seq.map(Par(
-            Seq(
-                Instant(i => `tomato${i.toString().padStart(2, "0")}.png`),
-                Set(image, "src").dur(1000 / FPS)
-            ),
-            Set(frame, "textContent").dur(Infinity)
-        ).take(1))
-    ).repeat()
-));
+score.add(Element(image).dur(Infinity));
+score.add(Seq(
+    Instant(K([...range(1, 18)])),
+    Seq.map(Par(
+        Seq(
+            Instant(i => `tomato${i.toString().padStart(2, "0")}.png`),
+            Set(image, "src").dur(1000 / FPS)
+        ),
+        Set(document.querySelector("span"), "textContent").dur(Infinity)
+    ).take(1))
+).repeat());
 
 deck.start();
 
@@ -43,5 +40,6 @@ window.$ = () => { console.log(dump(score.instance)); };
         </script>
     </head>
     <body>
+        <p>Frame #<span>0</span></p>
     </body>
 </html>

--- a/tests/timing/set.html
+++ b/tests/timing/set.html
@@ -100,6 +100,34 @@ test("Cancel", t => {
   * Set-2 [17, 40[ (cancelled) {o1@40}`, "dump matches");
 });
 
+test("Cancel and set again", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const object = {
+        values: [1],
+        get value() {
+            return this.values.at(-1);
+        },
+        set value(x) {
+            this.values.push(x);
+        }
+    };
+    const instance = tape.instantiate(Seq(
+        Par(Delay(23), Set(object, "value", 2).dur(Infinity)).take(1),
+        Par(Delay(31), Set(object, "value", 3).dur(Infinity)).take(1)
+    ), 17);
+    Deck({ tape }).now = 73;
+    t.equal(dump(instance, true),
+`* Seq-0 [17, 71[ <>
+  * Par-1 [17, 40[ <>
+    * Delay-2 [17, 40[ <undefined> {o0@40}
+    * Set-3 [17, 40[ (cancelled) {o1@40}
+  * Par-4 [40, 71[ <>
+    * Delay-5 [40, 71[ <> {o2@71}
+    * Set-6 [40, 71[ (cancelled) {o3@71}`, "dump matches");
+    t.equal(object.values, [1, 2, 1, 3, 1], "value was set and unset");
+});
+
 test("Prune", t => {
     const tape = Tape();
     const p = html("p", "ok");


### PR DESCRIPTION
Cancelling Set could fail if it was followed by another scheduled set because the occurrence for the cancel was added after the occurrence for the following set, undoing it. In order to ensure that occurrences are added in the correct order when they happen at the same instant, we go up the instance tree to verify which one should go first.