### PR TITLE
2102 Topological sort for correct queue priority

### DIFF
--- a/lib/runtime/thread.js
+++ b/lib/runtime/thread.js
@@ -63,8 +63,8 @@ export const Thread = () => extend(thread, { id: ID++, ops: [], timeline: [], va
 
 const threads = {
     init() {
-        this.futureQueue = Queue((a, b) => time.cmp(a.t, b.t) || b.item.order - a.item.order);
-        this.pastQueue = Queue((a, b) => time.cmp(b.t, a.t) || a.item.order - b.item.order);
+        this.futureQueue = Queue((a, b) => time.cmp(a.t, b.t) || (order(b) - order(a)));
+        this.pastQueue = Queue((a, b) => time.cmp(b.t, a.t) || (order(a) - order(b)));
         this.schedule = new Map();
     },
 
@@ -127,5 +127,7 @@ const threads = {
         return this.pastQueue.insert(extend(thread, { t, pc }));
     }
 };
+
+const order = thread => thread.item?.order ?? thread.order;
 
 export const Threads = () => create().call(threads);

--- a/lib/runtime/thread.js
+++ b/lib/runtime/thread.js
@@ -7,9 +7,12 @@ import * as time from "../timing/time.js";
 export const [Do, Undo, Redo] = [0, 1, 2];
 
 // Generate a thread for an item, setting its begin/end.
-export function generate(item, begin) {
-    const thread = Object.assign(Thread(), { begin });
-    thread.end = item.generate(thread, begin);
+export function generate(item, begin, items) {
+    if (!items.has(item)) {
+        items.set(item, [new Set(), new Set()]);
+    }
+    const thread = Object.assign(Thread(), { item, begin });
+    thread.end = item.generate(thread, begin, items);
     return thread;
 }
 
@@ -60,8 +63,8 @@ export const Thread = () => extend(thread, { id: ID++, ops: [], timeline: [], va
 
 const threads = {
     init() {
-        this.futureQueue = Queue((a, b) => time.cmp(a.t, b.t));
-        this.pastQueue = Queue((a, b) => time.cmp(b.t, a.t));
+        this.futureQueue = Queue((a, b) => time.cmp(a.t, b.t) || b.item.order - a.item.order);
+        this.pastQueue = Queue((a, b) => time.cmp(b.t, a.t) || a.item.order - b.item.order);
         this.schedule = new Map();
     },
 

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -1,5 +1,5 @@
 import { notify, off, on } from "../events.js";
-import { add, create, del, nop } from "../util.js";
+import { add, create, del, foldit, nop } from "../util.js";
 import { Clock } from "./clock.js";
 import { generate, Thread, Threads, Do, Undo, Redo } from "./thread.js";
 import * as time from "../timing/time.js";
@@ -15,6 +15,9 @@ const proto = {
         this.clock = Clock();
         on(this.clock, "update", this);
         this.listeners = new Set();
+
+        // Graph representation: map each item to [incoming, outgoing, order]
+        this.items = new Map();
     },
 
     // Start the clock and return self.
@@ -33,6 +36,8 @@ const proto = {
             item.target.removeEventListener(item.type, handler);
         }
         delete this.listeners;
+        delete this.inputs;
+        delete this.items;
     },
 
     // Schedule a thread for a new item, now by default or at a later time.
@@ -42,7 +47,39 @@ const proto = {
         if (t < this.clock.now) {
             return;
         }
-        return this.threads.scheduleForward(generate(item, t), t);
+        const thread = this.threads.scheduleForward(generate(item, t, this.items), t);
+        this.sortGraph();
+        return thread;
+    },
+
+    // Sort items in topological order.
+    sortGraph() {
+        const items = foldit(this.items.entries(), (items, [item, [incoming]]) => {
+            if (incoming.size === 0) {
+                item.order = items.length;
+                items.push(item);
+            }
+            return items;
+        }, []);
+        const sorted = new Set(items);
+        const seen = new Set();
+        const queue = items.slice();
+        while (queue.length > 0) {
+            const item = queue.shift();
+            if (seen.has(item)) {
+                throw new window.Error("Cycle detected");
+            }
+            seen.add(item);
+            for (const it of this.items.get(item)[1]) {
+                if ([...this.items.get(it)[0]].every(i => sorted.has(i))) {
+                    item.order = items.length;
+                    sorted.add(it);
+                    items.push(it);
+                }
+                queue.push(it);
+            }
+        }
+        console.log(items);
     },
 
     // Update forward or backward.

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -207,7 +207,7 @@ const proto = {
     // [from, to] range of ops.
     cutoff(thread, dur, from, to) {
         this.threads.scheduleForward(Object.assign(Thread(), {
-            item: { order: Infinity },
+            item: thread.item,
             ops: [[(_, vm) => {
                 if (this.threads.didReschedule(thread, vm.t, to, Do)) {
                     for (let i = from; i < to; ++i) {
@@ -255,7 +255,7 @@ const proto = {
         if (time.isDefinite(end)) {
             // Set a timeout thread
             const timeout = Object.assign(Thread(), {
-                item: { order: Infinity },
+                item,
                 begin,
                 end,
                 ops: [[() => {
@@ -284,7 +284,7 @@ const proto = {
         if (time.isDefinite(thread.end)) {
             // Set a timeout thread
             const timeout = Object.assign(Thread(), {
-                item: { order: Infinity },
+                item: thread.item,
                 begin: t,
                 end: thread.end,
                 ops: [[() => {

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -207,6 +207,7 @@ const proto = {
     // [from, to] range of ops.
     cutoff(thread, dur, from, to) {
         this.threads.scheduleForward(Object.assign(Thread(), {
+            item: { order: Infinity },
             ops: [[(_, vm) => {
                 if (this.threads.didReschedule(thread, vm.t, to, Do)) {
                     for (let i = from; i < to; ++i) {
@@ -254,6 +255,7 @@ const proto = {
         if (time.isDefinite(end)) {
             // Set a timeout thread
             const timeout = Object.assign(Thread(), {
+                item: { order: Infinity },
                 begin,
                 end,
                 ops: [[() => {
@@ -282,6 +284,7 @@ const proto = {
         if (time.isDefinite(thread.end)) {
             // Set a timeout thread
             const timeout = Object.assign(Thread(), {
+                item: { order: Infinity },
                 begin: t,
                 end: thread.end,
                 ops: [[() => {

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -79,7 +79,6 @@ const proto = {
                 queue.push(it);
             }
         }
-        console.log(items);
     },
 
     // Update forward or backward.
@@ -207,7 +206,7 @@ const proto = {
     // [from, to] range of ops.
     cutoff(thread, dur, from, to) {
         this.threads.scheduleForward(Object.assign(Thread(), {
-            item: thread.item,
+            order: thread.item.order + 0.5,
             ops: [[(_, vm) => {
                 if (this.threads.didReschedule(thread, vm.t, to, Do)) {
                     for (let i = from; i < to; ++i) {
@@ -255,7 +254,7 @@ const proto = {
         if (time.isDefinite(end)) {
             // Set a timeout thread
             const timeout = Object.assign(Thread(), {
-                item,
+                order: thread.item.order + 0.5,
                 begin,
                 end,
                 ops: [[() => {
@@ -284,7 +283,7 @@ const proto = {
         if (time.isDefinite(thread.end)) {
             // Set a timeout thread
             const timeout = Object.assign(Thread(), {
-                item: thread.item,
+                order: thread.item.order + 0.5,
                 begin: t,
                 end: thread.end,
                 ops: [[() => {

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -72,7 +72,7 @@ const proto = {
             seen.add(item);
             for (const it of this.items.get(item)[1]) {
                 if ([...this.items.get(it)[0]].every(i => sorted.has(i))) {
-                    item.order = items.length;
+                    it.order = items.length;
                     sorted.add(it);
                     items.push(it);
                 }

--- a/lib/timing/par.js
+++ b/lib/timing/par.js
@@ -10,7 +10,7 @@ const proto = {
     dur,
     take,
 
-    generate(thread, t) {
+    generate(thread, t, items) {
         thread.timeline.push(extend(this, { begin: true, pc: thread.ops.length, t }));
         const isNamed = !Array.isArray(this.children);
         const childCount = isNamed ? values(this.children).length : this.children.length;
@@ -35,12 +35,16 @@ const proto = {
         const takeSome = this.modifiers?.take < childCount;
         if (!takeNone) {
             const takeAny = this.modifiers?.take >= 0;
+            const outgoing = items.get(this)[1];
 
             // Generate threads for children and track the maximum end time.
             // When a thread ends, it pushes its value to the accumulator.
 
-            function generateChild(t, child, accumulate) {
-                const childThread = push(thread.ops, generate(wrap(child), begin));
+            const generateChild = (t, child, accumulate) => {
+                const childItem = wrap(child);
+                outgoing.add(childItem);
+                const childThread = push(thread.ops, generate(childItem, begin, items));
+                items.get(childItem)[0].add(this);
                 children.add(childThread);
                 t = time.max(t, childThread.end);
                 const op = [accumulate, nop, nop];
@@ -59,7 +63,7 @@ const proto = {
                 childThread.ops.push(op);
                 thread.timeline.push(childThread);
                 return t;
-            }
+            };
 
             function childThreadIsDone(vm, diff) {
                 if (takeSome && diff === 1) {

--- a/lib/timing/repeat.js
+++ b/lib/timing/repeat.js
@@ -16,13 +16,19 @@ const proto = {
     // Generate code for the child and add a jump back to the beginning at the
     // end. In order to rewind, also add a jump forward to the end at the
     // beginning when going backward.
-    generate(thread, t) {
+    generate(thread, t, items) {
         const pc = thread.ops.length;
         const jump = [nop, nop, nop];
         thread.ops.push(jump);
         thread.timeline.push(extend(this, { begin: true, pc, t }));
         const end = t + (this.modifiers?.dur ?? Infinity);
-        if (wrap(this.child).generate(thread, t) === t) {
+        const childItem = wrap(this.child);
+        if (!items.has(childItem)) {
+            items.set(childItem, [new Set(), new Set()]);
+        }
+        items.get(this)[1].add(childItem);
+        items.get(childItem)[0].add(this);
+        if (childItem.generate(thread, t, items) === t) {
             throw new Error("cannot repeat a zero-duration child", this.child);
         }
         thread.ops.push([

--- a/lib/timing/seq.js
+++ b/lib/timing/seq.js
@@ -10,7 +10,7 @@ const proto = {
 
     // Generate code for the children, keeping track of time along the way. Set
     // the end if the dur modifier is set.
-    generate(thread, t) {
+    generate(thread, t, items) {
         const pc = thread.ops.length;
         thread.timeline.push(extend(this, { begin: true, pc, t }));
         const dur = this.modifiers?.dur;
@@ -19,8 +19,15 @@ const proto = {
             // Reserve space for the cutoff thread.
             thread.ops.push([nop, nop, nop]);
         }
+        const outgoing = items.get(this)[1];
         for (const child of this.children) {
-            t = wrap(child).generate(thread, t);
+            const childItem = wrap(child);
+            outgoing.add(childItem);
+            if (!items.has(childItem)) {
+                items.set(childItem, [new Set(), new Set()]);
+            }
+            items.get(childItem)[0].add(this);
+            t = childItem.generate(thread, t, items);
         }
         // A delay may be needed to ensure that the duration is extended.
         if (time.isDefinite(end)) {

--- a/tests/runtime/vm.html
+++ b/tests/runtime/vm.html
@@ -7,6 +7,7 @@
         <script type="module">
 
 import { test } from "../test.js";
+import { K } from "../../lib/util.js";
 import { notification } from "../../lib/events.js";
 import { VM } from "../../lib/runtime.js";
 import { Par, Seq, Delay } from "../../lib/timing.js";
@@ -47,6 +48,16 @@ test("Threading", t => {
     ), 17);
     vm.clock.seek(35);
     t.equal(out, ["A", "B", "C", "D", "E", "F"], "execution order");
+});
+
+test("Queuing order", t => {
+    const vm = VM();
+    const seq = vm.add(Seq(
+        Par(K("ok"), Seq(Delay(23), K("later"))),
+        vs => vs.join(" ")
+    ), 17);
+    vm.clock.seek(41);
+    t.equal(seq.value, "ok later", "end value");
 });
 
         </script>

--- a/tests/runtime/vm.html
+++ b/tests/runtime/vm.html
@@ -50,10 +50,20 @@ test("Threading", t => {
     t.equal(out, ["A", "B", "C", "D", "E", "F"], "execution order");
 });
 
-test("Queuing order", t => {
+test("Topological sort", t => {
     const vm = VM();
     const seq = vm.add(Seq(
         Par(K("ok"), Seq(Delay(23), K("later"))),
+        vs => vs.join(" ")
+    ), 17);
+    vm.clock.seek(41);
+    t.equal(seq.value, "ok later", "end value");
+});
+
+test("Thread cutoff", t => {
+    const vm = VM();
+    const seq = vm.add(Seq(
+        Par(K("ok"), Seq(Delay(23), K("later"))).dur(23),
         vs => vs.join(" ")
     ), 17);
     vm.clock.seek(41);

--- a/tests/runtime/vm.html
+++ b/tests/runtime/vm.html
@@ -63,11 +63,11 @@ test("Topological sort", t => {
 test("Thread cutoff", t => {
     const vm = VM();
     const seq = vm.add(Seq(
-        Par(K("ok"), Seq(Delay(23), K("later"))).dur(23),
+        Par(K("ok"), Seq(K(23), Delay())),
         vs => vs.join(" ")
-    ), 17);
+    ).dur(23), 17);
     vm.clock.seek(41);
-    t.equal(seq.value, "ok later", "end value");
+    t.equal(seq.value, "ok 23", "end value");
 });
 
         </script>


### PR DESCRIPTION
When an item is add()ed to the VM, sort all items in topological order (also detecting cycles, which cannot be introduced yet anyway). The order is then used as a tie-breaker when queuing threads at the same time, making sure that a parent does not end before its children. Cutoff and timeout threads have the same order as the thread that they are interrupting with a 0.5 shift to allow the thread to end normally when it reaches its maximum duration exactly.