### PR TITLE
2101 Threads dequeued in wrong order

### DIFF
--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -20,7 +20,6 @@ const proto = {
         console.assert(this.futureQueue[0].t >= from);
         while (this.futureQueue.length > 0 && this.futureQueue[0].t < to) {
             const thread = this.futureQueue.remove();
-            this.lastUpdateTime = thread.t;
             this.run(thread);
         }
     },

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -8,11 +8,7 @@ import * as time from "../timing/time.js";
 const proto = {
     init() {
         this.clock = Clock();
-
-        // DEBUG
-        this.lastUpdateTime = this.clock.now;
-
-        this.futureQueue = Queue(time.cmp);
+        this.futureQueue = Queue((a, b) => time.cmp(a.t, b.t));
         this.resolvedTimes = new Map();
         on(this.clock, "update", this);
     },
@@ -21,10 +17,8 @@ const proto = {
         if (this.futureQueue.length === 0) {
             return;
         }
-        console.assert(this.futureQueue[0].t >= from);
         while (this.futureQueue.length > 0 && this.futureQueue[0].t < to) {
             const thread = this.futureQueue.remove();
-            console.assert(thread.t >= this.lastUpdateTime);
             this.lastUpdateTime = thread.t;
             this.run(thread);
         }

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -17,6 +17,7 @@ const proto = {
         if (this.futureQueue.length === 0) {
             return;
         }
+        console.assert(this.futureQueue[0].t >= from);
         while (this.futureQueue.length > 0 && this.futureQueue[0].t < to) {
             const thread = this.futureQueue.remove();
             this.lastUpdateTime = thread.t;

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -8,6 +8,10 @@ import * as time from "../timing/time.js";
 const proto = {
     init() {
         this.clock = Clock();
+
+        // DEBUG
+        this.lastUpdateTime = this.clock.now;
+
         this.futureQueue = Queue(time.cmp);
         this.resolvedTimes = new Map();
         on(this.clock, "update", this);
@@ -20,6 +24,8 @@ const proto = {
         console.assert(this.futureQueue[0].t >= from);
         while (this.futureQueue.length > 0 && this.futureQueue[0].t < to) {
             const thread = this.futureQueue.remove();
+            console.assert(thread.t >= this.lastUpdateTime);
+            this.lastUpdateTime = thread.t;
             this.run(thread);
         }
     },

--- a/tests/runtime/vm.html
+++ b/tests/runtime/vm.html
@@ -14,6 +14,16 @@ test("VM()", t => {
     t.equal(vm.clock.now, 0, "clock starts at 0");
 });
 
+test("Thread priority queue", t => {
+    const vm = VM();
+    vm.schedule({ name: "B" }, 40);
+    vm.schedule({ name: "C" }, 48);
+    vm.schedule({ name: "A" }, 36);
+    t.equal(vm.futureQueue.remove().name, "A", "A first");
+    t.equal(vm.futureQueue.remove().name, "B", "B second");
+    t.equal(vm.futureQueue.remove().name, "C", "C last");
+});
+
         </script>
     </head>
     <body>


### PR DESCRIPTION
The priority queue comparison function was incorrect so threads where not inserted correctly in (hence, removed from) the queue.