### PR TITLE
1Q0N `parseTime()` should support clock values

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -172,10 +172,11 @@ export const nop = () => {};
 // Normalize whitespace in a string.
 export const normalizeWhitespace = string => string.trim().replace(/\s+/g, " ");
 
-// Parse time values into a number of milliseconds.
-// Units are week (w), day (d), hour (h), minute (mn), second (s) and millisecond
-// (ms). Unitless values default to ms (e.g., "500" is 500ms), and strings can
-// contain several units ("1m 30s" is 90000ms).
+// Parse time values into a number of milliseconds, following the SMIL spec
+// (https://www.w3.org/TR/2008/REC-SMIL3-20081201/smil-timing.html#TimingSyntax-Clock-value)
+// roughly. Units are week (w), day (d), hour (h), minute (mn), second (s) and
+// millisecond (ms). Unitless values default to ms (e.g., "500" is 500ms), and
+// strings can contain several units ("1m 30s" is 90000ms).
 const Units = [
     ["weeks?|wk?", 7 * 24 * 60 * 60 * 1000],
     ["days?|d", 24 * 60 * 60 * 1000],
@@ -186,9 +187,22 @@ const Units = [
 ];
 
 export function parseTime(string) {
+    // Infinity
     if (/^\s*(infinity|indefinite|∞)\s*$/i.test(string)) {
         return Infinity;
     }
+
+    // Clock value
+    const match = string.match(/^\s*(?:([0-9]+):)?([0-5][0-9]):([0-5][0-9])(?:(\.[0-9]+))?\s*$/);
+    if (match) {
+        const h = match[1] ? parseInt(match[0], 10) : 0;
+        const m = parseInt(match[2], 10);
+        const s = parseInt(match[3], 10);
+        const ms = match[4] ? parseFloat(match[4]) : 0;
+        return (h * 3600000 + m * 60000 + (s + ms) * 1000);
+    }
+
+    // Timecout value
     const [t, rest] = Units.reduce(([t, rest], [unit, ms]) => {
         const match = rest.match(new RegExp(`^\\s*(\\d+(?:\\.\\d+)?)\\s*(?:${unit})`, "i"));
         return match ? [t + parseFloat(match[1]) * ms, rest.slice(match[0].length)] : [t, rest];

--- a/tests/util.html
+++ b/tests/util.html
@@ -256,7 +256,26 @@ test("normalizeWhitespace(string)", t => {
         "trim and collapse whitespace");
 });
 
-test("parseTime(string)", t => {
+test("parseTime(string), infinity", t => {
+    t.equal(parseTime("Infinity"), Infinity, "Infinity");
+    t.equal(parseTime("indefinite"), Infinity, "indefinite");
+    t.equal(parseTime("   ∞    "), Infinity, "∞");
+    t.throws(() => { parseTime("Infinity 1s"); }, "only infinity");
+});
+
+test("parseTime(string), clock value", t => {
+    t.equal(parseTime("02:30:03"), 9003000, "02:30:03 = 2h 30mn 3s");
+    t.equal(parseTime("50:00:10.25"), 180010250, "50:00:10.25 = 50h 10s 250ms");
+    t.equal(parseTime("02:33"), 153000, "02:33 = 2mn 33s");
+    t.equal(parseTime("00:10.5"), 10500, "00:10.5 = 10s 500ms");
+    t.throws(() => { parseTime("03:10."); }, "trailing dot");
+    t.throws(() => { parseTime("63:10.5"); }, "too many minutes");
+    t.throws(() => { parseTime("03:70.5"); }, "too many seconds");
+    t.throws(() => { parseTime("3:10.5"); }, "too few digits (minutes)");
+    t.throws(() => { parseTime("03:0.5"); }, "too few digits (seconds)");
+});
+
+test("parseTime(string), timecount value", t => {
     t.equal(parseTime("365 days 6hr"), 31557600000, "1 average year = 31,557,600,000 ms");
     t.equal(parseTime("1w"), 604800000, "1w = 604,800,000 ms");
     t.equal(parseTime("1 week"), 604800000, "1 week = 604,800,000 ms");
@@ -280,13 +299,9 @@ test("parseTime(string)", t => {
     t.equal(parseTime("500"), 500, "ms is the default unit");
     t.equal(parseTime(" 2 hr 30 mn 10 S  "), 9010000, "several units in the right order");
     t.equal(parseTime("2hr30mn10s"), 9010000, "no spaces");
-    t.equal(parseTime("Infinity"), Infinity, "Infinity");
-    t.equal(parseTime("indefinite"), Infinity, "indefinite");
-    t.equal(parseTime("   ∞    "), Infinity, "∞");
     t.throws(() => { parseTime("2hr:30mn:10s"); }, "extra separators");
     t.throws(() => { parseTime(" 10 min  2H "); }, "several units in the wrong order");
     t.throws(() => { parseTime("one week"); }, "unexpected format");
-    t.throws(() => { parseTime("Infinity 1s"); }, "only infinity");
 });
 
 test("partition(xs, p)", t => {


### PR DESCRIPTION
Follow the SMIL spec for this one, and split the parseTime test in three.