### PR TITLE
1Z01 assoco

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -86,6 +86,17 @@ export function assoc(xs, f = I) {
     return m;
 }
 
+// Create an object from a collection xs by applying a function f to every x.
+// f is expected to return a [key, value] pair to be added to the object.
+export function assoco(xs, f = I) {
+    const o = {};
+    for (let i = 0, n = xs.length; i < n; ++i) {
+        const [key, value] = f(xs[i], i);
+        o[key] = value;
+    }
+    return o;
+}
+
 // Clamp x between min and max.
 export const clamp = (x, min, max) => Math.min(Math.max(min, x), max);
 
@@ -376,11 +387,4 @@ export function zip(xs, ys) {
 }
 
 // Zip an array of keys with an array of values into an object.
-export function zipo(keys, vals) {
-    const o = {};
-    const n = Math.min(keys.length, vals.length);
-    for (let i = 0; i < n; ++i) {
-        o[keys[i]] = vals[i];
-    }
-    return o;
-}
+export const zipo = (keys, vals) => assoco(zip(keys, vals));

--- a/tests/util.html
+++ b/tests/util.html
@@ -8,10 +8,10 @@
 
 import { test } from "./test.js";
 import {
-    add, addBy, assign, assoc, clamp, clockTime, create, cycle, escapeMarkup,
-    extend, filterit, flip, foldit, fold1, get, html, I, imagePromise, isAsync,
-    isEmpty, isIterable, isNumber, isObject, K, mapit, mod, nop,
-    normalizeWhitespace, parseTime, partition, push, range, remove,
+    add, addBy, assign, assoc, assoco, clamp, clockTime, create, cycle,
+    escapeMarkup, extend, filterit, flip, foldit, fold1, get, html, I,
+    imagePromise, isAsync, isEmpty, isIterable, isNumber, isObject, K, mapit,
+    mod, nop, normalizeWhitespace, parseTime, partition, push, range, remove,
     removeChildren, reverse, safe, shuffle, sign, single, snd, timecount,
     timeout, todo, typeOf, zip, zipo
 } from "../lib/util.js";
@@ -58,7 +58,17 @@ test("assoc(xs, f?)", t => {
     map.set("one", 1);
     map.set("two", 2);
     map.set("three", 3);
-    t.equal(assoc(["one", "two", "three"], (x, i) => [x, i + 1]), map);
+    t.equal(assoc(["one", "two", "three"], (x, i) => [x, i + 1]), map, "f");
+});
+
+test("assoco(xs, f?)", t => {
+    t.empty(assoco([], nop), "empty list");
+
+    const simpleObject = { foo: 1, bar: 2 };
+    t.equal(assoco([["foo", 1], ["bar", 2]]), simpleObject, "I is the default for f");
+
+    const o = { one: 1, two: 2, three: 3 };
+    t.equal(assoco(["one", "two", "three"], (x, i) => [x, i + 1]), o, "f");
 });
 
 test("clamp(x, min, max)", t => {


### PR DESCRIPTION
Same as assoc but for objects instead of Map; this allows writing zipo as the composition of zip and assoco.