### PR TITLE
2405 Seq cutoff ends the whole thread

### DIFF
--- a/lib/runtime/thread.js
+++ b/lib/runtime/thread.js
@@ -62,6 +62,7 @@ const threads = {
     init() {
         this.futureQueue = Queue((a, b) => time.cmp(a.t, b.t));
         this.pastQueue = Queue((a, b) => time.cmp(b.t, a.t));
+        this.schedule = new Map();
     },
 
     get hasFuture() {
@@ -72,13 +73,42 @@ const threads = {
         return this.futureQueue[0].t;
     },
 
+    get nextFutureThread() {
+        const thread = this.futureQueue.remove();
+        if (thread.executionMode === Do) {
+            const key = Object.getPrototypeOf(thread);
+            console.assert(this.schedule.get(key) === thread);
+            this.schedule.delete(key);
+        }
+        return thread;
+    },
+
     scheduleForward(thread, t, pc, executionMode) {
         if (time.isDefinite(t)) {
             if (time.cmp(t, thread.end) <= 0) {
-                this.futureQueue.insert(extend(thread, { t, pc, executionMode }));
+                const scheduled = this.futureQueue.insert(extend(thread, { t, pc, executionMode }));
+                if (executionMode === Do) {
+                    this.schedule.set(thread, scheduled);
+                }
             }
         }
         return thread;
+    },
+
+    // Attempt to reschedule a thread if it is scheduled for a later time.
+    didReschedule(thread, t, pc) {
+        if (this.schedule.has(thread)) {
+            const scheduled = this.schedule.get(thread);
+            if (scheduled.t > t) {
+                this.schedule.delete(thread);
+                scheduled.rescheduled = true;
+            } else {
+                return false;
+            }
+        }
+        delete thread.suspended;
+        this.scheduleForward(thread, t, pc, Do);
+        return true;
     },
 
     get hasPast() {

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -50,7 +50,10 @@ const proto = {
         console.assert(this.threads.nextFutureTime >= from);
         this.forward = true;
         while (this.threads.hasFuture && this.threads.nextFutureTime < to) {
-            const thread = this.threads.futureQueue.remove();
+            const thread = this.threads.nextFutureThread;
+            if (thread.rescheduled) {
+                continue;
+            }
             this.t = thread.t;
             this.pc = thread.pc;
             this.runForward(Object.getPrototypeOf(thread), thread.executionMode);
@@ -150,9 +153,23 @@ const proto = {
         this.threads.scheduleBackward(thread, this.t, this.pc - 1);
     },
 
+    // Cutoff a thread after a duration, cancelling all subthreads in the
+    // [from, to] range of ops.
+    cutoff(thread, dur, from, to) {
+        this.threads.scheduleForward(Object.assign(Thread(), {
+            ops: [[(_, vm) => {
+                if (this.threads.didReschedule(thread, vm.t, to, Do)) {
+                    for (let i = from; i < to; ++i) {
+                        thread.ops[i].cancel?.();
+                    }
+                }
+            }]]
+        }), this.t + dur, 0, Do);
+    },
+
     // Wake a suspended thread.
     wake(thread, t) {
-        console.assert(thread.suspended);
+        console.assert(thread.suspended >= 0);
         this.threads.scheduleForward(thread, t ?? this.t, del(thread, "suspended"), Do);
     },
 

--- a/lib/timing/seq.js
+++ b/lib/timing/seq.js
@@ -11,8 +11,14 @@ const proto = {
     // Generate code for the children, keeping track of time along the way. Set
     // the end if the dur modifier is set.
     generate(thread, t) {
-        thread.timeline.push(extend(this, { begin: true, pc: thread.ops.length, t }));
-        const end = time.add(t, this.modifiers?.dur);
+        const pc = thread.ops.length;
+        thread.timeline.push(extend(this, { begin: true, pc, t }));
+        const dur = this.modifiers?.dur;
+        const end = time.add(t, dur ?? time.unresolved);
+        if (time.isDefinite(end)) {
+            // Reserve space for the cutoff thread.
+            thread.ops.push([nop, nop, nop]);
+        }
         for (const child of this.children) {
             t = wrap(child).generate(thread, t);
         }
@@ -20,10 +26,16 @@ const proto = {
         if (time.isDefinite(end)) {
             if (time.isUnresolved(t) || end > t) {
                 thread.ops.push([
-                    (thread, vm) => { vm.schedule(thread, end); },
+                    (thread, vm) => { vm.schedule(thread, vm.t + dur); },
                     (thread, vm) => { vm.yield(thread); },
                     (thread, vm) => { vm.yield(thread); },
                 ]);
+            }
+            if (time.cmp(t, end) > 0) {
+                // Thread may need to be cutoff, so schedule a cutoff thread
+                // at the beginning.
+                const to = thread.ops.length;
+                thread.ops[pc][0] = (_, vm) => { vm.cutoff(thread, dur, pc + 1, to); };
             }
             t = end;
         }

--- a/tests/timing/dur.html
+++ b/tests/timing/dur.html
@@ -61,6 +61,17 @@ test("Do, undo, redo: Seq.dur() with unresolved duration, cutoff", t => {
     t.equal(vm.t, 17, "redo");
 });
 
+test("Seq.dur(): cutoff within thread", t => {
+    const vm = VM();
+    const seq = vm.add(Seq(
+        Seq(K("ok"), Delay(31), K("ko")).dur(23),
+        x => x + "!"
+    ), 17);
+    vm.clock.seek(49);
+    console.log(seq.dump());
+    t.equal(seq.value, "ok!", "inner seq was cut off");
+});
+
 test("Seq.dur(), extended", t => {
     const vm = VM();
     const seq = vm.add(Seq(Seq(Delay(23), (x, t) => t * (x ?? 2)).dur(31), (x, t) => x + t), 17);

--- a/tests/timing/dur.html
+++ b/tests/timing/dur.html
@@ -21,9 +21,9 @@ test("Seq.dur(), cutoff", t => {
     t.equal(seq.end, 36, "timed out");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
-* 17/0 Delay(23)
-* 40/1 Instant
-* 36/2 [end] Seq`, "dump matches");
+* 17/1 Delay(23)
+* 40/2 Instant
+* 36/3 [end] Seq`, "dump matches");
 });
 
 test("Do, undo, redo: Seq.dur(), cutoff", t => {
@@ -34,7 +34,7 @@ test("Do, undo, redo: Seq.dur(), cutoff", t => {
     vm.clock.seek(0);
     t.undefined(seq.value, "undo");
     vm.clock.seek(40);
-    t.equal(vm.t, 17, "redo (time)");
+    t.equal(vm.t, 36, "redo (time)");
     t.undefined(seq.value, "redo (value)");
 });
 
@@ -45,9 +45,9 @@ test("Seq.dur() with unresolved duration, cutoff", t => {
     t.equal(seq.end, 36, "timed out");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
-* 17/0 Instant
-* 17/1 Delay()
-* 36/3 [end] Seq`, "dump matches");
+* 17/1 Instant
+* 17/2 Delay()
+* 36/4 [end] Seq`, "dump matches");
 });
 
 test("Do, undo, redo: Seq.dur() with unresolved duration, cutoff", t => {
@@ -58,7 +58,7 @@ test("Do, undo, redo: Seq.dur() with unresolved duration, cutoff", t => {
     vm.clock.seek(0);
     t.undefined(seq.value, "undo");
     vm.clock.seek(40);
-    t.equal(vm.t, 17, "redo");
+    t.equal(vm.t, 36, "redo");
 });
 
 test("Seq.dur(): cutoff within thread", t => {
@@ -68,35 +68,57 @@ test("Seq.dur(): cutoff within thread", t => {
         x => x + "!"
     ), 17);
     vm.clock.seek(49);
-    console.log(seq.dump());
     t.equal(seq.value, "ok!", "inner seq was cut off");
+    t.equal(seq.dump(),
+`+ 17/0 [begin] Seq
+* 17/0 [begin] Seq
+* 17/1 Instant
+* 17/2 Delay(31)
+* 48/3 Instant
+* 40/4 [end] Seq
+* 40/4 Instant
+* 40/5 [end] Seq`, "dump matches");
+});
+
+test("Do, undo, redo: Seq.dur(): cutoff within thread", t => {
+    const vm = VM();
+    const seq = vm.add(Seq(
+        Seq(K("ok"), Delay(31), K("ko")).dur(23),
+        x => x + "!"
+    ), 17);
+    vm.clock.seek(49);
+    t.equal(seq.value, "ok!", "do");
+    vm.clock.seek(0);
+    t.undefined(seq.value, "undo");
+    vm.clock.seek(49);
+    t.equal(seq.value, "ok!", "redo");
 });
 
 test("Seq.dur(), extended", t => {
     const vm = VM();
     const seq = vm.add(Seq(Seq(Delay(23), (x, t) => t * (x ?? 2)).dur(31), (x, t) => x + t), 17);
     vm.clock.seek(49);
-    t.equal(seq.value, 128, "end value");
+    t.equal(seq.value, 80, "end value");
     t.equal(seq.end, 48, "end time");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
 * 17/0 [begin] Seq
-* 17/0 Delay(23)
-* 40/1 Instant
-* 48/3 [end] Seq
-* 48/3 Instant
-* 48/4 [end] Seq`, "dump matches");
+* 17/1 Delay(23)
+* 40/2 Instant
+* 48/4 [end] Seq
+* 48/4 Instant
+* 48/5 [end] Seq`, "dump matches");
 });
 
 test("Do, undo, redo: Seq.dur(), extended", t => {
     const vm = VM();
     const seq = vm.add(Seq(Seq(Delay(23), (x, t) => t * (x ?? 2)).dur(31), (x, t) => t + x), 17);
     vm.clock.seek(49);
-    t.equal(seq.value, 128, "do");
+    t.equal(seq.value, 80, "do");
     vm.clock.seek(0);
     t.undefined(seq.value, "undo");
     vm.clock.seek(49);
-    t.equal(seq.value, 128, "redo");
+    t.equal(seq.value, 80, "redo");
 });
 
 test("Seq.dur() with unresolved duration, extended", t => {
@@ -106,9 +128,9 @@ test("Seq.dur() with unresolved duration, extended", t => {
     t.equal(seq.end, 48, "end time");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
-* 17/0 Instant
-* 17/1 Delay()
-* 48/3 [end] Seq`, "dump matches");
+* 17/1 Instant
+* 17/2 Delay()
+* 48/4 [end] Seq`, "dump matches");
 });
 
 test("Do, undo, redo: Seq.dur() with unresolved duration, extended", t => {
@@ -227,7 +249,7 @@ test("Par.dur(), cutoff child", t => {
     const vm = VM();
     const par = vm.add(Par(Seq(Delay(31), (x, t) => t * (x ?? 2)).dur(23)), 17);
     vm.clock.seek(49);
-    t.equal(par.value, [], "Child cutoff");
+    t.equal(par.value, [undefined], "Child cutoff");
 });
 
 test("Repeat.dur()", t => {
@@ -361,9 +383,9 @@ test("dur(0) still allows instants", t => {
     t.equal(seq.end, 17, "timed out");
     t.equal(seq.dump(),
 `+ 17/0 [begin] Seq
-* 17/0 Instant
-* 17/1 Delay(23)
-* 17/2 [end] Seq`, "dump matches");
+* 17/1 Instant
+* 17/2 Delay(23)
+* 17/3 [end] Seq`, "dump matches");
 });
 
         </script>


### PR DESCRIPTION
Insert a cutoff thread at the beginning of a Seq with dur so that cutting it off can resume the rest of the thread. A reschedule feature is introduced to allow cancelling the rest of the seq.