### PR TITLE
1V04 Iterator helpers

### DIFF
--- a/lib/show.js
+++ b/lib/show.js
@@ -1,4 +1,4 @@
-import { isEmpty, typeOf } from "./util.js";
+import { isEmpty, mapit, typeOf } from "./util.js";
 
 const quoted = {
     "\n": "n",
@@ -24,17 +24,17 @@ export function show(x, shown) {
 
     const helpers = {
         array: (xs, shown) => showOnce(xs, shown, () => `[${xs.map(x => show(x, shown)).join(", ")}]`),
-        map: (m, shown) => showOnce(m, shown, () => `Map {${isEmpty(m) ? "" : ` ${[...m.entries()].map(
-                kv => kv.map(x => show(x, shown)).join(" => ")
-            ).join(", ")} `}}`),
+        map: (m, shown) => showOnce(m, shown, () => `Map {${isEmpty(m) ? "" : ` ${
+            mapit(m.entries(), kv => kv.map(x => show(x, shown)).join(" => ")).join(", ")
+        } `}}`),
         object: (h, shown) => h.toString === Object.prototype.toString ?
             showOnce(h, shown, () => `{${isEmpty(h) ? "" : ` ${Object.entries(h).map(
                 ([k, v]) => [k, show(v, shown)].join(": ")
             ).join(", ")} `}}`) : h.toString(),
         "object/function": f => show(Object.getPrototypeOf(f)),
-        set: (s, shown) => showOnce(s, shown, () => `Set {${isEmpty(s) ? "" : ` ${[...s.values()].map(
-                v => show(v, shown)
-            ).join(", ")} `}}`),
+        set: (s, shown) => showOnce(s, shown, () => `Set {${isEmpty(s) ? "" : ` ${
+            mapit(s.values(), v => show(v, shown)).join(", ")
+        } `}}`),
         string: s => `"${s.replace(/["\\\n\t]/g, c => `\\${quoted[c]}`)}"`
     };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -194,10 +194,7 @@ export const isObject = x => typeof x === "object" && x !== null;
 export const K = x => y => x;
 
 // Map over and collect the values produced by an iterator.
-export const mapit = (it, f, that) => foldit(it, (xs, x) => {
-    xs.push(f.call(that, x));
-    return xs;
-}, [], that);
+export const mapit = (it, f, that) => foldit(it, (xs, x) => (xs.push(f.call(that, x)), xs), [], that);
 
 // See floored division in
 // https://en.wikipedia.org/wiki/Modulo_operation#Variants_of_the_definition.

--- a/lib/util.js
+++ b/lib/util.js
@@ -128,8 +128,24 @@ export function get(map, key, f) {
     return map.get(key);
 }
 
+// Filter the values produced by an iterator.
+export const filterit = (it, p, that) => foldit(it, (xs, x) => {
+    if (p.call(that, x)) {
+        xs.push(x);
+    }
+    return xs;
+}, [], that);
+
 // Reverse the first two arguments of f (and discard any other).
 export const flip = f => (x, y) => f(y, x);
+
+// Fold over all the values produced by an iterator.
+export function foldit(it, f, z, that) {
+    for (const x of it) {
+        z = f.call(that, z, x);
+    }
+    return z;
+}
 
 // Fold using the first x as the initial accumulator value.
 export function fold1(xs, f, that) {
@@ -176,6 +192,12 @@ export const isObject = x => typeof x === "object" && x !== null;
 
 // Constant combinator.
 export const K = x => y => x;
+
+// Map over and collect the values produced by an iterator.
+export const mapit = (it, f, that) => foldit(it, (xs, x) => {
+    xs.push(f.call(that, x));
+    return xs;
+}, [], that);
 
 // See floored division in
 // https://en.wikipedia.org/wiki/Modulo_operation#Variants_of_the_definition.
@@ -276,6 +298,13 @@ export function removeChildren(node) {
         child = sibling;
     }
     return node;
+}
+
+// Iterate through an array in reverse.
+export function* reverse(xs) {
+    for (let i = xs.length - 1; i >= 0; --i) {
+        yield(xs[i]);
+    }
 }
 
 // Wrap a function that throws in a try/catch and just ignore errors.

--- a/tests/util.html
+++ b/tests/util.html
@@ -9,10 +9,11 @@
 import { test } from "./test.js";
 import {
     add, addBy, assign, assoc, clamp, clockTime, create, cycle, escapeMarkup,
-    extend, flip, fold1, get, html, I, imagePromise, isAsync, isEmpty,
-    isIterable, isNumber, isObject, K, mod, nop, normalizeWhitespace, parseTime,
-    partition, push, range, remove, removeChildren, safe, shuffle, sign, single,
-    snd, timecount, timeout, todo, typeOf
+    extend, filterit, flip, foldit, fold1, get, html, I, imagePromise, isAsync,
+    isEmpty, isIterable, isNumber, isObject, K, mapit, mod, nop,
+    normalizeWhitespace, parseTime, partition, push, range, remove,
+    removeChildren, reverse, safe, shuffle, sign, single, snd, timecount,
+    timeout, todo, typeOf
 } from "../lib/util.js";
 
 test("add(collection, item/key, value?)", t => {
@@ -134,6 +135,14 @@ test("extend(object, ...properties)", t => {
     t.equal(Bar.x, "z", "x");
 });
 
+test("filterit(xs, p, this?)", t => {
+    t.equal(filterit(range(1, 10), x => x % 2 === 0), [2, 4, 6, 8, 10], "filter/collect iterator values");
+    t.equal(filterit(new Set().values(), x => x % 2 === 0), [], "empty set");
+    t.equal(filterit(new Set(["foo", "bar", "baz"]).values(), function(x) {
+        return this[x] % 2 === 0;
+    }, { foo: 1, bar: 2, baz: 3 }), ["bar"], "this");
+});
+
 test("flip(f)", t => {
     const sub = (x, y) => x - y;
     const bus = flip(sub);
@@ -142,6 +151,14 @@ test("flip(f)", t => {
     const xyz = (x, y, z) => x + y + z;
     const yx = flip(xyz);
     t.equal(yx(1, 2), NaN, "Flip discards any extra argument");
+});
+
+test("foldit(xs, f, z, this?)", t => {
+    t.equal(foldit(range(1, 10), (z, x) => z + x, 0), 55, "fold over an iterator");
+    t.equal(foldit(new Set().values(), (z, x) => z + x, 0), 0, "empty set");
+    t.equal(foldit(new Set(["foo", "bar", "baz"]).values(), function(z, x) {
+        return z + this[x];
+    }, 0, { foo: 1, bar: 2, baz: 3 }), 6, "this");
 });
 
 test("fold1(xs, f, this?)", t => {
@@ -250,6 +267,14 @@ test("isObject(x)", t => {
 test("K(x)", t => {
     t.typeof(K, "function", "K returns a constant function");
     t.equal(K("foo")("bar"), "foo", "K x y = x");
+});
+
+test("mapit(xs, f, this?)", t => {
+    t.equal(mapit(range(1, 7), x => x ** 2), [1, 4, 9, 16, 25, 36, 49], "map/collect iterator values");
+    t.equal(mapit(new Set().values(), x => x ** 2), [], "empty set");
+    t.equal(mapit(new Set(["foo", "bar", "baz"]).values(), function(x) {
+        return this[x] ** 2;
+    }, { foo: 1, bar: 2, baz: 3 }), [1, 4, 9], "this");
 });
 
 test("mod(x, m)", t => {
@@ -361,6 +386,11 @@ test("removeChildren(node)", t => {
     t.equal(removeChildren(p).textContent, "", "Remove text content");
     const div = html("div", html("p", "Some text"), html("p", "Some more text"));
     t.equal(removeChildren(div).innerHTML, "", "Removed all children");
+});
+
+test("reverse(xs)", t => {
+    t.equal([...reverse([])], [], "empty array");
+    t.equal([...reverse([1, 2, 3])], [3, 2, 1], "non-empty array");
 });
 
 test("safe(f)", t => {


### PR DESCRIPTION
`foldit()`, `filterit()` and `mapit()` fold over and collect the values of an iterator. `reverse()` iterates through an array in reverse, starting from the end.