### PR TITLE
1X05 Cannot restart a score

### DIFF
--- a/lib/gui/transport-bar.js
+++ b/lib/gui/transport-bar.js
@@ -29,7 +29,7 @@ export const TransportBar = Object.assign(score => create({ score }).call(Transp
                 if (States[this.state][key]) {
                     const [state, effect] = States[this.state][key];
                     this.state = state;
-                    effect(deck);
+                    effect(deck, this.score);
                     this.update();
                 }
             });
@@ -83,6 +83,12 @@ const States = {
     },
 
     stopped: {
+        Play: ["playing", (deck, score) => {
+            score.reset();
+            deck.speed = 1;
+            deck.now = 0;
+            deck.start();
+        }],
     }
 }
 

--- a/lib/timing/score.js
+++ b/lib/timing/score.js
@@ -12,8 +12,20 @@ export const Score = Object.assign(properties => create(properties).call(Score),
     // Set up children and tape.
     init() {
         this.children = [];
+        this.begins = new Map();
         this.tape ??= Tape();
         this.instance = this.tape.instantiate(this, 0, Infinity);
+    },
+
+    // Clear the tape and instantiate all children again.
+    reset() {
+        this.tape.erase();
+        this.instance = this.tape.instantiate(this, 0, Infinity);
+        for (const child of this.children) {
+            this.instance.children.push(this.tape.instantiate(
+                child, this.begins.get(child), this.instance.end - this.instance.begin, this.instance
+            ));
+        }
     },
 
     // Instantiate the score to fill up the entire available duration.
@@ -30,8 +42,10 @@ export const Score = Object.assign(properties => create(properties).call(Score),
     add(item, at) {
         console.assert(!Object.hasOwn(item, parent));
         this.children.push(item);
+        const t = at ?? this.tape.deck?.now ?? 0;
+        this.begins.set(item, t);
         this.instance.children.push(this.tape.instantiate(
-            item, at ?? this.tape.deck?.now ?? 0, this.instance.end - this.instance.begin, this.instance
+            item, t, this.instance.end - this.instance.begin, this.instance
         ));
         return item;
     },


### PR DESCRIPTION
Reset the score by erasing all instances and recreating them. The transport bar can then start playback again after being stopped.