### PR TITLE
2104 Review thread time management

### DIFF
--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -10,11 +10,7 @@ const proto = {
         this.clock = Clock();
         this.resolvedTimes = new Map();
         this.futureTimes = new Map();
-        this.futureQueue = Queue((a, b) => {
-            console.assert(this.futureTimes.has(a));
-            console.assert(this.futureTimes.has(b));
-            return time.cmp(this.futureTimes.get(a), this.futureTimes.get(b));
-        });
+        this.futureQueue = Queue((a, b) => time.cmp(this.futureTimes.get(a), this.futureTimes.get(b)));
         on(this.clock, "update", this);
     },
 

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -1,5 +1,5 @@
 import { on } from "../events.js";
-import { create, extend } from "../util.js";
+import { create, extend, mapdel } from "../util.js";
 import { Queue } from "../priority-queue.js";
 import { Clock } from "./clock.js";
 import { Thread } from "./thread.js";
@@ -8,8 +8,9 @@ import * as time from "../timing/time.js";
 const proto = {
     init() {
         this.clock = Clock();
-        this.futureQueue = Queue((a, b) => time.cmp(a.t, b.t));
         this.resolvedTimes = new Map();
+        this.futureTimes = new Map();
+        this.futureQueue = Queue((a, b) => time.cmp(this.futureTimes.get(a) - this.futureTimes.get(b)));
         on(this.clock, "update", this);
     },
 
@@ -17,9 +18,10 @@ const proto = {
         if (this.futureQueue.length === 0) {
             return;
         }
-        console.assert(this.futureQueue[0].t >= from);
-        while (this.futureQueue.length > 0 && this.futureQueue[0].t < to) {
+        console.assert(this.futureTimes.get(this.futureQueue[0]) >= from);
+        while (this.futureQueue.length > 0 && this.futureTimes.get(this.futureQueue[0]) < to) {
             const thread = this.futureQueue.remove();
+            this.t = mapdel(this.futureTimes, thread);
             if (!Object.hasOwn(thread, "timeout")) {
                 this.run(thread);
             }
@@ -30,8 +32,9 @@ const proto = {
         if (t < this.clock.now) {
             return;
         }
-        const thread = Object.assign(Thread(), { t });
+        const thread = Object.assign(Thread(), { begin: t });
         thread.end = item.generate(thread, t);
+        this.futureTimes.set(thread, t);
         return this.futureQueue.insert(thread);
     },
 
@@ -49,18 +52,18 @@ const proto = {
                     }
                     resolved = Math.max(resolved, this.resolvedTimes.get(u));
                 }
-                thread.t = resolved;
+                this.futureTimes.set(thread, resolved);
                 this.futureQueue.insert(thread);
             } else if (this.resolvedTimes.has(t)) {
                 // This time was resolved so we can schedule normally.
-                thread.t = this.resolvedTimes.get(t);
+                this.futureTimes.set(this.resolvedTimes.get(t));
                 this.futureQueue.insert(thread);
             }
         } else {
             // Definite time, can schedule normally. Indefinite times are
             // ignored and the thread is simply discarded.
-            thread.t = t;
             if (time.isDefinite(t)) {
+                this.futureTimes.set(thread, t);
                 this.futureQueue.insert(thread);
             }
             if (unresolvedTime && !(t instanceof Set)) {
@@ -72,16 +75,14 @@ const proto = {
 
     // Set a timeout for a thread.
     timeout(thread, t) {
-        if (this.futureQueue[0]?.t <= t) {
-            return;
-        }
         const timeoutThread = Thread();
         timeoutThread.ops.push(() => {
             if (time.cmp(thread.t, t) > 0) {
                 thread.timeout = t;
             }
         });
-        this.futureQueue.insert(Object.assign(timeoutThread, { t }));
+        this.futureTimes.set(timeoutThread, t);
+        this.futureQueue.insert(timeoutThread);
     },
 
     run(thread) {

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -1,5 +1,5 @@
 import { on } from "../events.js";
-import { create, extend, mapdel } from "../util.js";
+import { create, mapdel } from "../util.js";
 import { Queue } from "../priority-queue.js";
 import { Clock } from "./clock.js";
 import { Thread } from "./thread.js";
@@ -10,7 +10,11 @@ const proto = {
         this.clock = Clock();
         this.resolvedTimes = new Map();
         this.futureTimes = new Map();
-        this.futureQueue = Queue((a, b) => time.cmp(this.futureTimes.get(a) - this.futureTimes.get(b)));
+        this.futureQueue = Queue((a, b) => {
+            console.assert(this.futureTimes.has(a));
+            console.assert(this.futureTimes.has(b));
+            return time.cmp(this.futureTimes.get(a), this.futureTimes.get(b));
+        });
         on(this.clock, "update", this);
     },
 
@@ -29,13 +33,14 @@ const proto = {
     },
 
     add(item, t = 0) {
+        console.assert(!time.isUnresolved(t));
         if (t < this.clock.now) {
             return;
         }
         const thread = Object.assign(Thread(), { begin: t });
         thread.end = item.generate(thread, t);
         this.futureTimes.set(thread, t);
-        return this.futureQueue.insert(thread);
+        return time.isDefinite(t) ? this.futureQueue.insert(thread) : thread;
     },
 
     schedule(thread, t, unresolvedTime) {
@@ -56,7 +61,7 @@ const proto = {
                 this.futureQueue.insert(thread);
             } else if (this.resolvedTimes.has(t)) {
                 // This time was resolved so we can schedule normally.
-                this.futureTimes.set(this.resolvedTimes.get(t));
+                this.futureTimes.set(thread, this.resolvedTimes.get(t));
                 this.futureQueue.insert(thread);
             }
         } else {
@@ -77,7 +82,7 @@ const proto = {
     timeout(thread, t) {
         const timeoutThread = Thread();
         timeoutThread.ops.push(() => {
-            if (time.cmp(thread.t, t) > 0) {
+            if (this.futureTimes.has(thread)) {
                 thread.timeout = t;
             }
         });
@@ -99,7 +104,8 @@ const proto = {
                     return;
                 }
             } else {
-                this.run(Object.assign(op, { value: thread.value, t: thread.t }));
+                op.value = thread.value;
+                this.run(op);
             }
         }
     }

--- a/lib/timing/delay.js
+++ b/lib/timing/delay.js
@@ -24,8 +24,7 @@ const proto = {
                 if (!(typeof duration === "number" && duration > 0)) {
                     throw new Error("invalid duration for delay", { duration: thread.value });
                 }
-                thread.end = vm.t + duration;
-                vm.schedule(thread, thread.end, end);
+                vm.schedule(thread, vm.t + duration, end);
             });
         } else if (this.duration > 0) {
             // Non-zero delay

--- a/lib/timing/delay.js
+++ b/lib/timing/delay.js
@@ -24,11 +24,12 @@ const proto = {
                 if (!(typeof duration === "number" && duration > 0)) {
                     throw new Error("invalid duration for delay", { duration: thread.value });
                 }
-                vm.schedule(thread, vm.t + duration, end);
+                thread.end = vm.t + duration;
+                vm.schedule(thread, thread.end, end);
             });
         } else if (this.duration > 0) {
             // Non-zero delay
-            thread.ops.push((thread, vm) => { vm.schedule(thread, thread.t + this.duration); });
+            thread.ops.push((thread, vm) => { vm.schedule(thread, vm.t + this.duration); });
         }
         return end;
     }

--- a/lib/timing/delay.js
+++ b/lib/timing/delay.js
@@ -11,7 +11,8 @@ const proto = {
 
     generate(thread, t) {
         thread.timeline.push(extend(this, { pc: thread.ops.length, t }));
-        const end = time.add(t, this.duration ?? time.unresolved());
+        const begin = t;
+        const end = time.add(begin, this.duration ?? time.unresolved());
         if (time.isUnresolved(end)) {
             // Variable delay: get the duration from the thread value. Duration
             // must be definite and > 0.
@@ -23,7 +24,7 @@ const proto = {
                 if (!(typeof duration === "number" && duration > 0)) {
                     throw new Error("invalid duration for delay", { duration: thread.value });
                 }
-                vm.schedule(thread, thread.t + duration, end);
+                vm.schedule(thread, vm.t + duration, end);
             });
         } else if (this.duration > 0) {
             // Non-zero delay

--- a/lib/timing/instant.js
+++ b/lib/timing/instant.js
@@ -5,7 +5,7 @@ const proto = {
 
     generate(thread, t) {
         thread.timeline.push(extend(this, { pc: thread.ops.length, t }));
-        thread.ops.push(thread => { thread.value = this.f(thread.value, thread.t); });
+        thread.ops.push((thread, vm) => { thread.value = this.f(thread.value, vm.t); });
         return t;
     }
 };

--- a/lib/timing/par.js
+++ b/lib/timing/par.js
@@ -21,13 +21,15 @@ const proto = {
         t = this.children.reduce(
             (t, child, i) => {
                 const childThread = push(thread.ops, Thread());
+                childThread.begin = t;
                 t = time.max(t, wrap(child).generate(childThread, begin));
+                childThread.end = t;
                 childThread.ops.push(thread => { accumulator[i] = thread.value; });
                 thread.timeline.push(childThread);
                 return t;
             }, t
         );
-        if (time.cmp(t, thread.t) > 0) {
+        if (time.cmp(t, begin) > 0) {
             const scheduledEnd = time.isDefinite(this.modifiers?.dur) && time.cmp(end, t) > 0 ? end : t;
             thread.ops.push((thread, vm) => { vm.schedule(thread, scheduledEnd); });
             t = scheduledEnd;

--- a/tests/timing/delay.html
+++ b/tests/timing/delay.html
@@ -77,6 +77,20 @@ test("Variable delay (errors)", t => {
     t.warns(() => vm.clock.seek(52), "Invalid value for delay");
 });
 
+test("Consecutive variable delays", t => {
+    const vm = VM();
+    const seq = vm.add(Seq(K(23), Delay(), K(31), Delay()), 17);
+    vm.clock.seek(72);
+    t.equal(seq.t, 71, "resolved end time");
+    t.equal(seq.dump(),
+`+ 17/0 [begin] Seq
+* 17/0 Instant
+* 17/1 Delay()
+* #/2 Instant
+* #/3 Delay()
+* #/4 [end] Seq`, "dump matches");
+});
+
         </script>
     </head>
     <body>

--- a/tests/timing/delay.html
+++ b/tests/timing/delay.html
@@ -24,7 +24,9 @@ test("Non-zero delay", t => {
     const vm = VM();
     const delay = vm.add(Delay(23), 17);
     vm.clock.seek(41);
-    t.equal(delay.t, 40, "end time after execution");
+    t.equal(vm.t, 40, "vm time after execution");
+    t.equal(delay.begin, 17, "begin time");
+    t.equal(delay.end, 40, "end time");
     t.undefined(delay.value, "no end value");
     t.equal(delay.dump(), "+ 17/0 Delay(23)", "dump matches");
 });
@@ -33,7 +35,7 @@ test("Infinite delay", t => {
     const vm = VM();
     const delay = vm.add(Delay(Infinity), 17);
     vm.clock.seek(41);
-    t.equal(delay.t, Infinity, "indefinite end time");
+    t.equal(delay.end, Infinity, "indefinite end time");
     t.equal(delay.dump(), "+ 17/0 Delay(∞)", "dump matches");
 });
 
@@ -48,7 +50,7 @@ test("Variable delay", t => {
     const vm = VM();
     const seq = vm.add(Seq(K(23), Delay()), 17);
     vm.clock.seek(41);
-    t.equal(seq.t, 40, "end time after execution");
+    t.equal(seq.end, 40, "end time after execution");
     t.equal(seq.value, 23, "end value");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
@@ -61,7 +63,7 @@ test("Variable delay (indefinite)", t => {
     const vm = VM();
     const seq = vm.add(Seq(K(Infinity), Delay()), 17);
     vm.clock.seek(41);
-    t.equal(seq.t, Infinity, "resolved end time");
+    t.equal(seq.end, Infinity, "resolved end time");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
 * 17/0 Instant
@@ -81,7 +83,7 @@ test("Consecutive variable delays", t => {
     const vm = VM();
     const seq = vm.add(Seq(K(23), Delay(), K(31), Delay()), 17);
     vm.clock.seek(72);
-    t.equal(seq.t, 71, "resolved end time");
+    t.equal(seq.end, 71, "resolved end time");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
 * 17/0 Instant

--- a/tests/timing/delay.html
+++ b/tests/timing/delay.html
@@ -50,7 +50,6 @@ test("Variable delay", t => {
     const vm = VM();
     const seq = vm.add(Seq(K(23), Delay()), 17);
     vm.clock.seek(41);
-    t.equal(seq.end, 40, "end time after execution");
     t.equal(seq.value, 23, "end value");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
@@ -63,7 +62,6 @@ test("Variable delay (indefinite)", t => {
     const vm = VM();
     const seq = vm.add(Seq(K(Infinity), Delay()), 17);
     vm.clock.seek(41);
-    t.equal(seq.end, Infinity, "resolved end time");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
 * 17/0 Instant
@@ -83,7 +81,6 @@ test("Consecutive variable delays", t => {
     const vm = VM();
     const seq = vm.add(Seq(K(23), Delay(), K(31), Delay()), 17);
     vm.clock.seek(72);
-    t.equal(seq.end, 71, "resolved end time");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
 * 17/0 Instant

--- a/tests/timing/dur.html
+++ b/tests/timing/dur.html
@@ -40,8 +40,8 @@ test("Seq.dur(), extended", t => {
     const vm = VM();
     const seq = vm.add(Seq(Seq(Delay(23), (x, t) => t * (x ?? 2)).dur(31), (x, t) => t + x), 17);
     vm.clock.seek(49);
-    t.equal(seq.value, 128, "end value");
-    t.equal(seq.t, 48, "end time");
+    t.equal(seq.value, 80, "end value");
+    t.equal(seq.end, 48, "end time");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
 * 17/0 [begin] Seq
@@ -56,7 +56,7 @@ test("Seq.dur() with unresolved duration, extended", t => {
     const vm = VM();
     const seq = vm.add(Seq(K(23), Delay()).dur(31), 17);
     vm.clock.seek(49);
-    t.equal(seq.t, 48, "end time");
+    t.equal(seq.end, 48, "end time");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
 * 17/1 Instant

--- a/tests/timing/instant.html
+++ b/tests/timing/instant.html
@@ -22,7 +22,9 @@ test("Code generation", t => {
     const vm = VM();
     const instant = vm.add(Instant((x, t) => t * (x ?? 2)), 17);
     vm.clock.seek(18);
-    t.equal(instant.t, 17, "end time after execution");
+    t.equal(vm.t, 17, "current vm time");
+    t.equal(instant.begin, 17, "thread begin");
+    t.equal(instant.begin, 17, "thread end");
     t.equal(instant.value, 34, "end value");
     t.equal(instant.dump(), "+ 17/0 Instant", "dump matches");
 });

--- a/tests/timing/instant.html
+++ b/tests/timing/instant.html
@@ -24,7 +24,7 @@ test("Code generation", t => {
     vm.clock.seek(18);
     t.equal(vm.t, 17, "current vm time");
     t.equal(instant.begin, 17, "thread begin");
-    t.equal(instant.begin, 17, "thread end");
+    t.equal(instant.end, 17, "thread end");
     t.equal(instant.value, 34, "end value");
     t.equal(instant.dump(), "+ 17/0 Instant", "dump matches");
 });

--- a/tests/timing/par.html
+++ b/tests/timing/par.html
@@ -23,7 +23,8 @@ test("Empty par", t => {
     const vm = VM();
     const par = vm.add(Par(), 17);
     vm.clock.seek(18);
-    t.equal(par.t, 17, "end time");
+    t.equal(par.begin, 17, "begin time");
+    t.equal(par.end, 17, "end time");
     t.equal(par.value, [], "end value");
     t.equal(par.dump(), "+ 17/0 [begin] Par\n* 17/1 [end] Par", "dump matches");
 });
@@ -32,7 +33,7 @@ test("Non-empty, zero duration par", t => {
     const vm = VM();
     const par = vm.add(Par((x, t) => t * (x ?? 2), (x, t) => t + (x ?? 3)), 17);
     vm.clock.seek(18);
-    t.equal(par.t, 17, "end time");
+    t.equal(par.end, 17, "end time");
     t.equal(par.value, [34, 20], "end value");
     t.equal(par.dump(),
 `+ 17/0 [begin] Par
@@ -48,7 +49,7 @@ test("Non-empty, non-zero duration par", t => {
         (x, t) => t + (x ?? 3)
     ), 17);
     vm.clock.seek(41);
-    t.equal(par.t, 40, "end time");
+    t.equal(par.end, 40, "end time");
     t.equal(par.value, [80, 20], "end value");
     t.equal(par.dump(),
 `+ 17/0 [begin] Par
@@ -70,7 +71,7 @@ test("Input value", t => {
         )
     ), 17);
     vm.clock.seek(41);
-    t.equal(par.t, 40, "end time");
+    t.equal(par.end, 40, "end time");
     t.equal(par.value, [280, 24], "end value");
     t.equal(par.dump(),
 `+ 17/0 [begin] Seq
@@ -89,7 +90,7 @@ test("Nesting", t => {
     const vm = VM();
     const par = vm.add(Par(Delay(23), Par(Delay(31), Delay(19))), 17);
     vm.clock.seek(49);
-    t.equal(par.t, 48, "end time");
+    t.equal(par.end, 48, "end time");
     t.equal(par.value, [undefined, [undefined, undefined]], "end value");
     t.equal(par.dump(),
 `+ 17/0 [begin] Par
@@ -97,7 +98,7 @@ test("Nesting", t => {
     + 17/0 [begin] Par
         + 17/0 Delay(31)
         + 17/0 Delay(19)
-    * 48/3 [end] Par
+    * 48/4 [end] Par
 * 48/4 [end] Par`, "dump matches");
 });
 
@@ -105,7 +106,6 @@ test("Unresolved duration within Par", t => {
     const vm = VM();
     const seq = vm.add(Seq(K(23), Par(Delay(), (x, t) => t * (x ?? 2))), 17);
     vm.clock.seek(41);
-    t.equal(seq.t, 40, "end time");
     t.equal(seq.value, [23, 391], "end value");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
@@ -124,7 +124,6 @@ test("Unresolved durations within Par", t => {
         Seq(K(31), Delay())
     ), 17);
     vm.clock.seek(49);
-    t.equal(par.t, 48, "end time");
     t.equal(par.value, [23, 31], "end value");
     t.equal(par.dump(),
 `+ 17/0 [begin] Par
@@ -146,7 +145,6 @@ test("Unresolved durations within Par (other way around)", t => {
         Seq(K(23), Delay())
     ), 17);
     vm.clock.seek(49);
-    t.equal(par.t, 48, "end time");
     t.equal(par.value, [31, 23], "end value");
     t.equal(par.dump(),
 `+ 17/0 [begin] Par
@@ -165,7 +163,6 @@ test("Indefinite duration within Par", t => {
     const vm = VM();
     const seq = vm.add(Seq(Par(Delay(Infinity), Delay(23)), xs => xs.length), 17);
     vm.clock.seek(41);
-    t.equal(seq.t, Infinity, "indefinite time");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
 * 17/0 [begin] Par

--- a/tests/timing/repeat.html
+++ b/tests/timing/repeat.html
@@ -23,8 +23,10 @@ test("Repeat", t => {
     const vm = VM();
     const repeat = vm.add(Repeat(Seq(Delay(23), (x = 0) => x + 1)), 17);
     vm.clock.seek(97);
-    t.equal(repeat.t, 109, "thread time (next iteration)");
     t.equal(repeat.value, 3, "thread value");
+    vm.clock.seek(111);
+    t.equal(vm.t, 109, "thread time for fourth iteration");
+    t.equal(repeat.value, 4, "thread value after one more iteration");
     t.equal(repeat.dump(),
 `+ 17/0 [begin] Repeat
 * 17/0 [begin] Seq

--- a/tests/timing/seq.html
+++ b/tests/timing/seq.html
@@ -76,7 +76,6 @@ test("Unresolved duration within Seq", t => {
     const vm = VM();
     const seq = vm.add(Seq(K(23), Delay(), (x, t) => t * (x ?? 2)), 17);
     vm.clock.seek(41);
-    t.equal(seq.end, 40, "end time");
     t.equal(seq.value, 920, "end value");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq

--- a/tests/timing/seq.html
+++ b/tests/timing/seq.html
@@ -23,7 +23,8 @@ test("Empty seq", t => {
     const vm = VM();
     const seq = vm.add(Seq(), 17);
     vm.clock.seek(18);
-    t.equal(seq.t, 17, "end time");
+    t.equal(seq.begin, 17, "begin time");
+    t.equal(seq.end, 17, "end time");
     t.undefined(seq.value, "end value");
     t.equal(seq.dump(), "+ 17/0 [begin] Seq\n* 17/0 [end] Seq", "dump matches");
 });
@@ -32,7 +33,8 @@ test("Non-empty, zero duration seq", t => {
     const vm = VM();
     const seq = vm.add(Seq((x, t) => t * (x ?? 2), x => x + 3), 17);
     vm.clock.seek(18);
-    t.equal(seq.t, 17, "end time");
+    t.equal(seq.begin, 17, "begin time");
+    t.equal(seq.end, 17, "end time");
     t.equal(seq.value, 37, "end value");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
@@ -45,7 +47,7 @@ test("Non-empty, non-zero duration seq", t => {
     const vm = VM();
     const seq = vm.add(Seq(Delay(23), (x, t) => t * (x ?? 2)), 17);
     vm.clock.seek(41);
-    t.equal(seq.t, 40, "end time");
+    t.equal(seq.end, 40, "end time");
     t.equal(seq.value, 80, "end value");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
@@ -58,7 +60,7 @@ test("Nesting", t => {
     const vm = VM();
     const seq = vm.add(Seq(Delay(23), Seq((x, t) => t * (x ?? 2), Delay(19))), 17);
     vm.clock.seek(60);
-    t.equal(seq.t, 59, "end time");
+    t.equal(seq.end, 59, "end time");
     t.equal(seq.value, 80, "end value");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
@@ -74,7 +76,7 @@ test("Unresolved duration within Seq", t => {
     const vm = VM();
     const seq = vm.add(Seq(K(23), Delay(), (x, t) => t * (x ?? 2)), 17);
     vm.clock.seek(41);
-    t.equal(seq.t, 40, "end time");
+    t.equal(seq.end, 40, "end time");
     t.equal(seq.value, 920, "end value");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq


### PR DESCRIPTION
In order to prepare for 1X02 (Running the clock backward), separate the current thread time from the thread object. This is achieved by keeping a separate map of future (resolved) times for threads.