### PR TITLE
1W07 Customize event handler

### DIFF
--- a/lib/timing/event.js
+++ b/lib/timing/event.js
@@ -1,4 +1,5 @@
 import { assign, extend, K } from "../util.js";
+import { Tape } from "../tape.js";
 import {
     cancelled, dur, ended, failed, hasModifier, label, min,
     FailureError, TimeoutError
@@ -77,30 +78,41 @@ export const Event = assign((target, event, child) => extend(Event, { target, ev
         }
     },
 
+    // When the event occurs and there is a child item, instantiate it in a
+    // separate tape with zero duration, and run the occurrences from that tape
+    // immediately. If no occurrences were created, then proceed to end with
+    // the event that occurred.
+    eventDidOccur(instance, event, t) {
+        let handled = false;
+        if (this.child) {
+            const tape = Tape();
+            tape.instantiate(this.child, t, 0, {
+                // Create a foster parent that feeds the event as the input
+                // value for its child and ends with a possibly altered event
+                // value.
+                item: {
+                    inputForChildInstance: K(event),
+                    childInstanceDidEnd: childInstance => {
+                        this.handledEvent(instance, childInstance.value, t);
+                    }
+                }
+            });
+            const interval = { from: t, to: Infinity };
+            for (const occurrence of tape.occurrencesInInterval(interval)) {
+                console.assert(occurrence.t === t);
+                occurrence.forward(occurrence.t, interval);
+                handled = true;
+            }
+        }
+        if (!handled) {
+            return this.handledEvent(instance, event, t);
+        }
+    },
+
     // The event has occurred for an instance at time t. It ends now with the
     // event as value, unless it has a duration, in which case it holds to that
     // value (unless the event occurs too late, but the instance already
     // failed).
-    eventDidOccur(instance, event, t) {
-        if (this.child) {
-            const childInstance = this.child.instantiate({ tape: instance.tape }, t, 0);
-            if (childInstance) {
-                childInstance.item = this.child;
-                childInstance.parent = {
-                    item: {
-                        inputForChildInstance: K(event),
-                        childInstanceDidEnd: childInstance => {
-                            this.handledEvent(instance, childInstance.value, t);
-                        }
-                    }
-                };
-                childInstance.forward(t);
-                return;
-            }
-        }
-        return this.handledEvent(instance, event, t);
-    },
-
     handledEvent(instance, event, t) {
         if (hasModifier(this, "dur")) {
             // Store the event value until the instance ends.

--- a/lib/timing/event.js
+++ b/lib/timing/event.js
@@ -1,4 +1,4 @@
-import { assign, extend } from "../util.js";
+import { assign, extend, K } from "../util.js";
 import {
     cancelled, dur, ended, failed, hasModifier, label, min,
     FailureError, TimeoutError
@@ -6,8 +6,17 @@ import {
 
 // Event ends when the first occurrence of an event occurs with the event
 // object as its value. This relies on the deck’s event handler.
-export const Event = assign((target, event) => extend(Event, { target, event }), {
+export const Event = assign((target, event, child) => extend(Event, { target, event, child }), {
     tag: "Event",
+
+    init() {
+        if (this.child) {
+            if (Object.hasOwn(this.child, "parent")) {
+                throw window.Error("Cannot share item between containers");
+            }
+            this.child.parent = this;
+        }
+    },
 
     show() {
         return `${this.tag}<${this.target}, ${this.event}>`;
@@ -73,6 +82,26 @@ export const Event = assign((target, event) => extend(Event, { target, event }),
     // value (unless the event occurs too late, but the instance already
     // failed).
     eventDidOccur(instance, event, t) {
+        if (this.child) {
+            const childInstance = this.child.instantiate({ tape: instance.tape }, t, 0);
+            if (childInstance) {
+                childInstance.item = this.child;
+                childInstance.parent = {
+                    item: {
+                        inputForChildInstance: K(event),
+                        childInstanceDidEnd: childInstance => {
+                            this.handledEvent(instance, childInstance.value, t);
+                        }
+                    }
+                };
+                childInstance.forward(t);
+                return;
+            }
+        }
+        return this.handledEvent(instance, event, t);
+    },
+
+    handledEvent(instance, event, t) {
         if (hasModifier(this, "dur")) {
             // Store the event value until the instance ends.
             instance.delayedEvent = event;

--- a/patcher/patch.js
+++ b/patcher/patch.js
@@ -200,7 +200,7 @@ export const Patch = Object.assign(properties => create(properties).call(Patch),
     inletAcceptsConnection(inlet, outlet) {
         return this.boxes.get(inlet.box).acceptFrom?.(
             this.boxes.get(outlet.box),
-            outlet.box.inlets.indexOf(inlet),
+            inlet.box.inlets.indexOf(inlet),
             outlet.box.outlets.indexOf(outlet)
         );
     }
@@ -336,10 +336,13 @@ const Parse = {
             const event = match[1];
             return {
                 label: `Event ${event}`,
-                inlets: 1,
+                inlets: 2,
                 isEvent: true,
-                acceptFrom: box => box.isElement || box.isWindow,
-                create: ([target]) => Event(target.element, event)
+                acceptFrom: (box, i) => {
+                    return (i === 0 && (box.isElement || box.isWindow)) ||
+                        (i === 1 && !(box.isElement || box.isWindow));
+                },
+                create: ([target, child]) => Event(target.element, event, child)
             };
         }
     },

--- a/tests/manual/drag.html
+++ b/tests/manual/drag.html
@@ -42,7 +42,7 @@ const drag = ([event, [x0, y0]]) => {
 };
 
 score.add(Repeat(Seq(
-    Event(box, "pointerdown"),
+    Event(box, "pointerdown", Effect(event => (event.preventDefault(), event))),
     first(
 
         // Tap

--- a/tests/timing/event.html
+++ b/tests/timing/event.html
@@ -194,6 +194,48 @@ test("Concurrent listeners", t => {
     t.equal(instance.value, ["ok", "ok too"], "Both listeners got the notification");
 });
 
+test("Event child", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const instance = tape.instantiate(Event(window, "synth", Instant(K("ok"))), 17);
+    deck.now = 31;
+    window.dispatchEvent(new window.Event("synth"));
+    deck.now = 32;
+    t.equal(dump(instance), "* Event-0 [17, 31[ <ok>", "dump matches");
+});
+
+test("Event child (end instantly)", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const instance = tape.instantiate(Event(window, "synth", Seq(Instant(K("ko")), Instant(K("ok")))), 17);
+    deck.now = 31;
+    window.dispatchEvent(new window.Event("synth"));
+    deck.now = 32;
+    t.equal(dump(instance), "* Event-0 [17, 31[ <ok>", "dump matches");
+});
+
+test("Event child (does not end instantly)", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const instance = tape.instantiate(Event(window, "synth", Delay(23)), 17);
+    deck.now = 31;
+    window.dispatchEvent(new window.Event("synth"));
+    deck.now = 32;
+    t.match(dump(instance), /^\* Event-0 \[17, 31\[ <[^>]+>$/, "dump matches");
+});
+
+test("Event child (does not end instantly; cut off)", t => {
+    const tape = Tape();
+    const deck = Deck({ tape });
+    const instance = tape.instantiate(Event(window, "synth", Seq(
+        Instant(K("ok")), Delay(23), Instant(K("ko")
+    ))), 17);
+    deck.now = 31;
+    window.dispatchEvent(new window.Event("synth"));
+    deck.now = 32;
+    t.equal(dump(instance), "* Event-0 [17, 31[ <ok>", "dump matches");
+});
+
         </script>
     </head>
     <body>


### PR DESCRIPTION
Event has an optional child that gets instantiated in a zero-duration interval and a separate tape which is run immediately. This allows e.g. preventing the event (see the Drag example) and is similar to what will happen with the ramp. The patcher adds an extra inlet to Event as well.