### PR TITLE
1R0B Make canvas scrollable

### DIFF
--- a/patcher/box.js
+++ b/patcher/box.js
@@ -60,5 +60,9 @@ export const Box = assign(properties => create(properties).call(Box), {
         } else {
             this.patcher.boxMoveWasCancelled();
         }
+    },
+
+    dragDidEnd() {
+        this.patcher.boxMoveEnded();
     }
 });

--- a/patcher/box.js
+++ b/patcher/box.js
@@ -63,6 +63,6 @@ export const Box = assign(properties => create(properties).call(Box), {
     },
 
     dragDidEnd() {
-        this.patcher.boxMoveEnded(this);
+        this.patcher.boxMoveEnded();
     }
 });

--- a/patcher/box.js
+++ b/patcher/box.js
@@ -63,6 +63,6 @@ export const Box = assign(properties => create(properties).call(Box), {
     },
 
     dragDidEnd() {
-        this.patcher.boxMoveEnded();
+        this.patcher.boxMoveEnded(this);
     }
 });

--- a/patcher/index.html
+++ b/patcher/index.html
@@ -10,47 +10,49 @@
         <p class="error hidden">No error!</p>
         <div class="main">
 
-            <svg class="canvas">
-                <defs>
-                    <pattern id="grid" patternUnits="userSpaceOnUse" width="24" height="24">
-                        <rect fill="#f8f9f0" width="24" height="24"/>
-                        <g stroke="#abc">
-                            <line y2="100%"/>
-                            <line x2="100%"/>
-                        </g>
-                    </pattern>
-                    <symbol id="stop" viewBox="0 0 100 100">
-                        <path fill="#222" stroke="#222" stroke-width="8" stroke-linejoin="round"
-                            d="M20,20v60h60v-60z"/>
-                    </symbol>
-                    <symbol id="play" viewBox="0 0 100 100">
-                        <path fill="#222" stroke="#222" stroke-width="8" stroke-linejoin="round"
-                            d="M15.359,10v80L69.282,50z"/>
-                    </symbol>
-                    <symbol id="pause" viewBox="0 0 100 100">
-                        <path fill="#222" stroke="#222" stroke-width="8" stroke-linejoin="round"
-                            d="M20,20v60h20v-60z M60,20v60h20v-60z"/>
-                    </symbol>
-                    <symbol id="step" viewBox="0 0 100 100">
-                        <path fill="#222" stroke="#222" stroke-width="8" stroke-linejoin="round"
-                            d="M0,20v60L50,50z M52,20v60h10v-60z M92,20v60h-10v-60z"/>
-                    </symbol>
-                    <symbol id="rewind" viewBox="0 0 100 100">
-                        <path fill="#222" stroke="#222" stroke-width="8" stroke-linejoin="round"
-                            d="M100,20v60L50,50z M50,20v60L0,50z"/>
-                    </symbol>
-                    <symbol id="fastForward" viewBox="0 0 100 100">
-                        <path fill="#222" stroke="#222" stroke-width="8" stroke-linejoin="round"
-                            d="M0,20v60L50,50z M50,20v60L100,50z"/>
-                    </symbol>
-                </defs>
-                <rect width="100%" height="100%" fill="url(#grid)" class="grid"/>
+            <div class="canvas">
+                <svg class="canvas">
+                    <defs>
+                        <pattern id="grid" patternUnits="userSpaceOnUse" width="24" height="24">
+                            <rect fill="#f8f9f0" width="24" height="24"/>
+                            <g stroke="#abc">
+                                <line y2="100%"/>
+                                <line x2="100%"/>
+                            </g>
+                        </pattern>
+                        <symbol id="stop" viewBox="0 0 100 100">
+                            <path fill="#222" stroke="#222" stroke-width="8" stroke-linejoin="round"
+                                d="M20,20v60h60v-60z"/>
+                        </symbol>
+                        <symbol id="play" viewBox="0 0 100 100">
+                            <path fill="#222" stroke="#222" stroke-width="8" stroke-linejoin="round"
+                                d="M15.359,10v80L69.282,50z"/>
+                        </symbol>
+                        <symbol id="pause" viewBox="0 0 100 100">
+                            <path fill="#222" stroke="#222" stroke-width="8" stroke-linejoin="round"
+                                d="M20,20v60h20v-60z M60,20v60h20v-60z"/>
+                        </symbol>
+                        <symbol id="step" viewBox="0 0 100 100">
+                            <path fill="#222" stroke="#222" stroke-width="8" stroke-linejoin="round"
+                                d="M0,20v60L50,50z M52,20v60h10v-60z M92,20v60h-10v-60z"/>
+                        </symbol>
+                        <symbol id="rewind" viewBox="0 0 100 100">
+                            <path fill="#222" stroke="#222" stroke-width="8" stroke-linejoin="round"
+                                d="M100,20v60L50,50z M50,20v60L0,50z"/>
+                        </symbol>
+                        <symbol id="fastForward" viewBox="0 0 100 100">
+                            <path fill="#222" stroke="#222" stroke-width="8" stroke-linejoin="round"
+                                d="M0,20v60L50,50z M50,20v60L100,50z"/>
+                        </symbol>
+                    </defs>
+                    <rect width="100%" height="100%" fill="url(#grid)" class="grid"/>
 
-                <!-- TODO remove -->
-                <rect class="bounding"/>
+                    <!-- TODO remove -->
+                    <rect class="bounding"/>
 
-                <g class="items"></g>
-            </svg>
+                    <g class="items"></g>
+                </svg>
+            </div>
 
             <ul class="transport-bar">
                 <li>

--- a/patcher/index.html
+++ b/patcher/index.html
@@ -45,6 +45,10 @@
                     </symbol>
                 </defs>
                 <rect width="100%" height="100%" fill="url(#grid)" class="grid"/>
+
+                <!-- TODO remove -->
+                <rect class="bounding"/>
+
                 <g class="items"></g>
             </svg>
 

--- a/patcher/index.html
+++ b/patcher/index.html
@@ -46,10 +46,6 @@
                         </symbol>
                     </defs>
                     <rect width="100%" height="100%" fill="url(#grid)" class="grid"/>
-
-                    <!-- TODO remove -->
-                    <rect class="bounding"/>
-
                     <g class="items"></g>
                 </svg>
             </div>

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -165,11 +165,6 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
         this.boundingRect.width = x2 - x1;
         this.boundingRect.y = Math.max(y1, 0);
         this.boundingRect.height = y2 - y1;
-        const boundingRect = document.querySelector("rect.bounding");
-        boundingRect.setAttribute("x", this.boundingRect.x);
-        boundingRect.setAttribute("y", this.boundingRect.y);
-        boundingRect.setAttribute("width", this.boundingRect.width);
-        boundingRect.setAttribute("height", this.boundingRect.height);
         notify(this, "bounding-rect", { rect: this.boundingRect });
     },
 

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -151,6 +151,8 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
         const x2 = Math.max(this.boundingRect.x + this.boundingRect.width, box.x + box.width + padding);
         const y2 = Math.max(this.boundingRect.y + this.boundingRect.height, box.y + box.height + padding);
 
+        // Shift everything when the canvas extends past the left/top edge of
+        // its container.
         if (x1 < 0 || y1 < 0) {
             const tx = Math.min(x1, 0);
             const ty = Math.min(y1, 0);

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -146,24 +146,19 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
     },
 
     updateBoundingRect() {
-        this.boundingRect = { x: 0, y: 0, width: 0, height: 0 };
+        const rect = { x: 0, y: 0, width: 0, height: 0 };
         for (const box of this.boxes.keys()) {
-            this.boundingRect.x = Math.min(this.boundingRect.x, box.x);
-            this.boundingRect.y = Math.min(this.boundingRect.y, box.y);
-            this.boundingRect.width = Math.max(
-                this.boundingRect.width, box.x + box.width - this.boundingRect.x
-            );
-            this.boundingRect.height = Math.max(
-                this.boundingRect.height, box.y + box.height - this.boundingRect.y
-            );
+            rect.x = Math.min(rect.x, box.x);
+            rect.y = Math.min(rect.y, box.y);
+            rect.width = Math.max(rect.width, box.x + box.width - rect.x);
+            rect.height = Math.max(rect.height, box.y + box.height - rect.y);
         }
-        const rect = document.querySelector("rect.bounding");
-        rect.setAttribute("x", this.boundingRect.x);
-        rect.setAttribute("y", this.boundingRect.y);
-        rect.setAttribute("width", this.boundingRect.width);
-        rect.setAttribute("height", this.boundingRect.height);
-        document.body.style.minWidth = `${this.boundingRect.width}px`;
-        document.body.style.minHeight = `${this.boundingRect.height}px`;
+        const boundingRect = document.querySelector("rect.bounding");
+        boundingRect.setAttribute("x", rect.x);
+        boundingRect.setAttribute("y", rect.y);
+        boundingRect.setAttribute("width", rect.width);
+        boundingRect.setAttribute("height", rect.height);
+        notify(this, "bounding-rect", { rect });
     },
 
     cordWasAdded(cord) {

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -145,14 +145,25 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
         this.boxes.delete(box);
     },
 
-    updateBoundingRect(box) {
-        const x1 = Math.min(this.boundingRect.x, box.x);
-        const y1 = Math.min(this.boundingRect.y, box.y);
-        const x2 = Math.max(this.boundingRect.x + this.boundingRect.width, box.x + box.width);
-        const y2 = Math.max(this.boundingRect.y + this.boundingRect.height, box.y + box.height);
-        this.boundingRect.x = x1;
+    updateBoundingRect(box, padding = 8) {
+        const x1 = Math.min(this.boundingRect.x, box.x - padding);
+        const y1 = Math.min(this.boundingRect.y, box.y - padding);
+        const x2 = Math.max(this.boundingRect.x + this.boundingRect.width, box.x + box.width + padding);
+        const y2 = Math.max(this.boundingRect.y + this.boundingRect.height, box.y + box.height + padding);
+
+        if (x1 < 0 || y1 < 0) {
+            const tx = Math.min(x1, 0);
+            const ty = Math.min(y1, 0);
+            for (const box of this.boxes.keys()) {
+                box.x -= tx;
+                box.y -= ty;
+                box.updatePosition();
+            }
+        }
+
+        this.boundingRect.x = Math.max(x1, 0);
         this.boundingRect.width = x2 - x1;
-        this.boundingRect.y = y1;
+        this.boundingRect.y = Math.max(y1, 0);
         this.boundingRect.height = y2 - y1;
         const boundingRect = document.querySelector("rect.bounding");
         boundingRect.setAttribute("x", this.boundingRect.x);

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -146,14 +146,14 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
     },
 
     updateBoundingRect(box) {
-        this.boundingRect.x = Math.min(this.boundingRect.x, box.x);
-        this.boundingRect.y = Math.min(this.boundingRect.y, box.y);
-        this.boundingRect.width = Math.max(
-            this.boundingRect.width, box.x + box.width - this.boundingRect.x
-        );
-        this.boundingRect.height = Math.max(
-            this.boundingRect.height, box.y + box.height - this.boundingRect.y
-        );
+        const x1 = Math.min(this.boundingRect.x, box.x);
+        const y1 = Math.min(this.boundingRect.y, box.y);
+        const x2 = Math.max(this.boundingRect.x + this.boundingRect.width, box.x + box.width);
+        const y2 = Math.max(this.boundingRect.y + this.boundingRect.height, box.y + box.height);
+        this.boundingRect.x = x1;
+        this.boundingRect.width = x2 - x1;
+        this.boundingRect.y = y1;
+        this.boundingRect.height = y2 - y1;
         const boundingRect = document.querySelector("rect.bounding");
         boundingRect.setAttribute("x", this.boundingRect.x);
         boundingRect.setAttribute("y", this.boundingRect.y);

--- a/patcher/patcher.js
+++ b/patcher/patcher.js
@@ -279,6 +279,10 @@ const Patcher = assign(canvas => create({ canvas }).call(Patcher), {
         }
     },
 
+    boxMoveEnded() {
+        this.patch.updateBoundingRect();
+    },
+
     // Selection (multiple if dragging a rect, single if tapping an item).
     dragDidBegin(x0, y0) {
         if (this.locked) {

--- a/patcher/patcher.js
+++ b/patcher/patcher.js
@@ -286,8 +286,8 @@ const Patcher = assign(canvas => create({ canvas }).call(Patcher), {
         }
     },
 
-    boxMoveEnded() {
-        this.patch.updateBoundingRect();
+    boxMoveEnded(box) {
+        this.patch.updateBoundingRect(box);
     },
 
     // Selection (multiple if dragging a rect, single if tapping an item).

--- a/patcher/patcher.js
+++ b/patcher/patcher.js
@@ -286,8 +286,10 @@ const Patcher = assign(canvas => create({ canvas }).call(Patcher), {
         }
     },
 
-    boxMoveEnded(box) {
-        this.patch.updateBoundingRect(box);
+    boxMoveEnded() {
+        for (const item of this.selection) {
+            this.patch.updateBoundingRect(item);
+        }
     },
 
     // Selection (multiple if dragging a rect, single if tapping an item).

--- a/patcher/port.js
+++ b/patcher/port.js
@@ -140,11 +140,12 @@ export const Port = assign(properties => create(properties).call(Port), {
 
     // Create a cord from this port. Prevent creating new incoming cords for
     // inlets that already have one.
-    dragDidBegin(x, y) {
+    dragDidBegin(x0, y0) {
         if (!this.isOutlet && this.cords.size > 0) {
             return false;
         }
-        this.cord = Cord(this, x, y);
+        this.cordOrigin = this.patcher.canvas.getBoundingClientRect();
+        this.cord = Cord(this, x0 - this.cordOrigin.x, y0 - this.cordOrigin.y);
         this.patcher.itemsGroup.appendChild(this.cord.element);
         this.patcher.deselect();
         this.possibleTargets = new Map();
@@ -169,6 +170,8 @@ export const Port = assign(properties => create(properties).call(Port), {
                 delete this.dragTarget;
             }
         }
+        x -= this.cordOrigin.x;
+        y -= this.cordOrigin.y;
         this.cord.updateEndpoint(x, y);
     },
 
@@ -201,8 +204,7 @@ export const Port = assign(properties => create(properties).call(Port), {
             this.cord.element.remove();
         }
         delete this.cord;
-        delete this.x0;
-        delete this.y0;
+        delete this.cordOrigin;
         delete this.possibleTargets;
     }
 });

--- a/patcher/port.js
+++ b/patcher/port.js
@@ -144,8 +144,8 @@ export const Port = assign(properties => create(properties).call(Port), {
         if (!this.isOutlet && this.cords.size > 0) {
             return false;
         }
-        this.cordOrigin = this.patcher.canvas.getBoundingClientRect();
-        this.cord = Cord(this, x0 - this.cordOrigin.x, y0 - this.cordOrigin.y);
+        this.canvasRect = this.patcher.canvas.getBoundingClientRect();
+        this.cord = Cord(this, x0 - this.canvasRect.x, y0 - this.canvasRect.y);
         this.patcher.itemsGroup.appendChild(this.cord.element);
         this.patcher.deselect();
         this.possibleTargets = new Map();
@@ -170,9 +170,7 @@ export const Port = assign(properties => create(properties).call(Port), {
                 delete this.dragTarget;
             }
         }
-        x -= this.cordOrigin.x;
-        y -= this.cordOrigin.y;
-        this.cord.updateEndpoint(x, y);
+        this.cord.updateEndpoint(x - this.canvasRect.x, y - this.canvasRect.y);
     },
 
     dragWasCancelled() {
@@ -204,7 +202,7 @@ export const Port = assign(properties => create(properties).call(Port), {
             this.cord.element.remove();
         }
         delete this.cord;
-        delete this.cordOrigin;
+        delete this.canvasRect;
         delete this.possibleTargets;
     }
 });

--- a/patcher/style.css
+++ b/patcher/style.css
@@ -149,3 +149,7 @@ svg.canvas.locked g.cord line:nth-child(2) {
 svg.canvas.locked .comment rect {
     stroke: none;
 }
+
+rect.bounding {
+    fill: rgba(64, 64, 255, 0.2);
+}

--- a/patcher/style.css
+++ b/patcher/style.css
@@ -154,7 +154,3 @@ svg.canvas.locked g.cord line:nth-child(2) {
 svg.canvas.locked .comment rect {
     stroke: none;
 }
-
-rect.bounding {
-    fill: rgba(64, 64, 255, 0.2);
-}

--- a/patcher/style.css
+++ b/patcher/style.css
@@ -10,9 +10,14 @@ div.main {
     height: 100%;
 }
 
-svg.canvas {
+div.canvas {
     flex: auto;
+    overflow: auto;
+}
+
+svg.canvas {
     display: block;
+    height: 100%;
     width: 100%;
 }
 


### PR DESCRIPTION
Compute the bounding rect of all the boxes in the canvas and set the minimum width of the canvas element so that it shows scrollbars if it gets larger than its container. Do this when boxes are added and move, and not when removed (so that the box only grows). When boxes are moved past the origin xwise or ywise, just shift everything to make our life simpler (this can be improved later with real panning and zooming, but we probably will want a real scene graph by that point).

Beware that now the canvas may have scrolled when using the drag event listener.