### PR TITLE
1X01 Unparent

### DIFF
--- a/lib/timing/event.js
+++ b/lib/timing/event.js
@@ -1,7 +1,7 @@
 import { assign, extend, K } from "../util.js";
 import { Tape } from "../tape.js";
 import {
-    cancelled, dur, ended, failed, hasModifier, initSingleChild, label, min,
+    cancelled, dur, ended, failed, hasModifier, label, min,
     FailureError, TimeoutError
 } from "./util.js";
 
@@ -9,7 +9,6 @@ import {
 // object as its value. This relies on the deck’s event handler.
 export const Event = assign((target, event, child) => extend(Event, { target, event, child }), {
     tag: "Event",
-    init: initSingleChild,
 
     show() {
         return `${this.tag}<${this.target}, ${this.event}>`;

--- a/lib/timing/par.js
+++ b/lib/timing/par.js
@@ -150,6 +150,7 @@ export const Par = assign((...children) => create().call(Par, { children }), {
     childInstanceDidEnd(childInstance) {
         const end = endOf(childInstance);
         const instance = childInstance.parent;
+        delete childInstance.input;
         console.assert(instance.item === this);
         if (!instance.finished) {
             // The instance has already finished (this is a lingering effect).
@@ -168,6 +169,7 @@ export const Par = assign((...children) => create().call(Par, { children }), {
                 for (const child of instance.children) {
                     if (child !== childInstance && !Object.hasOwn(child, "value")) {
                         child.item.cancelInstance(child, end);
+                        delete child.input;
                     }
                 }
                 delete instance.finished;
@@ -340,9 +342,7 @@ export const ParMap = {
     // child instances may be reordered, each instance records its input value.
     inputForChildInstance(childInstance) {
         console.assert(Object.hasOwn(childInstance, "input"));
-        const input = childInstance.input;
-        delete childInstance.input;
-        return input;
+        return childInstance.input;
     },
 };
 

--- a/lib/timing/par.js
+++ b/lib/timing/par.js
@@ -1,6 +1,6 @@
 import { assign, create, extend, fold1, isNumber, partition, push, remove, single } from "../util.js";
 import {
-    dur, cancelled, ended, endOf, failed, forward, hasModifier, init, label, max, min, show, take, pruned,
+    dur, cancelled, ended, endOf, failed, forward, hasModifier, label, max, min, show, take, pruned,
     CancelError, InputError, FailureError
 } from "./util.js";
 
@@ -16,7 +16,6 @@ export const Par = assign((...children) => create().call(Par, { children }), {
     label,
     take,
     dur,
-    init,
 
     // The duration of a par is the duration of the child that finishes last.
     // A par with no children has zero duration.
@@ -137,7 +136,10 @@ export const Par = assign((...children) => create().call(Par, { children }), {
     // Every child has the same input as the par itself, that is, the input
     // of the parent of the par.
     inputForChildInstance(childInstance) {
-        return this.parent?.inputForChildInstance(childInstance.parent);
+        const instance = childInstance.parent;
+        console.assert(instance.item === this);
+        const parentInstance = instance.parent;
+        return parentInstance?.item.inputForChildInstance(instance);
     },
 
     // When enough children have finished, then the par itself finishes with
@@ -250,7 +252,6 @@ export const Par = assign((...children) => create().call(Par, { children }), {
 // element).
 export const first = assign((...children) => create().call(first, { children }), Par, {
     init() {
-        Par.init.call(this);
         this.take(1);
     },
 

--- a/lib/timing/ramp.js
+++ b/lib/timing/ramp.js
@@ -1,6 +1,6 @@
 import { Tape } from "../tape.js";
 import { assign, create, extend, I, nop } from "../util.js";
-import { cancelled, dur, initSingleChild, label, pruned } from "./util.js";
+import { cancelled, dur, label, pruned } from "./util.js";
 
 // Ramp goes from 0 to 1 over a duration, then back to zero instantly at the
 // end. Its child gets called every time an update occurs within that duration
@@ -8,8 +8,6 @@ import { cancelled, dur, initSingleChild, label, pruned } from "./util.js";
 export const Ramp = assign(child => create().call(Ramp, { child }), {
     tag: "Ramp",
     dur,
-
-    init: initSingleChild,
 
     show() {
         return `${this.tag}`;

--- a/lib/timing/repeat.js
+++ b/lib/timing/repeat.js
@@ -1,7 +1,7 @@
 import { assign, extend, I, nop } from "../util.js";
 import { first } from "./par.js";
 import {
-    dur, ended, endOf, failed, hasModifier, init, label, min, show, take,
+    dur, ended, endOf, failed, hasModifier, label, min, show, take,
     CancelError, FailureError
 } from "./util.js";
 
@@ -14,7 +14,6 @@ export const Repeat = assign(child => extend(Repeat, { child }), {
     tag: "Repeat",
     show,
     label,
-    init,
     take,
     dur,
 

--- a/lib/timing/score.js
+++ b/lib/timing/score.js
@@ -30,7 +30,6 @@ export const Score = Object.assign(properties => create(properties).call(Score),
     add(item, at) {
         console.assert(!Object.hasOwn(item, parent));
         this.children.push(item);
-        item.parent = this;
         this.instance.children.push(this.tape.instantiate(
             item, at ?? this.tape.deck?.now ?? 0, this.instance.end - this.instance.begin, this.instance
         ));

--- a/lib/timing/seq.js
+++ b/lib/timing/seq.js
@@ -1,7 +1,7 @@
 import { assign, create, extend, isNumber, push } from "../util.js";
 import { Instant } from "./instant.js";
 import {
-    dur, ended, endOf, failed, forward, hasModifier, init, label, min, pruned, show, take,
+    dur, ended, endOf, failed, forward, hasModifier, label, min, pruned, show, take,
     CancelError, FailureError, InputError
 } from "./util.js";
 
@@ -13,7 +13,6 @@ export const Seq = assign((...children) => create().call(Seq, { children }), {
     tag: "Seq",
     show,
     label,
-    init,
     take,
     dur,
 
@@ -294,7 +293,6 @@ const Map = {
     tag: "Seq/map",
     show,
     label,
-    init,
     take,
     dur,
 

--- a/lib/timing/try.js
+++ b/lib/timing/try.js
@@ -1,11 +1,10 @@
 import { assign, create, isNumber, nop } from "../util.js";
-import { ended, endOf, failed, init, label, CancelError, FailureError } from "./util.js";
+import { ended, endOf, failed, label, CancelError, FailureError } from "./util.js";
 
 // Try wraps a child with an error child that gets instantiated with the error
 // if the child fails, similar to a try/catch block.
 export const Try = assign((child, _catch) => create().call(Try, { child, catch: _catch }), {
     tag: "Try",
-    init,
 
     // Don’t show child count since it is always 2.
     show() {
@@ -13,11 +12,6 @@ export const Try = assign((child, _catch) => create().call(Try, { child, catch: 
     },
 
     label,
-
-    // Used by init()
-    get children() {
-        return [this.child, this.catch];
-    },
 
     // Fallible when both children are fallible (since a child failure can be
     // caught).

--- a/lib/timing/util.js
+++ b/lib/timing/util.js
@@ -93,27 +93,6 @@ export const min = (x, y) => isNumber(y) ? Math.min(x, y) : x;
 // is considered higher than any definite number (for unresolved durations).
 export const max = (x, y) => isNumber(y) ? Math.max(x, y) : x === Infinity ? x : y;
 
-// Generic init function for containers, setting themselves as parent of their
-// children.
-export function init() {
-    for (const child of this.children ?? [this.child]) {
-        if (Object.hasOwn(child, "parent")) {
-            throw window.Error("Cannot share item between containers");
-        }
-        child.parent = this;
-    }
-}
-
-// Same but when there is only one, optional child.
-export function initSingleChild() {
-    if (this.child) {
-        if (Object.hasOwn(this.child, "parent")) {
-            throw window.Error("Cannot share item between containers");
-        }
-        this.child.parent = this;
-    }
-}
-
 // Get the input parameters for a function; first, the input from the parent,
 // then looking for every additional var. Throw if a var reference has no value.
 export function inputParameters(instance, t) {

--- a/tests/timing/par.html
+++ b/tests/timing/par.html
@@ -30,8 +30,6 @@ test("Par(xs)", t => {
     const par = Par(delay, instant);
     t.equal(par.show(), "Par/2", "show");
     t.equal(par.children, [delay, instant], "children");
-    t.equal(delay.parent, par, "parent (first child)");
-    t.equal(instant.parent, par, "parent (second child)");
     t.equal(par.duration, 17, "duration");
     t.equal(!par.fallible, true, "not fallible");
     t.equal(par.hasEffect, false, "no effect when children have no effect");

--- a/tests/timing/repeat.html
+++ b/tests/timing/repeat.html
@@ -141,9 +141,9 @@ test("Repeat(Par), instantiation", t => {
   * Par-1 [17, 40[ <A,>
     * Instant-2 @17 <A>
     * Delay-3 [17, 40[ <undefined>
-  * Par-4 [40, 63[ <A,>
+  * Par-4 [40, 63[ <A,A,>
     * Instant-5 @40 <A>
-    * Delay-6 [40, 63[ <undefined>
+    * Delay-6 [40, 63[ <A,>
   * Par-7 [63, 86[
     * Instant-8 @63 <A>
     * Delay-9 [63, 86[`, "dump matches");
@@ -160,16 +160,16 @@ test("Repeat(Par(xs)).take(n)", t => {
     const par = tape.instantiate(Repeat(Par(Delay(23), Delay(19))).take(3), 17);
     Deck({ tape }).now = 87;
     t.equal(dump(par),
-`* Repeat-0 [17, 86[ <,>
+`* Repeat-0 [17, 86[ <,,,,,,,>
   * Par-1 [17, 40[ <,>
     * Delay-2 [17, 40[ <undefined>
     * Delay-3 [17, 36[ <undefined>
-  * Par-4 [40, 63[ <,>
-    * Delay-5 [40, 63[ <undefined>
-    * Delay-6 [40, 59[ <undefined>
-  * Par-7 [63, 86[ <,>
-    * Delay-8 [63, 86[ <undefined>
-    * Delay-9 [63, 82[ <undefined>`, "dump matches");
+  * Par-4 [40, 63[ <,,,>
+    * Delay-5 [40, 63[ <,>
+    * Delay-6 [40, 59[ <,>
+  * Par-7 [63, 86[ <,,,,,,,>
+    * Delay-8 [63, 86[ <,,,>
+    * Delay-9 [63, 82[ <,,,>`, "dump matches");
 });
 
 test("Repeat(Par(xs)).take(n); empty par", t => {

--- a/tests/timing/score.html
+++ b/tests/timing/score.html
@@ -38,8 +38,6 @@ test("Score.add(child), no deck", t => {
     t.equal(instant.show(), "Instant", "show added child");
     t.equal(score.show(), "Score/2", "show after add");
     t.equal(score.children, [delay, instant], "children after add");
-    t.equal(delay.parent, score, "parent (1)");
-    t.equal(instant.parent, score, "parent (2)");
     t.equal(dump(score.instance),
 `* Score-0 [0, ∞[
   * Delay-1 [0, 23[

--- a/tests/timing/seq-map-item.html
+++ b/tests/timing/seq-map-item.html
@@ -18,7 +18,6 @@ test("Seq.map(child)", t => {
     const map = Seq.map(child);
     t.equal(map.show(), "Seq/map", "show");
     t.equal(map.child, child, "child item");
-    t.equal(map.child.parent, map, "child item parent");
     t.undefined(map.duration, "unresolved duration");
     t.equal(map.take(0).duration, 0, "down to zero with take(0)");
     t.equal(!map.fallible, true, "not fallible");

--- a/tests/timing/seq.html
+++ b/tests/timing/seq.html
@@ -33,8 +33,6 @@ test("Seq(xs)", t => {
     const seq = Seq(delay, instant);
     t.equal(seq.show(), "Seq/2", "show");
     t.equal(seq.children, [delay, instant], "children");
-    t.equal(delay.parent, seq, "parent (1)");
-    t.equal(instant.parent, seq, "parent (2)");
     t.equal(seq.duration, 17, "duration");
     t.equal(!seq.fallible, true, "not fallible");
     t.equal(seq.hasEffect, false, "no effect when no children has effect");


### PR DESCRIPTION
Remove the reference from child back to parent, which was barely used (and actually caused some input issues with Par), and contradicts the DAG structure. A few tests are updated/corrected now that this has been removed.