### PR TITLE
220C Unresolved time

### DIFF
--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -1,5 +1,5 @@
 import { on } from "../events.js";
-import { create, nop } from "../util.js";
+import { create, del, nop } from "../util.js";
 import { Clock } from "./clock.js";
 import { generate, Thread, Threads } from "./thread.js";
 import * as time from "../timing/time.js";
@@ -120,15 +120,24 @@ const proto = {
         this.threads.scheduleForward(thread, this.t, this.pc);
     },
 
-    // Schedule a thread forward in time.
-    schedule(thread, t, u) {
+    // Schedule a thread forward in time. If the time is not definite, the
+    // thread is simply suspended; in case of unresolved time, it may be
+    // rescheduled later.
+    schedule(thread, t) {
         this.yielded = true;
-        console.assert(time.isResolved(t));
-        // Indefinite times are ignored and the thread is simply discarded.
         if (time.isDefinite(t)) {
             this.threads.scheduleForward(thread, t, this.pc);
-            this.threads.scheduleBackward(thread, this.t, this.pc - 1);
+        } else {
+            // Keep track of the position at which the thread was suspended.
+            thread.suspended = this.pc;
         }
+        this.threads.scheduleBackward(thread, this.t, this.pc - 1);
+    },
+
+    // Wake a suspended thread.
+    wake(thread) {
+        console.assert(thread.suspended);
+        this.threads.scheduleForward(thread, this.t, del(thread, "suspended"));
     },
 
     // Yield a thread forward or backward (for redo/undo).

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -120,39 +120,14 @@ const proto = {
         this.threads.scheduleForward(thread, this.t, this.pc);
     },
 
-    // Schedule a thread forward in time, possibly resolving an unresolved time.
+    // Schedule a thread forward in time.
     schedule(thread, t, u) {
         this.yielded = true;
-        if (time.isResolved(t)) {
-            // Definite time, can schedule normally. Indefinite times are
-            // ignored and the thread is simply discarded.
-            if (time.isDefinite(t)) {
-                this.threads.scheduleForward(thread, t, this.pc);
-                this.threads.scheduleBackward(thread, this.t, this.pc - 1);
-            }
-            if (u && !(t instanceof Set)) {
-                // This unresolved time just became resolved.
-                this.resolvedTimes.set(u, t);
-            }
-        } else {
-            if (t instanceof Set) {
-                // Check if all unresolved times have been resolved, in which
-                // case the resolved time is the max of all resolved times.
-                console.assert(t.size >= 2);
-                let resolved = -Infinity;
-                for (const u of t) {
-                    if (!this.resolvedTimes.has(u)) {
-                        return;
-                    }
-                    resolved = Math.max(resolved, this.resolvedTimes.get(u));
-                }
-                this.threads.scheduleForward(thread, resolved, this.pc);
-                this.threads.scheduleBackward(thread, this.t, this.pc - 1);
-            } else if (this.resolvedTimes.has(t)) {
-                // This time was resolved so we can schedule normally.
-                this.threads.scheduleForward(thread, this.resolvedTimes.get(t), this.pc);
-                this.threads.scheduleBackward(thread, this.t, this.pc - 1);
-            }
+        console.assert(time.isResolved(t));
+        // Indefinite times are ignored and the thread is simply discarded.
+        if (time.isDefinite(t)) {
+            this.threads.scheduleForward(thread, t, this.pc);
+            this.threads.scheduleBackward(thread, this.t, this.pc - 1);
         }
     },
 

--- a/lib/timing/delay.js
+++ b/lib/timing/delay.js
@@ -30,7 +30,7 @@ const proto = {
                     if (!(typeof duration === "number" && duration > 0)) {
                         throw Error("invalid duration for delay", { duration: thread.value });
                     }
-                    vm.schedule(thread, vm.t + duration, end);
+                    vm.schedule(thread, vm.t + duration);
                 },
                 (thread, vm) => { vm.yield(thread); },
                 (thread, vm) => { vm.yield(thread); },

--- a/lib/timing/delay.js
+++ b/lib/timing/delay.js
@@ -16,7 +16,7 @@ const proto = {
 
         thread.timeline.push(extend(this, { pc: thread.ops.length, t }));
         const begin = t;
-        const end = time.add(begin, this.duration ?? time.unresolved());
+        const end = time.add(begin, this.duration ?? time.unresolved);
         if (time.isUnresolved(end)) {
             // Variable delay: get the duration from the thread value. Duration
             // must be definite and > 0. Keep track of the resolved duration

--- a/lib/timing/par.js
+++ b/lib/timing/par.js
@@ -12,8 +12,9 @@ const proto = {
     generate(thread, t) {
         thread.timeline.push(extend(this, { begin: true, pc: thread.ops.length, t }));
         const accumulator = [];
+        let unresolved = 0;
         const begin = t;
-        const end = time.add(t, this.modifiers?.dur);
+        const end = time.add(t, this.modifiers?.dur ?? time.unresolved);
 
         // Generate threads for children and track the maximum end time. When a
         // thread ends, it pushes its value to the accumulator.
@@ -21,14 +22,24 @@ const proto = {
             (t, child, i) => {
                 const childThread = push(thread.ops, generate(wrap(child), begin));
                 t = time.max(t, childThread.end);
-                if (time.cmp(childThread.end, end) > 0) {
-                    childThread.end = end;
-                }
-                childThread.ops.push([
+                const op = [
                     thread => { accumulator[i] = thread.value; },
                     nop,
                     nop
-                ]);
+                ];
+                if (time.isUnresolved(childThread.end)) {
+                    unresolved += 1;
+                    op[0] = (childThread, vm) => {
+                        accumulator[i] = childThread.value;
+                        if (--unresolved === 0) {
+                            vm.wake(thread);
+                        }
+                    };
+                }
+                if (time.cmp(childThread.end, end) > 0) {
+                    childThread.end = end;
+                }
+                childThread.ops.push(op);
                 thread.timeline.push(childThread);
                 return t;
             }, t

--- a/lib/timing/time.js
+++ b/lib/timing/time.js
@@ -1,8 +1,8 @@
 import { isNumber, parseTime, safe } from "../util.js";
 
 // Add times, may become unresolved if either is unresolved.
-export const add = (x, y) => isUnresolved(x) ? (y === Infinity ? y : unresolved()) :
-    (isUnresolved(y) ? (x === Infinity ? x : unresolved()) : x + y);
+export const add = (x, y) => isUnresolved(x) ? (y === Infinity ? y : unresolved) :
+    (isUnresolved(y) ? (x === Infinity ? x : unresolved) : x + y);
 
 // Check a duration/time argument, which may be a string or a number, and return
 // a number ≥ 0.
@@ -23,25 +23,16 @@ export const cmp = (x, y) => {
 }
 
 // Distinguish between unresolved, definite and indefinite times.
-export const isUnresolved = t => !isNumber(t);
+export const isUnresolved = t => t === null;
 export const isResolved = isNumber;
-export const isDefinite = isFinite;
+export const isDefinite = Number.isFinite;
 export const isIndefinite = t => t === Infinity;
 
 // Max of two times.
 export function max(x, y) {
     if (isUnresolved(x)) {
         if (isUnresolved(y)) {
-            const z = x instanceof Set ? new Set(x) : new Set([x]);
-            // max(u, v) = union(u, v), flattening the sets if necessary.
-            if (y instanceof Set) {
-                for (const u of y) {
-                    z.add(u);
-                }
-            } else {
-                z.add(y);
-            }
-            return z;
+            return unresolved;
         }
         if (y === Infinity) {
             // max(u, ∞) = ∞
@@ -63,7 +54,7 @@ export function max(x, y) {
 }
 
 // Show a time.
-export const show = t => t == null ? "" : isUnresolved(t) ? "#" : isDefinite(t) ? t.toString() : "∞";
+export const show = t => isUnresolved(t) ? "#" : isDefinite(t) ? t.toString() : isIndefinite(t) ? "∞" : "";
 
-// Create a new unresolved time.
-export const unresolved = () => ({});
+// Unresolved is just null.
+export const unresolved = null;

--- a/tests/timing/dur.html
+++ b/tests/timing/dur.html
@@ -145,7 +145,7 @@ test("Par.dur() with unresolved duration, cutoff", t => {
     ), 17);
     vm.clock.seek(37);
     t.equal(par.value, 7, "Par (input) value");
-    t.equal(par.t, 36, "timed out");
+    t.equal(par.t, 17, "thread is suspended");
     t.equal(par.dump(),
 `+ 17/0 [begin] Seq
 * 17/0 Instant

--- a/tests/timing/time.html
+++ b/tests/timing/time.html
@@ -11,97 +11,78 @@ import * as time from "../../lib/timing/time.js";
 
 test("time.add(x, y)", t => {
     t.equal(time.add(17, 23), 40, "x definite, y definite");
-    const u = time.unresolved();
-    const v = time.unresolved();
-    const dv = time.add(17, v);
-    t.equal(time.isUnresolved(dv) && dv !== v, true, "x definite, y unresolved");
+    t.equal(time.add(17, time.unresolved), time.unresolved, "x definite, y unresolved");
     t.equal(time.add(17, Infinity), Infinity, "x definite, y indefinite");
-    const ud = time.add(u, 23);
-    t.equal(time.isUnresolved(ud) && ud !== u, true, "x unresolved, y definite");
-    const uv = time.add(u, v);
-    t.equal(time.isUnresolved(uv) && uv !== u && uv !== v, true, "x unresolved, y unresolved");
-    t.equal(time.add(u, Infinity), Infinity, "x unresolved, y indefinite");
+    t.equal(time.add(time.unresolved), time.unresolved, "x unresolved, y definite");
+    t.equal(time.add(time.unresolved, time.unresolved), time.unresolved, "x unresolved, y unresolved");
+    t.equal(time.add(time.unresolved, Infinity), Infinity, "x unresolved, y indefinite");
     t.equal(time.add(Infinity, 23), Infinity, "x indefinite, y definite");
-    t.equal(time.add(Infinity, v), Infinity, "x indefinite, y unresolved");
+    t.equal(time.add(Infinity, time.unresolved), Infinity, "x indefinite, y unresolved");
     t.equal(time.add(Infinity, Infinity), Infinity, "x indefinite, y indefinite");
-    t.equal(time.isUnresolved(time.add(17)), true, "x definite, y missing");
 });
 
 test("time.cmp(x, y)", t => {
     t.below(time.cmp(17, 23), 0, "x definite < y definite");
     t.equal(time.cmp(17, 17), 0, "x definite = y definite");
     t.above(time.cmp(23, 17), 0, "x definite > y definite");
-    t.below(time.cmp(17, time.unresolved()), 0, "x definite < y unresolved");
+    t.below(time.cmp(17, time.unresolved), 0, "x definite < y unresolved");
     t.below(time.cmp(17, Infinity), 0, "x definite < y indefinite");
-    t.above(time.cmp(time.unresolved(), 23), 0, "x unresolved > y definite");
-    t.equal(time.cmp(time.unresolved(), time.unresolved()), 0, "x unresolved = y unresolved");
-    t.equal(time.cmp(time.unresolved(), Infinity), 0, "x unresolved = y indefinite");
+    t.above(time.cmp(time.unresolved, 23), 0, "x unresolved > y definite");
+    t.equal(time.cmp(time.unresolved, time.unresolved), 0, "x unresolved = y unresolved");
+    t.equal(time.cmp(time.unresolved, Infinity), 0, "x unresolved = y indefinite");
     t.above(time.cmp(Infinity, 23), 0, "x indefinite > y definite");
-    t.equal(time.cmp(Infinity, time.unresolved()), 0, "x indefinite = y unresolved");
+    t.equal(time.cmp(Infinity, time.unresolved), 0, "x indefinite = y unresolved");
     t.equal(time.cmp(Infinity, Infinity), 0, "x indefinite = y indefinite");
 });
 
 test("time.isUnresolved(t)", t => {
-    t.equal(time.isUnresolved(), true, "no time");
-    t.equal(time.isUnresolved(time.unresolved()), true, "unresolved time");
+    t.equal(time.isUnresolved(), false, "no time");
+    t.equal(time.isUnresolved(time.unresolved), true, "unresolved time");
     t.equal(time.isUnresolved(17), false, "definite time");
     t.equal(time.isUnresolved(Infinity), false, "indefinite time");
 });
 
 test("time.isResolved(t)", t => {
     t.equal(time.isResolved(), false, "no time");
-    t.equal(time.isResolved(time.unresolved()), false, "unresolved time");
+    t.equal(time.isResolved(time.unresolved), false, "unresolved time");
     t.equal(time.isResolved(17), true, "definite time");
     t.equal(time.isResolved(Infinity), true, "indefinite time");
 });
 
 test("time.isDefinite(t)", t => {
     t.equal(time.isDefinite(), false, "no time");
-    t.equal(time.isDefinite(time.unresolved()), false, "unresolved time");
+    t.equal(time.isDefinite(time.unresolved), false, "unresolved time");
     t.equal(time.isDefinite(17), true, "definite time");
     t.equal(time.isDefinite(Infinity), false, "indefinite time");
 });
 
 test("time.isIndefinite(t)", t => {
     t.equal(time.isIndefinite(), false, "no time");
-    t.equal(time.isIndefinite(time.unresolved()), false, "unresolved time");
+    t.equal(time.isIndefinite(time.unresolved), false, "unresolved time");
     t.equal(time.isIndefinite(17), false, "definite time");
     t.equal(time.isIndefinite(Infinity), true, "indefinite time");
 });
 
 test("time.max(x, y)", t => {
-    const u = time.unresolved();
-    const v = time.unresolved();
-    const w = time.unresolved();
-    const x = time.unresolved();
-
     t.equal(time.max(17, 23), 23, "max(x definite < y definite) = y");
     t.equal(time.max(17, 17), 17, "max(x definite = y definite) = x");
     t.equal(time.max(23, 17), 23, "max(x definite > y definite) = x");
-    t.equal(time.max(17, v), v, "max(x definite < y unresolved) = y");
+    t.equal(time.max(17, time.unresolved), time.unresolved, "max(x definite < y unresolved) = y");
     t.equal(time.max(17, Infinity), Infinity, "max(x definite < y indefinite) = y");
-    t.equal(time.max(u, 23), u, "max(x unresolved > y definite) = x");
-    t.equal(time.max(u, v), new Set([u, v]), "max(x unresolved, y unresolved) = union(x, y)");
-    t.equal(time.max(new Set([u, v]), w), new Set([u, v, w]),
-        "max(xs unresolved, y unresolved) = union(xs, y)");
-    t.equal(time.max(u, new Set([v, w])), new Set([u, v, w]),
-        "max(x unresolved, ys unresolved) = union(x, ys)");
-    t.equal(time.max(new Set([u, v]), new Set([w, x])), new Set([u, v, w, x]),
-        "max(x unresolved, ys unresolved) = union(xs, ys)");
-    t.equal(time.max(u, Infinity), Infinity, "max(x unresolved < y indefinite) = y");
+    t.equal(time.max(time.unresolved, 23), time.unresolved, "max(x unresolved > y definite) = x");
+    t.equal(time.max(time.unresolved, time.unresolved), time.unresolved,
+        "max(x unresolved, y unresolved) = unresolved");
+    t.equal(time.max(time.unresolved, Infinity), Infinity, "max(x unresolved < y indefinite) = y");
     t.equal(time.max(Infinity, 23), Infinity, "max(x indefinite > y definite) = x");
-    t.equal(time.max(Infinity, v), Infinity, "max(x indefinite > y unresolved) =x");
+    t.equal(time.max(Infinity, time.unresolved), Infinity, "max(x indefinite > y unresolved) =x");
     t.equal(time.max(Infinity, Infinity), Infinity, "max(x indefinite = y indefinite) = x");
 });
 
 test("time.show(t)", t => {
+    t.equal(time.show(), "", "no time");
     t.equal(time.show(17), "17", "definite time");
     t.equal(time.show(Infinity), "∞", "indefinite time");
-    t.equal(time.show(time.unresolved()), "#", "unresolved time");
-});
-
-test("time.unresolved()", t => {
-    t.equal(time.unresolved() === time.unresolved(), false, "generate a unique unresolved time");
+    t.equal(time.show(time.unresolved), "#", "unresolved time");
 });
 
         </script>


### PR DESCRIPTION
Simplify unresolved times—just use `null` instead of creating new values, and suspend threads to be awaken when unresolved times become resolved.