### PR TITLE
2409 Event duration within longer thread is wrong

### DIFF
--- a/lib/runtime/clock.js
+++ b/lib/runtime/clock.js
@@ -18,10 +18,11 @@ const proto = {
 
     // Stop the clock immediately.
     stop() {
-        console.assert(this.boundUpdate);
-        window.cancelAnimationFrame(this.request);
-        delete this.request;
-        delete this.boundUpdate;
+        if (this.boundUpdate) {
+            window.cancelAnimationFrame(this.request);
+            delete this.request;
+            delete this.boundUpdate;
+        }
     },
 
     // Execute the updates for a running clock.

--- a/lib/runtime/thread.js
+++ b/lib/runtime/thread.js
@@ -83,7 +83,7 @@ const threads = {
         return thread;
     },
 
-    scheduleForward(thread, t, pc, executionMode) {
+    scheduleForward(thread, t, pc = 0, executionMode = Do) {
         if (time.isDefinite(t)) {
             if (time.cmp(t, thread.end) <= 0) {
                 const scheduled = this.futureQueue.insert(extend(thread, { t, pc, executionMode }));
@@ -106,6 +106,7 @@ const threads = {
                 return false;
             }
         }
+        console.log(`--- Rescheduled thread ${thread.id} @${time.show(t)} (suspended at ${thread.suspended})`);
         delete thread.suspended;
         this.scheduleForward(thread, t, pc, Do);
         return true;

--- a/lib/runtime/thread.js
+++ b/lib/runtime/thread.js
@@ -106,7 +106,6 @@ const threads = {
                 return false;
             }
         }
-        console.log(`--- Rescheduled thread ${thread.id} @${time.show(t)} (suspended at ${thread.suspended})`);
         delete thread.suspended;
         this.scheduleForward(thread, t, pc, Do);
         return true;

--- a/lib/runtime/thread.js
+++ b/lib/runtime/thread.js
@@ -107,7 +107,7 @@ const threads = {
             }
         }
         delete thread.suspended;
-        this.scheduleForward(thread, t, pc, Do);
+        this.scheduleForward(thread, t, pc);
         return true;
     },
 

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -147,7 +147,6 @@ const proto = {
         this.yielded = true;
         // Keep track of the position at which the thread was suspended.
         thread.suspended = this.pc;
-        console.log(`>>> Suspend thread ${thread.id} @${time.show(t)}`);
         if (time.isDefinite(t)) {
             this.threads.scheduleForward(thread, t, this.pc);
         }
@@ -170,9 +169,10 @@ const proto = {
 
     // Wake a suspended thread.
     wake(thread, t) {
-        console.log(`<<< Wake thread ${thread.id} @${time.show(t)} (suspended at ${thread.suspended})`);
-        console.assert(thread.suspended >= 0);
-        this.threads.scheduleForward(thread, t ?? this.t, del(thread, "suspended"));
+        const wakeTime = t ?? this.t;
+        if (thread.suspended >= 0 && thread.suspended < wakeTime) {
+            this.threads.scheduleForward(thread, wakeTime, del(thread, "suspended"));
+        }
     },
 
     // Schedule a thread to wait for an event to occur. A notification is sent.

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -182,9 +182,8 @@ const proto = {
 
     // Wake a suspended thread.
     wake(thread, t) {
-        const wakeTime = t ?? this.t;
-        console.assert(thread.suspended >= 0 && thread.suspended < wakeTime);
-        this.threads.scheduleForward(thread, wakeTime, del(thread, "suspended"));
+        console.assert(thread.suspended >= 0);
+        this.threads.scheduleForward(thread, t ?? this.t, del(thread, "suspended"));
     },
 
     // Schedule a thread to wait for an event to occur. A notification is sent.

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -177,7 +177,7 @@ const proto = {
                     }
                 }
             }]]
-        }), this.t + dur, 0, Do);
+        }), this.t + dur);
     },
 
     // Wake a suspended thread.

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -29,7 +29,7 @@ const proto = {
         if (t < this.clock.now) {
             return;
         }
-        return this.threads.scheduleForward(generate(item, t), t, 0, Do);
+        return this.threads.scheduleForward(generate(item, t), t);
     },
 
     // Update forward or backward.
@@ -147,8 +147,9 @@ const proto = {
         this.yielded = true;
         // Keep track of the position at which the thread was suspended.
         thread.suspended = this.pc;
+        console.log(`>>> Suspend thread ${thread.id} @${time.show(t)}`);
         if (time.isDefinite(t)) {
-            this.threads.scheduleForward(thread, t, this.pc, Do);
+            this.threads.scheduleForward(thread, t, this.pc);
         }
         this.threads.scheduleBackward(thread, this.t, this.pc - 1);
     },
@@ -169,19 +170,21 @@ const proto = {
 
     // Wake a suspended thread.
     wake(thread, t) {
+        console.log(`<<< Wake thread ${thread.id} @${time.show(t)} (suspended at ${thread.suspended})`);
         console.assert(thread.suspended >= 0);
-        this.threads.scheduleForward(thread, t ?? this.t, del(thread, "suspended"), Do);
+        this.threads.scheduleForward(thread, t ?? this.t, del(thread, "suspended"));
     },
 
     // Schedule a thread to wait for an event to occur. A notification is sent.
-    listen(thread, item) {
+    listen(thread, item, dur) {
         this.schedule(thread, time.unresolved);
-        const t = this.t;
+        const begin = this.t;
+        const end = time.add(begin, dur);
         const pc = this.pc;
         let done = false;
         const handler = event => {
             const now = this.clock.now;
-            if (time.cmp(now, thread.end) <= 0) {
+            if (time.cmp(now, end) <= 0) {
                 console.assert(done === false);
                 done = true;
                 item.target.removeEventListener(item.type, handler);
@@ -195,25 +198,25 @@ const proto = {
                     event.stopPropagation();
                 }
                 thread.value = event;
-                this.wake(thread, time.isResolved(thread.end) ? thread.end : now);
+                this.wake(thread, time.isResolved(end) ? end : now);
             }
             notify(this, "event", { thread, event });
         };
-        if (time.isDefinite(thread.end)) {
+        if (time.isDefinite(end)) {
             // Set a timeout thread
             const timeout = Object.assign(Thread(), {
-                begin: t,
-                end: thread.end,
+                begin,
+                end,
                 ops: [[() => {
                     if (!done) {
                         done = true;
                         item.target.removeEventListener(item.type, handler);
                         thread.value = Timeout;
-                        this.threads.scheduleForward(thread, thread.end, pc, Do);
+                        this.threads.scheduleForward(thread, end, pc);
                     }
                 }]]
             });
-            this.threads.scheduleForward(timeout, thread.end, 0, Do);
+            this.threads.scheduleForward(timeout, end);
         }
         item.target.addEventListener(item.type, handler);
     },
@@ -237,11 +240,11 @@ const proto = {
                     if (!done) {
                         done = true;
                         thread.value = Timeout;
-                        this.threads.scheduleForward(thread, thread.end, pc, Do);
+                        this.threads.scheduleForward(thread, thread.end, pc);
                     }
                 }]]
             });
-            this.threads.scheduleForward(timeout, thread.end, 0, Do);
+            this.threads.scheduleForward(timeout, thread.end);
         }
         promise.then(value => {
             const now = this.clock.now;

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -1,5 +1,5 @@
-import { notify, on } from "../events.js";
-import { create, del, nop } from "../util.js";
+import { notify, off, on } from "../events.js";
+import { add, create, del, nop } from "../util.js";
 import { Clock } from "./clock.js";
 import { generate, Thread, Threads, Do, Undo, Redo } from "./thread.js";
 import * as time from "../timing/time.js";
@@ -14,12 +14,25 @@ const proto = {
         this.threads = Threads();
         this.clock = Clock();
         on(this.clock, "update", this);
+        this.listeners = new Set();
     },
 
     // Start the clock and return self.
     start() {
         this.clock.start();
         return this;
+    },
+
+    // Stop completely, clearing remaining event listeners.
+    shutdown() {
+        off(this.clock, "update", this);
+        this.clock.stop();
+        delete this.clock;
+        delete this.threads;
+        for (const [item, handler] of this.listeners) {
+            item.target.removeEventListener(item.type, handler);
+        }
+        delete this.listeners;
     },
 
     // Schedule a thread for a new item, now by default or at a later time.
@@ -170,9 +183,8 @@ const proto = {
     // Wake a suspended thread.
     wake(thread, t) {
         const wakeTime = t ?? this.t;
-        if (thread.suspended >= 0 && thread.suspended < wakeTime) {
-            this.threads.scheduleForward(thread, wakeTime, del(thread, "suspended"));
-        }
+        console.assert(thread.suspended >= 0 && thread.suspended < wakeTime);
+        this.threads.scheduleForward(thread, wakeTime, del(thread, "suspended"));
     },
 
     // Schedule a thread to wait for an event to occur. A notification is sent.
@@ -187,7 +199,8 @@ const proto = {
             if (time.cmp(now, end) <= 0) {
                 console.assert(done === false);
                 done = true;
-                item.target.removeEventListener(item.type, handler);
+                item.target.removeEventListener(item, handler);
+                this.listeners.delete(listener);
                 if (item.modifiers?.preventDefault) {
                     event.preventDefault();
                 }
@@ -202,6 +215,7 @@ const proto = {
             }
             notify(this, "event", { thread, event });
         };
+        const listener = add(this.listeners, [item, handler]);
         if (time.isDefinite(end)) {
             // Set a timeout thread
             const timeout = Object.assign(Thread(), {

--- a/lib/timing/event.js
+++ b/lib/timing/event.js
@@ -20,8 +20,9 @@ const proto = {
     // Listen to the event and wait for it to occur.
     generate(thread, t) {
         thread.timeline.push(extend(this, { pc: thread.ops.length, t }));
+        const dur = this.modifiers?.dur ?? time.unresolved;
         thread.ops.push([
-            (thread, vm) => { vm.listen(thread, this); },
+            (thread, vm) => { vm.listen(thread, this, dur); },
             (thread, vm) => {
                 thread.undo();
                 vm.yield(thread);
@@ -31,8 +32,7 @@ const proto = {
                 vm.yield(thread);
             }
         ]);
-        const end = time.add(t, this.modifiers?.dur ?? time.unresolved);
-        return end;
+        return time.add(t, dur);
     }
 };
 

--- a/tests/timing/event.html
+++ b/tests/timing/event.html
@@ -35,6 +35,7 @@ test("Code generation", t => {
     t.equal(event.value, e, "thread value");
     t.equal(e.defaultPrevented, false, "default not prevented");
     t.equal(event.dump(), "+ 17/0 Event(synth)", "dump matches");
+    vm.shutdown();
 });
 
 test("Do, undo, redo", t => {
@@ -50,6 +51,7 @@ test("Do, undo, redo", t => {
     t.undefined(item.value, "undo");
     vm.clock.seek(19);
     t.equal(item.value, e, "redo");
+    vm.shutdown();
 });
 
 test("Event in par", t => {
@@ -67,6 +69,7 @@ test("Event in par", t => {
     window.dispatchEvent(e);
     vm.clock.seek(41);
     t.equal(par.value, [window, "ok", "later"], "end value");
+    vm.shutdown();
 });
 
 test("Event().preventDefault()", t => {
@@ -78,6 +81,7 @@ test("Event().preventDefault()", t => {
     vm.clock.seek(19);
     t.equal(event.value, e, "thread value");
     t.equal(e.defaultPrevented, true, "default prevented");
+    vm.shutdown();
 });
 
 test("Event().stopImmediatePropagation()", t => {
@@ -90,6 +94,7 @@ test("Event().stopImmediatePropagation()", t => {
     document.body.dispatchEvent(new window.Event("synth", { bubbles: true }));
     vm.clock.seek(19);
     t.undefined(par.value, "thread value");
+    vm.shutdown();
 });
 
 test("Event bubbling", t => {
@@ -103,6 +108,7 @@ test("Event bubbling", t => {
     document.body.dispatchEvent(e);
     vm.clock.seek(19);
     t.equal(par.value, [e, e], "thread value");
+    vm.shutdown();
 });
 
 test("Event().stopPropagation()", t => {
@@ -115,6 +121,7 @@ test("Event().stopPropagation()", t => {
     document.body.dispatchEvent(new window.Event("synth", { bubbles: true }));
     vm.clock.seek(19);
     t.undefined(par.value, "thread value");
+    vm.shutdown();
 });
 
 test("Event within a longer thread", t => {
@@ -124,6 +131,7 @@ test("Event within a longer thread", t => {
     window.dispatchEvent(new window.Event("synth"));
     vm.clock.seek(41);
     t.equal(seq.value, "ok!", "end value");
+    vm.shutdown();
 });
 
 test("Event within a longer thread (timeout)", t => {
@@ -131,6 +139,7 @@ test("Event within a longer thread (timeout)", t => {
     const seq = vm.add(Seq(Seq(K("ko"), Event(window, "synth"), K("ok")).dur(23), x => x + "!"), 17);
     vm.clock.seek(41);
     t.equal(seq.value, "ko!", "end value");
+    vm.shutdown();
 });
 
         </script>

--- a/tests/timing/event.html
+++ b/tests/timing/event.html
@@ -117,6 +117,22 @@ test("Event().stopPropagation()", t => {
     t.undefined(par.value, "thread value");
 });
 
+test("Event within a longer thread", t => {
+    const vm = VM();
+    const seq = vm.add(Seq(Seq(Event(window, "synth"), K("ok")).dur(23), x => x + "!"), 17);
+    vm.clock.seek(31);
+    window.dispatchEvent(new window.Event("synth"));
+    vm.clock.seek(41);
+    t.equal(seq.value, "ok!", "end value");
+});
+
+test("Event within a longer thread (timeout)", t => {
+    const vm = VM();
+    const seq = vm.add(Seq(Seq(K("ko"), Event(window, "synth"), K("ok")).dur(23), x => x + "!"), 17);
+    vm.clock.seek(41);
+    t.equal(seq.value, "ko!", "end value");
+});
+
         </script>
     </head>
     <body>


### PR DESCRIPTION
Make the event listener aware of the duration of the event to know when the end of the event occurs (rather than the end of the thread). Some assertions were failing in the test file because of stale event listeners, so the VM has a shutdown() method to stop listening to events.