### PR TITLE
1V01 Event issue trying to distinguish drag from tap

### DIFF
--- a/lib/deck.js
+++ b/lib/deck.js
@@ -175,13 +175,14 @@ export const Deck = assign(properties => create(properties).call(Deck), {
     // occurred in the targets maps that have the event name as key, pass the
     // event value to the instance.
     handleEvent(event) {
-        const targets = this.eventTargets.get(event.currentTarget);
+        const target = event.currentTarget;
+        const targets = this.eventTargets.get(target);
         const instances = targets[event.type];
         delete targets[event.type];
-        if (targets.size === 0) {
-            this.eventTargets.delete(event.currentTarget);
+        if (Object.keys(targets).length === 0) {
+            this.eventTargets.delete(target);
         }
-        event.target.removeEventListener(event.type, this);
+        target.removeEventListener(event.type, this);
         const t = this.instantAtTime(performance.now());
         for (const instance of instances) {
             if (t >= instance.begin) {

--- a/lib/deck.js
+++ b/lib/deck.js
@@ -177,7 +177,10 @@ export const Deck = assign(properties => create(properties).call(Deck), {
     handleEvent(event) {
         const targets = this.eventTargets.get(event.currentTarget);
         const instances = targets[event.type];
-        this.eventTargets.delete(event.target);
+        delete targets[event.type];
+        if (targets.size === 0) {
+            this.eventTargets.delete(event.currentTarget);
+        }
         event.target.removeEventListener(event.type, this);
         const t = this.instantAtTime(performance.now());
         for (const instance of instances) {

--- a/tests/timing/event.html
+++ b/tests/timing/event.html
@@ -109,6 +109,16 @@ test("Event(target, type).dur(d); event occurs late", async t => {
     t.equal(dump(event), "* Event-0 [17, 40[ (timeout)", "dump matches");
 });
 
+test("target v. currentTarget", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const event = tape.instantiate(Event(window, "synth"), 17);
+    deck.now = 31;
+    document.body.dispatchEvent(new window.CustomEvent("synth", { bubbles: true }));
+    deck.now = 32;
+    t.match(dump(event), /^\* Event-0 \[17, 31\[ <[^>]+>$/, "dump matches");
+});
+
 test("Cancel", t => {
     const tape = Tape();
     const deck = Deck({ tape });

--- a/tests/timing/event.html
+++ b/tests/timing/event.html
@@ -10,7 +10,7 @@ import { test } from "../test.js";
 import { K, timeout } from "../../lib/util.js";
 import { Tape } from "../../lib/tape.js";
 import { Deck } from "../../lib/deck.js";
-import { Delay, Event, Instant, Par, Seq } from "../../lib/timing.js";
+import { Delay, Event, first, Instant, Par, Seq } from "../../lib/timing.js";
 import { dump } from "../../lib/timing/util.js";
 
 test("Tag", t => { t.equal(Event.tag, "Event", "Event"); });
@@ -140,6 +140,16 @@ test("Cancel with repeat", t => {
     deck.now = 47;
     window.dispatchEvent(new window.Event("synth"));
     t.match(dump(par, true), /^\* Par-0 \[17, 40\[ <>\n  \* Seq\/repeat-1 \[17, 40\[ \(cancelled\)\n    \* Event-2 \[17, 27\[ <[^>]+>\n    \* Event-4 \[27, 37\[ <[^>]+>\n    \* Event-5 \[37, 40\[ \(cancelled\)\n  \* Delay-3 \[17, 40\[ <undefined> {o0@40}$/, "dump matches");
+});
+
+test("Cancel with multiple event types for the same target", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const instance = tape.instantiate(first(Event(window, "A"), Event(window, "B")), 17);
+    deck.now = 27;
+    window.dispatchEvent(new window.Event("A"));
+    deck.now = 28;
+    t.match(dump(instance), /^\* Par-0 \[17, 27\[ <[^>]+>\n  \* Event-1 \[17, 27\[ <[^>]+>\n  \* Event-2 \[17, 27\[ \(cancelled\)$/, "dump matches");
 });
 
 test("Prune", t => {


### PR DESCRIPTION
When listening to two events from the same target, handling one event would remove listeners for all events of that target, so cancellation later would fail.