### PR TITLE
1U0G Gate

### DIFF
--- a/lib/timing.js
+++ b/lib/timing.js
@@ -9,3 +9,5 @@ export { Score } from "./timing/score.js";
 export { Seq } from "./timing/seq.js";
 export { Set } from "./timing/set.js";
 export { Try } from "./timing/try.js";
+
+export { gate } from "./timing/extra.js";

--- a/lib/timing/extra.js
+++ b/lib/timing/extra.js
@@ -1,0 +1,9 @@
+import { Seq } from "./seq.js";
+import { Instant } from "./instant.js";
+
+// Sequence of x and y ignoring the output of x; useful for events that only
+// serve as trigger but don’t have a value of their own.
+export function gate(x, y) {
+    const label = Symbol();
+    return Seq(x, Instant(([_, input]) => input).var(label), y).label(label);
+};

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -1,5 +1,6 @@
 import {
-    Await, Delay, Effect, Element, Event, Instant, Media, Par, Score, Seq, Set, Try
+    Await, Delay, Effect, Element, Event, Instant, Media, Par, Score, Seq, Set, Try,
+    gate
 } from "../lib/timing.js";
 import { dump } from "../lib/timing/util.js";
 import {
@@ -472,7 +473,7 @@ const Parse = {
         }
     },
 
-    "first": input => {
+    first: input => {
         const match = input.match(/^(?:\s+(\d+))?\s*$/);
         if (match) {
             const n = match[1] ? parseInt(match[1], 10) : 1;
@@ -485,6 +486,8 @@ const Parse = {
             }
         }
     },
+
+    gate: only(gate),
 };
 
 // Pick the right deserialization method for a serialized box (Item or Comment).

--- a/tests/manual/7guis/counter.html
+++ b/tests/manual/7guis/counter.html
@@ -8,7 +8,7 @@
 
 import { Tape } from "../../../lib/tape.js";
 import { Deck } from "../../../lib/deck.js";
-import { Effect, Event, Instant, Score, Seq } from "../../../lib/timing.js";
+import { Effect, Event, Instant, Score, Seq, gate } from "../../../lib/timing.js";
 
 const tape = Tape();
 const deck = Deck({ tape });
@@ -17,11 +17,8 @@ const input = document.querySelector("input");
 const button = document.querySelector("button");
 
 score.add(Seq(
-    Seq(
-        Event(button, "click"),
-        Instant(([_, x]) => x).var("count")
-    ).label("count"),
-    Instant((x = 0) => x + 1),
+    gate(Event(button, "click"), Instant((x = 0) => x + 1)),
+    // FIXME 1U0C Set with no duration should just set a value
     Effect(v => { input.value = v; return v; })
 ).repeat());
 

--- a/tests/timing.html
+++ b/tests/timing.html
@@ -7,9 +7,12 @@
         <script type="module">
 
 import { test } from "./test.js";
-import { html } from "../lib/util.js";
+import { html, K } from "../lib/util.js";
+import { Deck } from "../lib/deck.js";
+import { Tape } from "../lib/tape.js";
 import {
-    Await, Delay, Effect, Element, Event, Instant, Media, Par, Score, Seq, Set, Try
+    Await, Delay, Effect, Element, Event, Instant, Media, Par, Score, Seq, Set, Try,
+    gate
 } from "../lib/timing.js";
 
 test("Exports", t => {
@@ -26,6 +29,16 @@ test("Exports", t => {
     t.equal(Seq().show(), "Seq/0", "Seq");
     t.equal(Set(p, "textContent").show(), "Set<textContent>", "Set");
     t.equal(Try(Instant(() => { throw "!!!"; }), Instant(() => "ko")).show(), "Try", "Try");
+});
+
+test("gate(x, y)", t => {
+    const tape = Tape();
+    const instance = tape.instantiate(Seq(
+        Instant(K("ok")),
+        gate(Effect(() => { console.warn("ko"); }), Instant(x => x + "!"))
+    ), 17);
+    t.warns(() => { Deck({ tape }).now = 18; }, "has effect when running");
+    t.equal(instance.value, "ok!", "value matches");
 });
 
         </script>


### PR DESCRIPTION
Convenience element to ignore the input of the first item (e.g. an event). Comes with a patcher box and improvement to the counter example.