### PR TITLE
1O04 Shift cord origin

### DIFF
--- a/patcher/index.html
+++ b/patcher/index.html
@@ -46,7 +46,10 @@
                         </symbol>
                     </defs>
                     <rect width="100%" height="100%" fill="url(#grid)" class="grid"/>
+
                     <g class="items"></g>
+                    <g class="targets"></g>
+
                 </svg>
             </div>
 

--- a/patcher/item-box.js
+++ b/patcher/item-box.js
@@ -20,8 +20,10 @@ export const ItemBox = assign(properties => create(properties).call(ItemBox), Bo
             height: this.height - 2 * Port.height
         }, this.input);
         element.appendChild(this.foreignObject);
+        this.targets = svg("g");
         for (const port of this.ports()) {
             element.appendChild(port.element);
+            this.targets.appendChild(port.target);
         }
         return element;
     },
@@ -59,6 +61,7 @@ export const ItemBox = assign(properties => create(properties).call(ItemBox), Bo
     },
 
     selected() {
+        bringElementFrontward(this.targets);
         for (const port of this.ports()) {
             for (const cord of port.cords.values()) {
                 bringElementFrontward(cord.element);
@@ -77,6 +80,7 @@ export const ItemBox = assign(properties => create(properties).call(ItemBox), Bo
     // Move all cords from the ports when moving the box.
     updatePosition() {
         Box.updatePosition.call(this);
+        this.targets.setAttribute("transform", this.element.getAttribute("transform"));
         for (const port of this.ports()) {
             port.updateCords();
         }

--- a/patcher/patcher.js
+++ b/patcher/patcher.js
@@ -57,6 +57,7 @@ const LockedCommands = new Set(["d", " ", "Escape"]);
 const Patcher = assign(canvas => create({ canvas }).call(Patcher), {
     init() {
         this.itemsGroup = this.canvas.querySelector(".items");
+        this.targetsGroup = this.canvas.querySelector(".targets");
         this.elements = new Map();
         this.elements.set(this.canvas, this);
         this.dragEventListener = DragEventListener(this.elements);
@@ -197,6 +198,9 @@ const Patcher = assign(canvas => create({ canvas }).call(Patcher), {
 
     boxWasAdded(box, interactive) {
         this.itemsGroup.appendChild(box.element);
+        if (box.targets) {
+            this.targetsGroup.appendChild(box.targets);
+        }
         this.observeElementInBox(box.input, box);
         if (interactive) {
             this.select(box);

--- a/patcher/port.js
+++ b/patcher/port.js
@@ -13,18 +13,19 @@ export const Port = assign(properties => create(properties).call(Port), {
     init() {
         this.patcher = this.box.patcher;
         this.rect = svg("rect", { width: this.width, height: this.height, x: this.x, y: this.y });
+        this.element = svg("g", { class: "port" }, this.rect);
         this.target = svg("circle", {
             class: "target", cx: this.x + this.width / 2, cy: this.y + this.height / 2, r: this.r
         });
-        this.element = svg("g", { class: "port" }, this.rect, this.target);
-        this.target.addEventListener("pointerdown", this.patcher.dragEventListener);
         this.patcher.elements.set(this.target, this);
+        this.target.addEventListener("pointerdown", this.patcher.dragEventListener);
         this.cords = new Map();
     },
 
     // Remove all cords from/to this port when deleting it.
     remove() {
         this.target.removeEventListener("pointerdown", this.patcher.dragEventListener);
+        this.target.remove();
         for (const cord of this.cords.values()) {
             cord.remove();
         }
@@ -79,8 +80,8 @@ export const Port = assign(properties => create(properties).call(Port), {
     // whether the target is valid or invalid.
     set isTargetForCord([possible, target]) {
         const isTarget = !!target;
-        this.element.classList.toggle("potential-target", isTarget && possible);
-        this.element.classList.toggle("invalid-target", isTarget && !possible);
+        this.target.classList.toggle("potential-target", isTarget && possible);
+        this.target.classList.toggle("invalid-target", isTarget && !possible);
     },
 
     // Enable or disable the port.
@@ -90,6 +91,7 @@ export const Port = assign(properties => create(properties).call(Port), {
 
     set enabled(value) {
         this.element.classList.toggle("disabled", !value);
+        this.target.classList.toggle("disabled", !value);
         if (!value) {
             for (const cord of this.cords.values()) {
                 cord.remove();

--- a/patcher/style.css
+++ b/patcher/style.css
@@ -109,19 +109,19 @@ g.box g.port rect {
     fill: #102040;
 }
 
-g.port circle {
+g.targets circle {
     fill: transparent;
 }
 
-g.port.potential-target circle {
+g.targets circle.potential-target {
     fill: rgba(64, 255, 64, 0.25);
 }
 
-g.port.invalid-target circle {
+g.targets circle.invalid-target {
     fill: rgba(255, 64, 64, 0.25);
 }
 
-g.port.disabled {
+g.port.disabled, g.targets circle.disabled {
     display: none;
 }
 


### PR DESCRIPTION
Actually keep the origin, but move targets to a separate layer above the items so that they are easier to pick. This adds a bit of bookkeeping, e.g. when selecting, moving and removing.