### PR TITLE
230B Breadth-first evaluation

### DIFF
--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -55,6 +55,7 @@ const proto = {
     runForward(thread) {
         const i = thread.t < this.t ? DO : REDO;
         const n = thread.ops.length;
+        const childThreads = [];
         while (this.pc < n) {
             const op = thread.ops[this.pc++];
             if (Array.isArray(op)) {
@@ -64,24 +65,32 @@ const proto = {
                     console.warn(error.message ?? "Error", error);
                 }
                 if (this.yielded) {
-                    if (this.t > thread.t) {
+                    if (this.t > thread.t && this.t !== thread.suspended[1]) {
                         thread.t = this.t;
                     }
-                    delete this.yielded;
-                    return;
+                    break;
                 }
             } else {
-                op.value = thread.value;
-                const pc = this.pc;
-                this.pc = 0;
-                this.runForward(op);
-                this.pc = pc;
+                childThreads.push(op);
             }
         }
-        thread.end = thread.t = this.t;
-        console.assert(this.pc === thread.ops.length);
-        if (!thread.transient) {
-            this.threads.scheduleBackward(thread, this.t, this.pc);
+
+        if (this.yielded) {
+            // The thread was suspended.
+            delete this.yielded;
+        } else {
+            // The thread reached its end.
+            thread.end = thread.t = this.t;
+            console.assert(this.pc === thread.ops.length);
+            if (!thread.transient) {
+                this.threads.scheduleBackward(thread, this.t, this.pc);
+            }
+        }
+
+        for (const childThread of childThreads) {
+            childThread.value = thread.value;
+            this.pc = 0;
+            this.runForward(childThread);
         }
     },
 
@@ -129,11 +138,10 @@ const proto = {
     // rescheduled later.
     schedule(thread, t) {
         this.yielded = true;
+        // Keep track of the position at which the thread was suspended.
+        thread.suspended = [this.pc, t];
         if (time.isDefinite(t)) {
             this.threads.scheduleForward(thread, t, this.pc);
-        } else {
-            // Keep track of the position at which the thread was suspended.
-            thread.suspended = this.pc;
         }
         this.threads.scheduleBackward(thread, this.t, this.pc - 1);
     },
@@ -141,7 +149,7 @@ const proto = {
     // Wake a suspended thread.
     wake(thread, t) {
         console.assert(thread.suspended);
-        this.threads.scheduleForward(thread, t ?? this.t, del(thread, "suspended"));
+        this.threads.scheduleForward(thread, t ?? this.t, del(thread, "suspended")[0]);
     },
 
     // Schedule a thread to wait for an event to occur. A notification is sent.

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -110,7 +110,8 @@ const proto = {
 
     // Run a thread backward to the beginning, or until it yields.
     runBackward(thread) {
-        while (this.pc > 0) {
+        const childThreads = [];
+        while (this.pc > 0 && !this.yielded) {
             const op = thread.ops[--this.pc];
             if (Array.isArray(op)) {
                 try {
@@ -118,19 +119,21 @@ const proto = {
                 } catch (error) {
                     console.warn(error.message ?? "Error", error);
                 }
-                if (this.yielded) {
-                    delete this.yielded;
-                    return;
-                }
             } else {
-                const pc = this.pc;
-                this.pc = 0;
-                this.runBackward(op);
-                this.pc = pc;
+                childThreads.push(op);
             }
         }
-        console.assert(this.pc === 0);
-        this.threads.scheduleForward(thread, this.t, this.pc);
+
+        if (this.yielded) {
+            delete this.yielded;
+        } else {
+            console.assert(this.pc === 0);
+            this.threads.scheduleForward(thread, this.t, this.pc);
+        }
+
+        for (const childThread of childThreads) {
+            this.runBackward(childThread);
+        }
     },
 
     // Schedule a thread forward in time. If the time is not definite, the

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -70,7 +70,7 @@ const proto = {
                     }
                     break;
                 }
-            } else {
+            } else if (i === DO) {
                 childThreads.push(op);
             }
         }
@@ -110,7 +110,6 @@ const proto = {
 
     // Run a thread backward to the beginning, or until it yields.
     runBackward(thread) {
-        const childThreads = [];
         while (this.pc > 0 && !this.yielded) {
             const op = thread.ops[--this.pc];
             if (Array.isArray(op)) {
@@ -119,8 +118,6 @@ const proto = {
                 } catch (error) {
                     console.warn(error.message ?? "Error", error);
                 }
-            } else {
-                childThreads.push(op);
             }
         }
 
@@ -129,10 +126,6 @@ const proto = {
         } else {
             console.assert(this.pc === 0);
             this.threads.scheduleForward(thread, this.t, this.pc);
-        }
-
-        for (const childThread of childThreads) {
-            this.runBackward(childThread);
         }
     },
 

--- a/lib/timing/par.js
+++ b/lib/timing/par.js
@@ -15,6 +15,7 @@ const proto = {
         let unresolved = 0;
         const begin = t;
         const end = time.add(t, this.modifiers?.dur ?? time.unresolved);
+        const hasDur = time.isResolved(end);
 
         // Generate threads for children and track the maximum end time. When a
         // thread ends, it pushes its value to the accumulator.
@@ -45,11 +46,10 @@ const proto = {
             }, t
         );
 
-        // Non-zero duration par needs a delay to the end of the child ending
-        // last, possibly extended to meet the duration (but no less in case
-        // the par is cut off).
-        if (time.cmp(t, begin) > 0) {
-            const parEnd = time.isUnresolved(end) ? t : time.max(t, end);
+        if (this.children.length > 0) {
+            // Suspend the thread to wait for the child threads to end (even
+            // when they all have a zero duration).
+            const parEnd = hasDur ? time.max(t, end) : t;
             thread.ops.push([
                 (thread, vm) => { vm.schedule(thread, parEnd); },
                 (thread, vm) => { vm.yield(thread); },
@@ -64,7 +64,7 @@ const proto = {
             thread => { thread.redo(); }
         ]);
 
-        if (time.isResolved(end)) {
+        if (hasDur) {
             t = end;
         }
         thread.timeline.push(extend(this, { end: true, pc: thread.ops.length, t }));

--- a/tests/timing/par.html
+++ b/tests/timing/par.html
@@ -127,6 +127,20 @@ test("Nesting", t => {
 * 48/4 [end] Par`, "dump matches");
 });
 
+test("Do, undo, redo: Nesting", t => {
+    const vm = VM();
+    const seq = vm.add(Seq(
+        Par(Seq(Delay(19), K("A")), Seq(Delay(23), K("B"))),
+        Par(Seq(Delay(31), K("x")), Seq(Delay(23), K("y")), Seq(Delay(19), K("z"))),
+    ), 17);
+    vm.clock.seek(72);
+    t.equal(seq.value, ["x", "y", "z"], "Do");
+    vm.clock.seek(51);
+    t.equal(seq.value, ["A", "B"], "Undo (partially)");
+    vm.clock.seek(72);
+    t.equal(seq.value, ["x", "y", "z"], "Redo");
+});
+
 test("Unresolved duration within Par", t => {
     const vm = VM();
     const seq = vm.add(Seq(K(23), Par(Delay(), (x, t) => t * (x ?? 2))), 17);

--- a/tests/timing/par.html
+++ b/tests/timing/par.html
@@ -39,7 +39,7 @@ test("Non-empty, zero duration par", t => {
 `+ 17/0 [begin] Par
     + 17/0 Instant
     + 17/0 Instant
-* 17/3 [end] Par`, "dump matches");
+* 17/4 [end] Par`, "dump matches");
 });
 
 test("Do, undo, redo (zero duration)", t => {


### PR DESCRIPTION
Instead of running child threads immediately from a Par thread, wait until the thread yields (which should simplify implementing the take modifier). Also simplify handling undoing/redoing since the child threads are already scheduled and do not need to run.