### PR TITLE
1S0T Cancelled element is not removed

### DIFF
--- a/lib/tape.js
+++ b/lib/tape.js
@@ -61,7 +61,22 @@ export const Tape = Object.assign(() => create().call(Tape), {
         const occurred = new Set();
         while (i < this.occurrences.length) {
             occurred.add(this.occurrences[i]);
+            const t = this.occurrences[i].t;
             yield this.occurrences[i];
+
+            // Check if no instance was added at the same instant but with a
+            // lower index (e.g., cancelling an element that comes before in
+            // the instance tree).
+            for (let j = i - 1; j >= 0; --j) {
+                const o = this.occurrences[j];
+                if (o?.t < t) {
+                    break;
+                }
+                if (o && !occurred.has(o) && typeof o.forward === "function") {
+                    i = j;
+                }
+            }
+
             while (i < this.occurrences.length) {
                 const o = this.occurrences[i];
                 if (o.t >= to) {

--- a/tests/timing/element.html
+++ b/tests/timing/element.html
@@ -52,14 +52,12 @@ test("Cancel", t => {
         Element(wait).dur(Infinity),
         Delay(23),
     ).take(1), 17);
-    deck.now = 31;
-    window.dispatchEvent(new window.Event("synth"));
     deck.now = 41;
-    t.equal(wait.parentElement, null, "element was removed");
     t.equal(dump(instance, true),
 `* Par-0 [17, 40[ <>
-  * Element-1 [17, 40[ (cancelled) {o1@40}
-  * Delay-2 [17, 40[ <undefined> {o0@40}`, "dump matches");
+  * Element-1 [17, 40[ (cancelled) {o0@40}
+  * Delay-2 [17, 40[ <undefined> {o1@40}`, "dump matches");
+    t.equal(wait.parentElement, null, "element was removed");
 });
 
 test("Prune", t => {

--- a/tests/timing/element.html
+++ b/tests/timing/element.html
@@ -49,8 +49,8 @@ test("Cancel", t => {
     const deck = Deck({ tape });
     const wait = html("p", "wait");
     const instance = tape.instantiate(Par(
+        Element(wait).dur(Infinity),
         Delay(23),
-        Element(wait).dur(Infinity)
     ).take(1), 17);
     deck.now = 31;
     window.dispatchEvent(new window.Event("synth"));
@@ -58,8 +58,8 @@ test("Cancel", t => {
     t.equal(wait.parentElement, null, "element was removed");
     t.equal(dump(instance, true),
 `* Par-0 [17, 40[ <>
-  * Delay-1 [17, 40[ <undefined> {o0@40}
-  * Element-2 [17, 40[ (cancelled) {o1@40}`, "dump matches");
+  * Element-1 [17, 40[ (cancelled) {o1@40}
+  * Delay-2 [17, 40[ <undefined> {o0@40}`, "dump matches");
 });
 
 test("Prune", t => {


### PR DESCRIPTION
If the instance being cancelled comes before the instance cancelling it in the instance tree, then the occurrence for removal is added before the one that caused the cancellation, and the update loop could miss it. Now it checks backward to make sure that it is not missed.