### PR TITLE
1T0A Dyadic Score

### DIFF
--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -184,7 +184,7 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
 
     cordWillBeRemoved(cord) {
         const box = cord.inlet.box;
-        if (this.boxes.get(box).isVariadic && cord.inlet === box.inlets[0] &&
+        if (this.boxes.get(box)?.isVariadic && cord.inlet === box.inlets[0] &&
             box.inlets[1].cords.size === 0) {
             box.inlets[1].enabled = false;
         }
@@ -226,10 +226,7 @@ const evalNode = Constructor => safe(input => {
             inlets: 1,
             isFunction: true,
             isVariadic: true,
-            create: ([extraVar]) => {
-                const item = Constructor(f);
-                return extraVar ? item.var(extraVar) : item;
-            }
+            create: extraVars => extraVars.reduce((item, v) => item.var(v), Constructor(f))
         };
     }
 });

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -176,6 +176,9 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
         const target = this.boxes.get(cord.inlet.box);
         cord.isReference = (target.isFunction) ||
             ((source.isElement || source.isWindow) && (target.isEvent || target.isSet));
+        if (target.isDyadic && cord.outlet === target.inlets[0]) {
+            target.inlets[1].enabled = true;
+        }
         delete this.score;
     },
 
@@ -283,6 +286,7 @@ const createElement = (...args) => function(_, box) {
 
 const score = {
     inlets: 1,
+    isDyadic: true,
     outlets: 0,
     create: ([item]) => item
 };


### PR DESCRIPTION
Enable the second inlet to Score (and functions) when the first one is connected, so that Score supports two inputs (both inputs are simply added to the score). Mark it as variadic since a follow-up will allow to add more inlets. Take care to re-add or not remove it when the box is edited.