### PR TITLE
1S0U Element with infinite duration does not begin

### DIFF
--- a/lib/timing/seq.js
+++ b/lib/timing/seq.js
@@ -309,6 +309,11 @@ const Map = {
         }
     },
 
+    // Has effect if the child has effect.
+    get hasEffect() {
+        return this.child.hasEffect;
+    },
+
     // Schedule instantiation of the contents.
     instantiate(instance, t, dur) {
         if (this.modifiers?.take === 0) {

--- a/lib/timing/seq.js
+++ b/lib/timing/seq.js
@@ -72,6 +72,11 @@ export const Seq = assign((...children) => create().call(Seq, { children }), {
         return this.durationForChildren(this.children) === null;
     },
 
+    // Has effect if any child has effect.
+    get hasEffect() {
+        return this.children.some(child => child.hasEffect);
+    },
+
     // The value of a Seq is the value of its last child.
     valueForInstance() {
         return this.children?.at(-1)?.value;

--- a/tests/timing/par-take.html
+++ b/tests/timing/par-take.html
@@ -7,10 +7,10 @@
         <script type="module">
 
 import { test } from "../test.js";
-import { K } from "../../lib/util.js";
+import { html, K } from "../../lib/util.js";
 import { Tape } from "../../lib/tape.js";
 import { Deck } from "../../lib/deck.js";
-import { Delay, Effect, Event, Instant, Par, Seq, Set } from "../../lib/timing.js";
+import { Delay, Effect, Element, Event, Instant, Par, Seq, Set } from "../../lib/timing.js";
 import { dump } from "../../lib/timing/util.js";
 
 test("Par(xs).take(n = ∞) duration", t => {
@@ -214,6 +214,20 @@ test("More effects", t => {
     * Set-3 [17, 40[ <ok>
   * Instant-4 @40 <ok>`, "dump matches");
 })
+
+test("Even more effects: Seq", t => {
+    const tape = Tape();
+    const instance = tape.instantiate(Par(
+        Seq(Delay(31), Element(html("p", "ok")).dur(Infinity)),
+        Delay(23)
+    ).take(1), 17);
+    Deck({ tape }).now = 41;
+    t.equal(dump(instance),
+`* Par-0 [17, 40[ <>
+  * Seq-1 [17, 40[ (cancelled)
+    * Delay-2 [17, 40[ (cancelled)
+  * Delay-4 [17, 40[ <undefined>`, "dump matches");
+});
 
         </script>
     </head>

--- a/tests/timing/seq-map-item.html
+++ b/tests/timing/seq-map-item.html
@@ -10,7 +10,7 @@ import { test } from "../test.js";
 import { K } from "../../lib/util.js";
 import { Tape } from "../../lib/tape.js";
 import { Deck } from "../../lib/deck.js";
-import { Await, Delay, Event, Instant, Par, Seq, Set } from "../../lib/timing.js";
+import { Await, Delay, Effect, Event, Instant, Par, Seq, Set } from "../../lib/timing.js";
 import { dump } from "../../lib/timing/util.js";
 
 test("Seq.map(child)", t => {
@@ -22,6 +22,11 @@ test("Seq.map(child)", t => {
     t.undefined(map.duration, "unresolved duration");
     t.equal(map.take(0).duration, 0, "down to zero with take(0)");
     t.equal(!map.fallible, true, "not fallible");
+    t.equal(!map.hasEffect, true, "no effect");
+});
+
+test("Seq.map(child).hasEffect", t => {
+    t.equal(Seq.map(Effect(x => { console.log(x); })).hasEffect, true, "has effect if child has effect");
 });
 
 test("Seq.map(child).repeat()", t => {

--- a/tests/timing/seq.html
+++ b/tests/timing/seq.html
@@ -11,7 +11,7 @@ import { K, timeout } from "../../lib/util.js";
 import { notification } from "../../lib/events.js";
 import { Tape } from "../../lib/tape.js";
 import { Deck } from "../../lib/deck.js";
-import { Await, Delay, Instant, Par, Seq, Set } from "../../lib/timing.js";
+import { Await, Delay, Effect, Instant, Par, Seq, Set } from "../../lib/timing.js";
 import { dump } from "../../lib/timing/util.js";
 
 test("Seq()", t => {
@@ -20,6 +20,7 @@ test("Seq()", t => {
     t.equal(seq.children, [], "no children");
     t.equal(seq.duration, 0, "zero duration");
     t.equal(!seq.fallible, true, "not fallible");
+    t.equal(seq.hasEffect, false, "no effect when empty");
 });
 
 test("Seq(xs)", t => {
@@ -32,6 +33,12 @@ test("Seq(xs)", t => {
     t.equal(instant.parent, seq, "parent (2)");
     t.equal(seq.duration, 17, "duration");
     t.equal(!seq.fallible, true, "not fallible");
+    t.equal(seq.hasEffect, false, "no effect when no children has effect");
+});
+
+test("Seq(xs).hasEffect", t => {
+    t.equal(Seq(Delay(17), Effect(x => { console.log(x); })).hasEffect, true,
+        "has effect if some child has effect");
 });
 
 test("Seq duration", t => {


### PR DESCRIPTION
Because Seq was not marked as having effect, it could be pruned from a Par.take(1). Seq, Seq/map (for item) and Par (in a follow-up, cf. 1S0Z) need to check their children for effect.