### PR TITLE
240C Sub threads of Repeat do not repeat

### DIFF
--- a/lib/runtime/thread.js
+++ b/lib/runtime/thread.js
@@ -46,6 +46,11 @@ const thread = {
         }
     },
 
+    // Convenience function to push an op that has no undo or redo.
+    do(op) {
+        this.ops.push([op, nop, nop]);
+    },
+
     dump(indent = "* ") {
         return this.timeline.map(
             (item, i) => item.tag ? `${i === 0 ? indent.replace(/\*/, "+") : indent}${

--- a/lib/runtime/thread.js
+++ b/lib/runtime/thread.js
@@ -1,4 +1,4 @@
-import { create, extend, nop } from "../util.js";
+import { create, del, extend, nop } from "../util.js";
 import { Queue } from "../priority-queue.js";
 import * as time from "../timing/time.js";
 
@@ -98,6 +98,18 @@ const threads = {
         return thread;
     },
 
+    // Wake a thread at time t unless it is already scheduled.
+    wake(thread, t) {
+        console.assert(thread.suspended >= 0);
+        if (this.schedule.has(thread)) {
+            const scheduled = this.schedule.get(thread);
+            console.assert(scheduled.t === t);
+            console.assert(scheduled.pc === thread.suspended);
+        } else {
+            this.scheduleForward(thread, t, del(thread, "suspended"));
+        }
+    },
+
     // Attempt to reschedule a thread if it is scheduled for a later time.
     didReschedule(thread, t, pc) {
         if (this.schedule.has(thread)) {
@@ -138,7 +150,8 @@ export function spawn(childThread, t) {
             t = time.add(entry.t, offset);
             return extend(entry, { t });
         });
-        const spawnedThread = extend(thread, {
+        console.assert(childThread.item);
+        return extend(thread, {
             id: childThread.id,
             subid: childThread.subid + 1,
             item: childThread.item,
@@ -149,8 +162,6 @@ export function spawn(childThread, t) {
             begin,
             end: t
         });
-        console.assert(spawnedThread.item);
-        return spawnedThread;
     }
     childThread.subid = 0;
     return childThread;

--- a/lib/runtime/thread.js
+++ b/lib/runtime/thread.js
@@ -61,6 +61,30 @@ let ID = 0;
 
 export const Thread = () => extend(thread, { id: ID++, ops: [], timeline: [], values: [], vp: 0 });
 
+export function spawn(childThread, t) {
+    if (childThread.subid >= 0) {
+        const begin = t;
+        const offset = begin - childThread.begin;
+        const timeline = childThread.timeline.map(entry => {
+            t = time.add(entry.t, offset);
+            return extend(entry, { t });
+        });
+        const spawnedThread = extend(thread, {
+            id: childThread.id, 
+            subid: childThread.subid + 1,
+            ops: childThread.ops,
+            timeline,
+            values: [],
+            vp: 0,
+            begin,
+            end: t
+        });
+        return spawnedThread;
+    }
+    childThread.subid = 0;
+    return childThread;
+}
+
 const threads = {
     init() {
         this.futureQueue = Queue((a, b) => time.cmp(a.t, b.t) || (order(b) - order(a)));

--- a/lib/runtime/thread.js
+++ b/lib/runtime/thread.js
@@ -61,30 +61,6 @@ let ID = 0;
 
 export const Thread = () => extend(thread, { id: ID++, ops: [], timeline: [], values: [], vp: 0 });
 
-export function spawn(childThread, t) {
-    if (childThread.subid >= 0) {
-        const begin = t;
-        const offset = begin - childThread.begin;
-        const timeline = childThread.timeline.map(entry => {
-            t = time.add(entry.t, offset);
-            return extend(entry, { t });
-        });
-        const spawnedThread = extend(thread, {
-            id: childThread.id, 
-            subid: childThread.subid + 1,
-            ops: childThread.ops,
-            timeline,
-            values: [],
-            vp: 0,
-            begin,
-            end: t
-        });
-        return spawnedThread;
-    }
-    childThread.subid = 0;
-    return childThread;
-}
-
 const threads = {
     init() {
         this.futureQueue = Queue((a, b) => time.cmp(a.t, b.t) || (order(b) - order(a)));
@@ -153,5 +129,31 @@ const threads = {
 };
 
 const order = thread => thread.item?.order ?? thread.order;
+
+export function spawn(childThread, t) {
+    if (childThread.subid >= 0) {
+        const begin = t;
+        const offset = begin - childThread.begin;
+        const timeline = childThread.timeline.map(entry => {
+            t = time.add(entry.t, offset);
+            return extend(entry, { t });
+        });
+        const spawnedThread = extend(thread, {
+            id: childThread.id,
+            subid: childThread.subid + 1,
+            item: childThread.item,
+            ops: childThread.ops,
+            timeline,
+            values: [],
+            vp: 0,
+            begin,
+            end: t
+        });
+        console.assert(spawnedThread.item);
+        return spawnedThread;
+    }
+    childThread.subid = 0;
+    return childThread;
+}
 
 export const Threads = () => create().call(threads);

--- a/lib/runtime/thread.js
+++ b/lib/runtime/thread.js
@@ -165,7 +165,7 @@ export function spawn(childThread, t) {
             values: [],
             vp: 0,
             begin,
-            end: t
+            end: time.add(offset, childThread.end)
         });
     }
     childThread.subid = 0;

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -1,5 +1,5 @@
 import { notify, off, on } from "../events.js";
-import { add, create, foldit, nop } from "../util.js";
+import { add, create, everyof, foldit, nop } from "../util.js";
 import { Clock } from "./clock.js";
 import { generate, spawn, Thread, Threads, Do, Undo, Redo } from "./thread.js";
 import * as time from "../timing/time.js";
@@ -71,7 +71,7 @@ const proto = {
             }
             seen.add(item);
             for (const it of this.items.get(item)[1]) {
-                if ([...this.items.get(it)[0]].every(i => sorted.has(i))) {
+                if (everyof(this.items.get(it)[0], i => sorted.has(i))) {
                     it.order = items.length;
                     sorted.add(it);
                     items.push(it);

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -104,7 +104,6 @@ const proto = {
                 continue;
             }
             this.t = thread.t;
-            console.log(`=== ${thread.id}${thread.subid >= 0 ? `_${thread.subid}` : ""} @${this.t}/${thread.item?.order ?? thread.order}`);
             this.pc = thread.pc;
             this.runForward(Object.getPrototypeOf(thread), thread.executionMode);
         }
@@ -129,7 +128,9 @@ const proto = {
                     console.warn(error.message ?? "Error", error);
                 }
             } else if (executionMode === Do) {
-                childThreads.push(spawn(op, this.t));
+                const childThread = spawn(op, this.t);
+                childThreads.push(childThread);
+                thread.parState.children.add(childThread);
             }
         }
 
@@ -198,7 +199,6 @@ const proto = {
         this.yielded = true;
         // Keep track of the position at which the thread was suspended.
         thread.suspended = this.pc;
-        console.log(`... schedule ${thread.id}${thread.subid >= 0 ? `_${thread.subid}` : ""} @${t}/${thread.item?.order ?? thread.order}`);
         if (time.isDefinite(t)) {
             this.threads.scheduleForward(thread, t, this.pc);
         }

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -1,7 +1,7 @@
 import { notify, off, on } from "../events.js";
 import { add, create, del, foldit, nop } from "../util.js";
 import { Clock } from "./clock.js";
-import { generate, Thread, Threads, Do, Undo, Redo } from "./thread.js";
+import { generate, spawn, Thread, Threads, Do, Undo, Redo } from "./thread.js";
 import * as time from "../timing/time.js";
 
 // Unique value for timeouts.
@@ -104,6 +104,7 @@ const proto = {
                 continue;
             }
             this.t = thread.t;
+            console.log(`=== ${thread.id}${thread.subid >= 0 ? `_${thread.subid}` : ""} @${this.t}`);
             this.pc = thread.pc;
             this.runForward(Object.getPrototypeOf(thread), thread.executionMode);
         }
@@ -128,7 +129,7 @@ const proto = {
                     console.warn(error.message ?? "Error", error);
                 }
             } else if (executionMode === Do) {
-                childThreads.push(op);
+                childThreads.push(spawn(op, this.t));
             }
         }
 
@@ -147,6 +148,7 @@ const proto = {
             }
         }
 
+        // Spawn child threads.
         for (const childThread of childThreads) {
             childThread.value = thread.value;
             this.pc = 0;
@@ -196,6 +198,7 @@ const proto = {
         this.yielded = true;
         // Keep track of the position at which the thread was suspended.
         thread.suspended = this.pc;
+        console.log(`... schedule ${thread.id}${thread.subid >= 0 ? `_${thread.subid}` : ""} @${t}`);
         if (time.isDefinite(t)) {
             this.threads.scheduleForward(thread, t, this.pc);
         }

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -1,5 +1,5 @@
 import { notify, off, on } from "../events.js";
-import { add, create, del, foldit, nop } from "../util.js";
+import { add, create, foldit, nop } from "../util.js";
 import { Clock } from "./clock.js";
 import { generate, spawn, Thread, Threads, Do, Undo, Redo } from "./thread.js";
 import * as time from "../timing/time.js";
@@ -104,7 +104,7 @@ const proto = {
                 continue;
             }
             this.t = thread.t;
-            console.log(`=== ${thread.id}${thread.subid >= 0 ? `_${thread.subid}` : ""} @${this.t}`);
+            console.log(`=== ${thread.id}${thread.subid >= 0 ? `_${thread.subid}` : ""} @${this.t}/${thread.item?.order ?? thread.order}`);
             this.pc = thread.pc;
             this.runForward(Object.getPrototypeOf(thread), thread.executionMode);
         }
@@ -222,8 +222,7 @@ const proto = {
 
     // Wake a suspended thread.
     wake(thread, t) {
-        console.assert(thread.suspended >= 0);
-        this.threads.scheduleForward(thread, t ?? this.t, del(thread, "suspended"));
+        this.threads.wake(thread, t ?? this.t);
     },
 
     // Schedule a thread to wait for an event to occur. A notification is sent.

--- a/lib/runtime/vm.js
+++ b/lib/runtime/vm.js
@@ -198,7 +198,7 @@ const proto = {
         this.yielded = true;
         // Keep track of the position at which the thread was suspended.
         thread.suspended = this.pc;
-        console.log(`... schedule ${thread.id}${thread.subid >= 0 ? `_${thread.subid}` : ""} @${t}`);
+        console.log(`... schedule ${thread.id}${thread.subid >= 0 ? `_${thread.subid}` : ""} @${t}/${thread.item?.order ?? thread.order}`);
         if (time.isDefinite(t)) {
             this.threads.scheduleForward(thread, t, this.pc);
         }

--- a/lib/timing/par.js
+++ b/lib/timing/par.js
@@ -20,6 +20,7 @@ const proto = {
         const hasDur = time.isResolved(dur);
         const end = time.add(t, dur);
         const children = new Set();
+        const acc = () => isNamed ? {} : [];
 
         // Check that we have enough children to take.
         const hasDefiniteTake = Number.isFinite(this.modifiers?.take);
@@ -120,7 +121,7 @@ const proto = {
                 const parDur = hasDur ? dur : time.isDefinite(t) ? t - begin : t;
                 thread.ops.push([
                     (thread, vm) => {
-                        thread.accumulator = isNamed ? {} : [];
+                        thread.accumulator = acc();
                         vm.schedule(thread, vm.t + parDur);
                     },
                     (thread, vm) => { vm.yield(thread); },
@@ -131,8 +132,8 @@ const proto = {
 
         // Set the value of the thread as that of the accumulator.
         const value = this.tag === "Par" ?
-            thread => { thread.value = del(thread, "accumulator"); } :
-            thread => { thread.value = single(del(thread, "accumulator")); };
+            thread => { thread.value = del(thread, "accumulator") ?? acc(); } :
+            thread => { thread.value = single(del(thread, "accumulator")) ?? acc(); };
         thread.ops.push([
             value,
             thread => { thread.undo(); },

--- a/lib/timing/par.js
+++ b/lib/timing/par.js
@@ -1,4 +1,4 @@
-import { del, extend, foldit, isObject, K, nop, push, single, values } from "../util.js";
+import { del, extend, foldit, isObject, K, push, single, values } from "../util.js";
 import { generate } from "../runtime/thread.js";
 import { wrap } from "./instant.js";
 import { dur, take } from "./util.js";
@@ -10,17 +10,13 @@ const proto = {
     dur,
     take,
 
+    // Generate code for the children, creating a child thread for each. When
+    // the par begins, some state is initialized to keep track of the results,
+    // then wait for all children to finish and update the value at the end.
     generate(thread, t, items) {
         thread.timeline.push(extend(this, { begin: true, pc: thread.ops.length, t }));
         const isNamed = !Array.isArray(this.children);
         const childCount = isNamed ? values(this.children).length : this.children.length;
-        let unresolved = 0;
-        const begin = t;
-        const dur = this.modifiers?.dur ?? time.unresolved;
-        const hasDur = time.isResolved(dur);
-        const end = time.add(t, dur);
-        const children = new Set();
-        const acc = () => isNamed ? {} : [];
 
         // Check that we have enough children to take.
         const hasDefiniteTake = Number.isFinite(this.modifiers?.take);
@@ -32,10 +28,29 @@ const proto = {
             })`);
         }
 
+        const begin = t;
+        const dur = this.modifiers?.dur ?? time.unresolved;
+        const hasDur = time.isResolved(dur);
+        const end = time.add(t, dur);
         const takeNone = this.modifiers?.take === 0;
         const takeSome = this.modifiers?.take < childCount;
-        if (!takeNone) {
+        const children = [];
+        const empty = takeNone || childCount === 0;
+
+        // Initialize state for this iteration of the par.
+        thread.do(thread => {
+            thread.parState = {
+                accumulator: isNamed ? {} : [],
+                children: new Set(children),
+                initialValue: thread.value,
+                complete: empty
+            };
+        });
+
+        // Create subthreads for children (if any).
+        if (!empty) {
             const takeAny = this.modifiers?.take >= 0;
+            const targetCount = hasDefiniteTake ? this.modifiers.take : childCount;
             const outgoing = items.get(this)[1];
 
             // Generate threads for children and track the maximum end time.
@@ -46,107 +61,73 @@ const proto = {
                 outgoing.add(childItem);
                 const childThread = push(thread.ops, generate(childItem, begin, items));
                 items.get(childItem)[0].add(this);
-                children.add(childThread);
                 t = time.max(t, childThread.end);
-                const op = [accumulate, nop, nop];
-                if (time.isUnresolved(childThread.end)) {
-                    unresolved += 1;
-                    op[0] = (childThread, vm) => {
-                        accumulate(childThread, vm);
-                        if (--unresolved === 0 && (!takeSome || children.size === 0)) {
-                            // No more unresolved children, so we can tell when
-                            // to wake the parent thread (unless we are in a
-                            // take and some children are left).
-                            vm.wake(thread, foldit(
-                                children.values(),
-                                (max, child) => time.max(max, child.end),
-                                vm.t
-                            ));
+                childThread.do((childThread, vm) => {
+                    accumulate(childThread);
+                    thread.parState.children.delete(childThread);
+                    if (childCount - thread.parState.children.size === targetCount) {
+                        // When enough children have ended, the parent thread
+                        // can be awakened, and the remaining child threads are
+                        // cancelled.
+                        thread.parState.complete = true;
+                        vm.wake(thread, hasDur ? end : vm.t);
+                        for (const child of thread.parState.children) {
+                            child.cancel();
                         }
-                    };
-                }
-                if (time.cmp(childThread.end, end) > 0) {
-                    childThread.end = end;
-                }
-                childThread.ops.push(op);
+                        thread.parState.children.clear();
+                    }
+                });
                 thread.timeline.push(childThread);
+                children.push(childThread);
                 return t;
             };
-
-            function childThreadIsDone(vm, diff) {
-                if (takeSome && diff === 1) {
-                    // The last item was added to the accumulator so the par is
-                    // done and the rest of the children will be cancelled.
-                    vm.wake(thread, hasDur ? end : vm.t);
-                    for (const child of children) {
-                        child.cancel();
-                    }
-                }
-            }
 
             if (isNamed) {
                 // For named parameters, keep track of both name and value of
                 // the children.
                 for (const name in this.children) {
-                    t = generateChild(t, this.children[name], takeAny ? (childThread, vm) => {
-                        children.delete(childThread);
-                        // Difference between the number of items to take
-                        // and the number of items in the accumulator.
-                        const diff = this.modifiers.take - Object.keys(thread.accumulator).length;
-                        if (diff > 0) {
-                            thread.accumulator[name] = childThread.value;
-                            childThreadIsDone(vm, diff);
-                        }
-                    } : childThread => {
-                        children.delete(childThread);
-                        thread.accumulator[name] = childThread.value;
+                    t = generateChild(t, this.children[name], childThread => {
+                        thread.parState.accumulator[name] = childThread.value;
                     });
                 }
             } else {
                 // Otherwise just push to the accumulator, or add at the child
                 // position (depending on whether we use take or not).
                 t = this.children.reduce((t, child, i) => generateChild(
-                    t, child, takeAny ? (childThread, vm) => {
-                        children.delete(childThread);
-                        // Difference between the number of items to take
-                        // and the number of items in the accumulator.
-                        const diff = this.modifiers.take - thread.accumulator.length;
-                        if (diff > 0) {
-                            thread.accumulator.push(childThread.value);
-                            childThreadIsDone(vm, diff);
-                        }
-                    } : (childThread, vm) => {
-                        console.log(`+++ value for ${thread.id} @${vm.t} from ${childThread.id}_${childThread.subid} = ${childThread.value}`);
-                        children.delete(childThread);
-                        thread.accumulator[i] = childThread.value;
+                    t, child, takeAny ? childThread => {
+                        thread.parState.accumulator.push(childThread.value);
+                    } : childThread => {
+                        thread.parState.accumulator[i] = childThread.value;
                     }
                 ), t);
             }
 
-            if (childCount > 0) {
-                if (takeSome) {
-                    t = time.unresolved;
-                }
-                // Suspend the thread to wait for the child threads to end (even
-                // when they all have a zero duration).
-                const parDur = hasDur ? dur : time.isDefinite(t) ? t - begin : t;
-                thread.ops.push([
-                    (thread, vm) => {
-                        thread.accumulator = acc();
-                        vm.schedule(thread, time.add(vm.t, parDur));
-                    },
-                    (thread, vm) => { vm.yield(thread); },
-                    (thread, vm) => { vm.yield(thread); },
-                ]);
+            if (takeSome) {
+                t = time.unresolved;
             }
+            // Suspend the thread to wait for the child threads to end (even
+            // when they all have a zero duration).
+            thread.ops.push([
+                (thread, vm) => { vm.schedule(thread, hasDur ? end : time.unresolved); },
+                (thread, vm) => { vm.yield(thread); },
+                (thread, vm) => { vm.yield(thread); },
+            ]);
         }
 
         // Set the value of the thread as that of the accumulator.
-        const value = this.tag === "Par" ?
-            thread => { thread.value = del(thread, "accumulator") ?? acc(); } :
-            thread => { thread.value = single(del(thread, "accumulator")) ?? acc(); };
         thread.ops.push([
-            value,
+            thread => {
+                const { accumulator, children, complete, initialValue } = del(thread, "parState");
+                if (complete) {
+                    console.assert(children.size === 0);
+                    thread.value = this.tag === "Par" ? accumulator : single(accumulator);
+                } else {
+                    for (const child of children) {
+                        child.cancel();
+                    }
+                    thread.value = initialValue;
+                }
+            },
             thread => { thread.undo(); },
             thread => { thread.redo(); }
         ]);

--- a/lib/timing/par.js
+++ b/lib/timing/par.js
@@ -34,14 +34,14 @@ const proto = {
         const end = time.add(t, dur);
         const takeNone = this.modifiers?.take === 0;
         const takeSome = this.modifiers?.take < childCount;
-        const children = [];
         const empty = takeNone || childCount === 0;
 
         // Initialize state for this iteration of the par.
-        thread.do(thread => {
+        thread.do((thread, vm) => {
             thread.parState = {
                 accumulator: isNamed ? {} : [],
-                children: new Set(children),
+                begin: vm.t,
+                children: new Set(),
                 initialValue: thread.value,
                 complete: empty
             };
@@ -70,7 +70,7 @@ const proto = {
                         // can be awakened, and the remaining child threads are
                         // cancelled.
                         thread.parState.complete = true;
-                        vm.wake(thread, hasDur ? end : vm.t);
+                        vm.wake(thread, hasDur ? thread.parState.begin + dur : vm.t);
                         for (const child of thread.parState.children) {
                             child.cancel();
                         }
@@ -78,7 +78,6 @@ const proto = {
                     }
                 });
                 thread.timeline.push(childThread);
-                children.push(childThread);
                 return t;
             };
 

--- a/lib/timing/par.js
+++ b/lib/timing/par.js
@@ -1,4 +1,4 @@
-import { extend, isObject, K, nop, push, single, values } from "../util.js";
+import { del, extend, isObject, K, nop, push, single, values } from "../util.js";
 import { generate } from "../runtime/thread.js";
 import { wrap } from "./instant.js";
 import { dur, take } from "./util.js";
@@ -14,11 +14,11 @@ const proto = {
         thread.timeline.push(extend(this, { begin: true, pc: thread.ops.length, t }));
         const isNamed = !Array.isArray(this.children);
         const childCount = isNamed ? values(this.children).length : this.children.length;
-        const accumulator = isNamed ? {} : [];
         let unresolved = 0;
         const begin = t;
-        const end = time.add(t, this.modifiers?.dur ?? time.unresolved);
-        const hasDur = time.isResolved(end);
+        const dur = this.modiers?.dur ?? time.unresolved;
+        const hasDur = time.isResolved(dur);
+        const end = time.add(t, dur);
         const children = new Set();
 
         // Check that we have enough children to take.
@@ -84,12 +84,12 @@ const proto = {
                         children.delete(childThread);
                         // Difference between the number of items to take
                         // and the number of items in the accumulator.
-                        const diff = this.modifiers.take - Object.keys(accumulator).length;
+                        const diff = this.modifiers.take - Object.keys(thread.accumulator).length;
                         if (diff > 0) {
-                            accumulator[name] = childThread.value;
+                            thread.accumulator[name] = childThread.value;
                             childThreadIsDone(vm, diff);
                         }
-                    } : childThread => { accumulator[name] = childThread.value; });
+                    } : childThread => { thread.accumulator[name] = childThread.value; });
                 }
             } else {
                 // Otherwise just push to the accumulator, or add at the child
@@ -99,12 +99,15 @@ const proto = {
                         children.delete(childThread);
                         // Difference between the number of items to take
                         // and the number of items in the accumulator.
-                        const diff = this.modifiers.take - accumulator.length;
+                        const diff = this.modifiers.take - thread.accumulator.length;
                         if (diff > 0) {
-                            accumulator.push(childThread.value);
+                            thread.accumulator.push(childThread.value);
                             childThreadIsDone(vm, diff);
                         }
-                    } : childThread => { accumulator[i] = childThread.value; }
+                    } : (childThread, vm) => {
+                        console.log(`+++ value for ${thread.id} @${vm.t} from ${childThread.id}_${childThread.subid} = ${childThread.value}`);
+                        thread.accumulator[i] = childThread.value;
+                    }
                 ), t);
             }
 
@@ -114,19 +117,22 @@ const proto = {
                 }
                 // Suspend the thread to wait for the child threads to end (even
                 // when they all have a zero duration).
-                const parEnd = hasDur ? time.max(t, end) : t;
+                const parDur = hasDur ? dur : time.isDefinite(t) ? t - begin : t;
                 thread.ops.push([
-                    (thread, vm) => { vm.schedule(thread, parEnd); },
+                    (thread, vm) => {
+                        thread.accumulator = isNamed ? {} : [];
+                        vm.schedule(thread, vm.t + parDur);
+                    },
                     (thread, vm) => { vm.yield(thread); },
                     (thread, vm) => { vm.yield(thread); },
                 ]);
             }
         }
 
-        // Set the value of the thread to the accumulator.
+        // Set the value of the thread as that of the accumulator.
         const value = this.tag === "Par" ?
-            thread => { thread.value = accumulator; } :
-            thread => { thread.value = single(accumulator); };
+            thread => { thread.value = del(thread, "accumulator"); } :
+            thread => { thread.value = single(del(thread, "accumulator")); };
         thread.ops.push([
             value,
             thread => { thread.undo(); },

--- a/lib/timing/par.js
+++ b/lib/timing/par.js
@@ -1,4 +1,4 @@
-import { del, extend, isObject, K, nop, push, single, values } from "../util.js";
+import { del, extend, foldit, isObject, K, nop, push, single, values } from "../util.js";
 import { generate } from "../runtime/thread.js";
 import { wrap } from "./instant.js";
 import { dur, take } from "./util.js";
@@ -16,7 +16,7 @@ const proto = {
         const childCount = isNamed ? values(this.children).length : this.children.length;
         let unresolved = 0;
         const begin = t;
-        const dur = this.modiers?.dur ?? time.unresolved;
+        const dur = this.modifiers?.dur ?? time.unresolved;
         const hasDur = time.isResolved(dur);
         const end = time.add(t, dur);
         const children = new Set();
@@ -52,9 +52,16 @@ const proto = {
                 if (time.isUnresolved(childThread.end)) {
                     unresolved += 1;
                     op[0] = (childThread, vm) => {
-                        accumulate(childThread);
-                        if (--unresolved === 0) {
-                            vm.wake(thread);
+                        accumulate(childThread, vm);
+                        if (--unresolved === 0 && (!takeSome || children.size === 0)) {
+                            // No more unresolved children, so we can tell when
+                            // to wake the parent thread (unless we are in a
+                            // take and some children are left).
+                            vm.wake(thread, foldit(
+                                children.values(),
+                                (max, child) => time.max(max, child.end),
+                                vm.t
+                            ));
                         }
                     };
                 }
@@ -90,7 +97,10 @@ const proto = {
                             thread.accumulator[name] = childThread.value;
                             childThreadIsDone(vm, diff);
                         }
-                    } : childThread => { thread.accumulator[name] = childThread.value; });
+                    } : childThread => {
+                        children.delete(childThread);
+                        thread.accumulator[name] = childThread.value;
+                    });
                 }
             } else {
                 // Otherwise just push to the accumulator, or add at the child
@@ -107,6 +117,7 @@ const proto = {
                         }
                     } : (childThread, vm) => {
                         console.log(`+++ value for ${thread.id} @${vm.t} from ${childThread.id}_${childThread.subid} = ${childThread.value}`);
+                        children.delete(childThread);
                         thread.accumulator[i] = childThread.value;
                     }
                 ), t);
@@ -122,7 +133,7 @@ const proto = {
                 thread.ops.push([
                     (thread, vm) => {
                         thread.accumulator = acc();
-                        vm.schedule(thread, vm.t + parDur);
+                        vm.schedule(thread, time.add(vm.t, parDur));
                     },
                     (thread, vm) => { vm.yield(thread); },
                     (thread, vm) => { vm.yield(thread); },

--- a/lib/timing/repeat.js
+++ b/lib/timing/repeat.js
@@ -18,8 +18,7 @@ const proto = {
     // beginning when going backward.
     generate(thread, t, items) {
         const pc = thread.ops.length;
-        const jump = [nop, nop, nop];
-        thread.ops.push(jump);
+        thread.do(nop);
         thread.timeline.push(extend(this, { begin: true, pc, t }));
         const end = t + (this.modifiers?.dur ?? Infinity);
         const childItem = wrap(this.child);
@@ -32,10 +31,7 @@ const proto = {
             throw new Error("cannot repeat a zero-duration child", this.child);
         }
         thread.ops.push([
-            (thread, vm) => {
-                console.log(`Repeat @${vm.t}`, thread.value);
-                vm.pc = pc;
-            },
+            (thread, vm) => { vm.pc = pc; },
             nop,
             (_, vm) => { vm.pc = pc; }
         ]);
@@ -43,7 +39,7 @@ const proto = {
 
         // Set the jump from the beginning for rewind.
         const dest = thread.ops.length - 1;
-        jump[1] = (_, vm) => { vm.pc = dest; };
+        thread.ops[pc][1] = (_, vm) => { vm.pc = dest; };
         return end;
     }
 };

--- a/lib/timing/repeat.js
+++ b/lib/timing/repeat.js
@@ -32,7 +32,10 @@ const proto = {
             throw new Error("cannot repeat a zero-duration child", this.child);
         }
         thread.ops.push([
-            (_, vm) => { vm.pc = pc; },
+            (thread, vm) => {
+                console.log(`Repeat @${vm.t}`, thread.value);
+                vm.pc = pc;
+            },
             nop,
             (_, vm) => { vm.pc = pc; }
         ]);

--- a/lib/timing/seq.js
+++ b/lib/timing/seq.js
@@ -17,7 +17,7 @@ const proto = {
         const end = time.add(t, dur ?? time.unresolved);
         if (time.isDefinite(end)) {
             // Reserve space for the cutoff thread.
-            thread.ops.push([nop, nop, nop]);
+            thread.do(nop);
         }
         const outgoing = items.get(this)[1];
         for (const child of this.children) {

--- a/tests/timing/dur.html
+++ b/tests/timing/dur.html
@@ -165,8 +165,8 @@ test("Par.dur(), cutoff", t => {
     * 40/1 Instant
     * 40/2 [end] Seq
     + 17/0 Instant
-* 36/5 [end] Par
-* 36/5 [end] Seq`, "dump matches");
+* 36/6 [end] Par
+* 36/6 [end] Seq`, "dump matches");
 });
 
 test("Par.dur() with unresolved duration, cutoff", t => {
@@ -191,8 +191,8 @@ test("Par.dur() with unresolved duration, cutoff", t => {
     * #/2 Instant
     * #/3 [end] Seq
     + 17/0 Instant
-* 36/5 [end] Par
-* 36/5 [end] Seq`, "dump matches");
+* 36/6 [end] Par
+* 36/6 [end] Seq`, "dump matches");
 });
 
 test("Par.dur(), extended", t => {
@@ -216,8 +216,8 @@ test("Par.dur(), extended", t => {
     * 40/1 Instant
     * 40/2 [end] Seq
     + 17/0 Instant
-* 48/5 [end] Par
-* 48/5 [end] Seq`, "dump matches");
+* 48/6 [end] Par
+* 48/6 [end] Seq`, "dump matches");
 });
 
 test("Par.dur() with unresolved duration, extended", t => {
@@ -241,8 +241,8 @@ test("Par.dur() with unresolved duration, extended", t => {
     * #/2 Instant
     * #/3 [end] Seq
     + 17/0 Instant
-* 48/5 [end] Par
-* 48/5 [end] Seq`, "dump matches");
+* 48/6 [end] Par
+* 48/6 [end] Seq`, "dump matches");
 });
 
 test("Par.dur(), cutoff child", t => {

--- a/tests/timing/event.html
+++ b/tests/timing/event.html
@@ -54,7 +54,7 @@ test("Do, undo, redo", t => {
     vm.shutdown();
 });
 
-test("Event in par", t => {
+test("Event in par (ends before other resolved children)", t => {
     const vm = VM();
     const par = vm.add(Par(
         Seq(
@@ -69,6 +69,61 @@ test("Event in par", t => {
     window.dispatchEvent(e);
     vm.clock.seek(41);
     t.equal(par.value, [window, "ok", "later"], "end value");
+    vm.shutdown();
+});
+
+test("Event in par (ends after all resolved children)", t => {
+    const vm = VM();
+    const par = vm.add(Par(
+        Seq(
+            Event(window, "synth"),
+            event => event.target
+        ),
+        K("ok"),
+        Seq(Delay(23), K("later"))
+    ), 17);
+    vm.clock.seek(51);
+    const e = new window.Event("synth");
+    window.dispatchEvent(e);
+    vm.clock.seek(52);
+    t.equal(par.value, [window, "ok", "later"], "end value");
+    vm.shutdown();
+});
+
+test("Event in par with take (ends before other resolved children)", t => {
+    const vm = VM();
+    const par = vm.add(Par(
+        Seq(
+            Event(window, "synth"),
+            event => event.target
+        ),
+        K("ok"),
+        Seq(Delay(23), K("later"))
+    ).take(2), 17);
+    vm.clock.seek(31);
+    const e = new window.Event("synth");
+    window.dispatchEvent(e);
+    vm.clock.seek(41);
+    t.equal(par.value, ["ok", window], "end value");
+    vm.shutdown();
+});
+
+test("Event in par with take (ends after all resolved children)", t => {
+    const vm = VM();
+    const par = vm.add(Par(
+        Seq(
+            Event(window, "synth"),
+            event => event.target
+        ),
+        K("ok"),
+        Seq(Delay(23), K("later"))
+    ).take(2), 17);
+    vm.clock.seek(51);
+    const e = new window.Event("synth");
+    window.dispatchEvent(e);
+    vm.clock.seek(52);
+    t.equal(par.end, 40, "end time");
+    t.equal(par.value, ["ok", "later"], "end value");
     vm.shutdown();
 });
 

--- a/tests/timing/first.html
+++ b/tests/timing/first.html
@@ -39,9 +39,9 @@ test("First()", t => {
     * 17/0 Delay(19)
     * 36/1 Instant
     * 36/2 [end] Seq
-* #/5 [end] First
-* #/5 Instant
-* #/6 [end] Seq`, "dump matches");
+* #/6 [end] First
+* #/6 Instant
+* #/7 [end] Seq`, "dump matches");
 });
 
 test("First().take() has no effect", t => {

--- a/tests/timing/par.html
+++ b/tests/timing/par.html
@@ -237,11 +237,12 @@ test("Named par", t => {
 
 test("Repeat par", t => {
     const vm = VM();
-    const repeat = vm.add(Repeat(Par((x = [0, 0]) => {
-        return x[0] + 1;
-    }, Delay(23))), 17);
+    const repeat = vm.add(Seq(
+        K([0]),
+        Repeat(Par(([x]) => x + 1, Delay(23)))
+    ), 17);
     vm.clock.seek(111);
-    t.equal(repeat.value, [4, undefined], "end value after 4 repeats");
+    t.equal(repeat.value, [4, [3, [2, [1, [0]]]]], "end value after 4 repeats");
 });
 
         </script>

--- a/tests/timing/par.html
+++ b/tests/timing/par.html
@@ -26,7 +26,7 @@ test("Empty par", t => {
     t.equal(par.begin, 17, "begin time");
     t.equal(par.end, 17, "end time");
     t.equal(par.value, [], "end value");
-    t.equal(par.dump(), "+ 17/0 [begin] Par\n* 17/1 [end] Par", "dump matches");
+    t.equal(par.dump(), "+ 17/0 [begin] Par\n* 17/2 [end] Par", "dump matches");
 });
 
 test("Non-empty, zero duration par", t => {
@@ -39,7 +39,7 @@ test("Non-empty, zero duration par", t => {
 `+ 17/0 [begin] Par
     + 17/0 Instant
     + 17/0 Instant
-* 17/4 [end] Par`, "dump matches");
+* 17/5 [end] Par`, "dump matches");
 });
 
 test("Do, undo, redo (zero duration)", t => {
@@ -69,7 +69,7 @@ test("Non-empty, non-zero duration par", t => {
     * 40/1 Instant
     * 40/2 [end] Seq
     + 17/0 Instant
-* 40/4 [end] Par`, "dump matches");
+* 40/5 [end] Par`, "dump matches");
 });
 
 test("Do, undo, redo (non-zero duration)", t => {
@@ -107,8 +107,8 @@ test("Input value", t => {
     * 40/1 Instant
     * 40/2 [end] Seq
     + 17/0 Instant
-* 40/5 [end] Par
-* 40/5 [end] Seq`, "dump matches");
+* 40/6 [end] Par
+* 40/6 [end] Seq`, "dump matches");
 });
 
 test("Nesting", t => {
@@ -123,8 +123,8 @@ test("Nesting", t => {
     + 17/0 [begin] Par
         + 17/0 Delay(31)
         + 17/0 Delay(19)
-    * 48/4 [end] Par
-* 48/4 [end] Par`, "dump matches");
+    * 48/5 [end] Par
+* 48/5 [end] Par`, "dump matches");
 });
 
 test("Do, undo, redo: Nesting", t => {
@@ -152,8 +152,8 @@ test("Unresolved duration within Par", t => {
 * 17/1 [begin] Par
     + 17/0 Delay()
     + 17/0 Instant
-* #/5 [end] Par
-* #/5 [end] Seq`, "dump matches");
+* #/6 [end] Par
+* #/6 [end] Seq`, "dump matches");
 });
 
 test("Do, undo, redo (unresolved duration within Par)", t => {
@@ -185,7 +185,7 @@ test("Unresolved durations within Par", t => {
     * 17/0 Instant
     * 17/1 Delay()
     * #/2 [end] Seq
-* #/4 [end] Par`, "dump matches");
+* #/5 [end] Par`, "dump matches");
 });
 
 test("Unresolved durations within Par (other way around)", t => {
@@ -206,7 +206,7 @@ test("Unresolved durations within Par (other way around)", t => {
     * 17/0 Instant
     * 17/1 Delay()
     * #/2 [end] Seq
-* #/4 [end] Par`, "dump matches");
+* #/5 [end] Par`, "dump matches");
 });
 
 test("Indefinite duration within Par", t => {
@@ -219,9 +219,9 @@ test("Indefinite duration within Par", t => {
 * 17/0 [begin] Par
     + 17/0 Delay(∞)
     + 17/0 Delay(23)
-* ∞/4 [end] Par
-* ∞/4 Instant
-* ∞/5 [end] Seq`, "dump matches");
+* ∞/5 [end] Par
+* ∞/5 Instant
+* ∞/6 [end] Seq`, "dump matches");
 });
 
 test("Named par", t => {

--- a/tests/timing/par.html
+++ b/tests/timing/par.html
@@ -8,7 +8,7 @@
 
 import { test } from "../test.js";
 import { K, typeOf } from "../../lib/util.js";
-import { Instant, Delay, Seq, Par } from "../../lib/timing.js";
+import { Instant, Delay, Seq, Par, Repeat } from "../../lib/timing.js";
 import { VM } from "../../lib/runtime.js";
 
 test("Par(...children)", t => {
@@ -233,6 +233,15 @@ test("Named par", t => {
     vm.clock.seek(41);
     t.equal(par.end, 40, "end time");
     t.equal(par.value, { foo: 1, bar: 2 }, "end value");
+});
+
+test("Repeat par", t => {
+    const vm = VM();
+    const repeat = vm.add(Repeat(Par((x = [0, 0]) => {
+        return x[0] + 1;
+    }, Delay(23))), 17);
+    vm.clock.seek(111);
+    t.equal(repeat.value, [4, undefined], "end value after 4 repeats");
 });
 
         </script>

--- a/tests/timing/take.html
+++ b/tests/timing/take.html
@@ -22,7 +22,7 @@ test("Par.take(n = ∞)", t => {
 `+ 17/0 [begin] Par
     + 17/0 Delay(23)
     + 17/0 Instant
-* 40/4 [end] Par`, "dump matches");
+* 40/5 [end] Par`, "dump matches");
 });
 
 test("Do, undo, redo: Par.take(n = ∞)", t => {
@@ -43,7 +43,7 @@ test("Par.take(0)", t => {
     t.equal(par.value, [], "empty list (no child value)");
     t.equal(par.dump(),
 `+ 17/0 [begin] Par
-* 17/1 [end] Par`, "dump matches");
+* 17/2 [end] Par`, "dump matches");
 });
 
 test("Do, undo, redo: Par.take(0)", t => {
@@ -66,7 +66,7 @@ test("Par.take(n), n = #children", t => {
 `+ 17/0 [begin] Par
     + 17/0 Delay(23)
     + 17/0 Instant
-* 40/4 [end] Par`, "dump matches");
+* 40/5 [end] Par`, "dump matches");
 });
 
 test("Do, undo, redo: Par.take(n), n = #children", t => {
@@ -103,7 +103,7 @@ test("Par.take(n), n < #children", t => {
     * 17/0 Delay(31)
     * 48/1 Instant
     * 48/2 [end] Seq
-* #/5 [end] Par`, "dump matches");
+* #/6 [end] Par`, "dump matches");
 });
 
 test("Do, undo, redo: Par.take(n), n < #children", t => {
@@ -130,7 +130,7 @@ test("Par.take(n), n < #children, children finish in zero duration.", t => {
 `+ 17/0 [begin] Par
     + 17/0 Delay(23)
     + 17/0 Instant
-* #/4 [end] Par`, "dump matches");
+* #/5 [end] Par`, "dump matches");
 });
 
 test("Do, undo, redo: Par.take(n), n < #children, children finish in zero duration.", t => {
@@ -174,7 +174,7 @@ test("Par.take().dur(), cutoff", t => {
     * 17/0 Delay(19)
     * 36/1 Instant
     * 36/2 [end] Seq
-* 30/5 [end] Par`, "dump matches");
+* 30/6 [end] Par`, "dump matches");
 });
 
 test("Par.take().dur(), extend zero dur", t => {
@@ -191,9 +191,9 @@ test("Par.take().dur(), extend zero dur", t => {
     + 17/0 Delay(23)
     + 17/0 Instant
     + 17/0 Instant
-* 36/5 [end] Par
-* 36/5 Instant
-* 36/6 [end] Seq`, "dump matches");
+* 36/6 [end] Par
+* 36/6 Instant
+* 36/7 [end] Seq`, "dump matches");
 });
 
 test("Par.take().dur(), extend non-zero dur", t => {


### PR DESCRIPTION
We need to make sure that each iteration of Par has its own state, including subthreads. This means that each iteration spawns a new copy of every child thread, offset by the new begin time (this will be mirrored in the timeline for repeated instances). Code for Par is reviewed and should be slightly simpler as a result.