### PR TITLE
1X06 Fast forward is brittle

### DIFF
--- a/lib/deck.js
+++ b/lib/deck.js
@@ -64,7 +64,7 @@ export const Deck = assign(properties => create(properties).call(Deck), {
         } else if (value !== this._speed) {
             if (this.request) {
                 this.intervals.push({
-                    from: this.lastUpdateTime,
+                    from: this.intervals.at(-1)?.to ?? this._now,
                     to: this.instantAtTime(performance.now())
                 });
             }

--- a/lib/gui/transport-bar.js
+++ b/lib/gui/transport-bar.js
@@ -59,7 +59,7 @@ export const TransportBar = Object.assign(score => create({ score }).call(Transp
     }
 });
 
-const Rates = [1, 1.5, 0.25, 0.5];
+const Rates = [1, 2, 4, 8, 0.25, 0.5];
 
 const Stop = ["stopped", deck => { deck.stop(); }];
 

--- a/tests/deck.html
+++ b/tests/deck.html
@@ -86,7 +86,10 @@ test("speed and updates: slowing down", async t => {
     const phi = performance.now();
     const target = deck.now + 53;
     deck.speed = 0.5;
-    await notifications(deck, "update", () => deck.now < target);
+    await notifications(deck, "update", interval => {
+        t.above(interval.to, interval.from);
+        return deck.now < target;
+    });
     t.atLeast(performance.now() - phi, 106, `moved slowly to ${deck.now} (${(performance.now() - phi) / 2})`);
 });
 


### PR DESCRIPTION
The additional interval added when changing speed had an incorrect lower bound, which led past occurrences to be evaluated again. The transport bar allows more speeds now that this is fixed; but further simplifications can be done as part of 1X09.